### PR TITLE
fix(source-processing): classify transient discovery health

### DIFF
--- a/src/native_app/app/source_processing_events.rs
+++ b/src/native_app/app/source_processing_events.rs
@@ -383,6 +383,26 @@ mod tests {
     }
 
     #[test]
+    fn maps_retry_pending_health_to_retry_pending_ui_status() {
+        let GuiMessage::SourceProcessingHealth(health) =
+            map_event(SourceProcessingEvent::Health(SourceProcessingHealthEvent {
+                lifecycle: SourceProcessingLifecycle::new("source", 19),
+                state: SourceProcessingHealthState::WaitingForRetry,
+                source_generation: 0,
+                readiness_revision: 0,
+                stage_counts: std::collections::BTreeMap::new(),
+                retry_at: Some(123),
+                failure_codes: vec![String::from("discovery_retry_pending")],
+            }))
+        else {
+            panic!("expected mapped health");
+        };
+        assert_eq!(health.status, SourceProcessingHealthStatus::WaitingForRetry);
+        assert_eq!(health.retry_at, Some(123));
+        assert_eq!(health.failure_codes, ["discovery_retry_pending"]);
+    }
+
+    #[test]
     fn large_discovery_counts_keep_the_phase_unit_and_denominator() {
         let (stage, detail) = discovery_copy(
             crate::native_app::source_processing::SourceDiscoveryPhase::ComparingReadiness,

--- a/src/native_app/source_processing/supervisor/discovery.rs
+++ b/src/native_app/source_processing/supervisor/discovery.rs
@@ -7,6 +7,130 @@ use super::{
     readiness_safety_probe, source_health_summary, source_processing_schema_available,
 };
 
+const DISCOVERY_RETRY_PENDING_CODE: &str = "discovery_retry_pending";
+const DISCOVERY_RECONCILIATION_FAILED_CODE: &str = "reconciliation_failed";
+
+/// Keep transient discovery outages out of the repair-needed state. The discovery boundary
+/// currently carries errors as strings, so classify only exact, known SQLite/OS leaf messages;
+/// unknown/schema-integrity failures remain durable reconciliation failures.
+fn discovery_error_is_retryable(error: &str) -> bool {
+    let error = error.trim().to_ascii_lowercase();
+    let leaf = error
+        .rsplit_once(": ")
+        .map_or(error.as_str(), |(_, leaf)| leaf);
+    let known_sqlite_wrapper = error == leaf
+        || error
+            .strip_prefix("database query failed: ")
+            .is_some_and(|cause| cause == leaf);
+    (known_sqlite_wrapper
+        && (matches!(
+            leaf,
+            "database is busy, please retry" | "database is locked"
+        ) || leaf
+            .strip_prefix("database is locked (")
+            .and_then(|suffix| suffix.strip_suffix(')'))
+            .is_some_and(|code| {
+                !code.is_empty() && code.chars().all(|character| character.is_ascii_digit())
+            })))
+        || [
+            "operation timed out",
+            "resource temporarily unavailable",
+            "stale file handle",
+            "input/output error",
+            "i/o error",
+            "interrupted system call",
+        ]
+        .iter()
+        .any(|marker| os_error_leaf_matches(leaf, marker))
+}
+
+fn os_error_leaf_matches(leaf: &str, marker: &str) -> bool {
+    leaf.strip_prefix(marker)
+        .and_then(|suffix| suffix.strip_prefix(" (os error "))
+        .and_then(|suffix| suffix.strip_suffix(')'))
+        .is_some_and(|code| {
+            !code.is_empty() && code.chars().all(|character| character.is_ascii_digit())
+        })
+}
+
+fn discovery_failure_health(error: &str, retry_at: i64) -> SourceHealthSummary {
+    if discovery_error_is_retryable(error) {
+        SourceHealthSummary::waiting_for_retry(DISCOVERY_RETRY_PENDING_CODE, retry_at)
+    } else {
+        SourceHealthSummary::reconciliation_failed(DISCOVERY_RECONCILIATION_FAILED_CODE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{discovery_error_is_retryable, discovery_failure_health};
+    use crate::native_app::source_processing::SourceProcessingHealthState;
+
+    #[test]
+    fn discovery_error_classification_is_conservative() {
+        assert!(discovery_error_is_retryable(
+            "Database is busy, please retry"
+        ));
+        assert!(discovery_error_is_retryable(
+            "Database query failed: database is locked"
+        ));
+        assert!(discovery_error_is_retryable(
+            "Could not read source: Input/output error (os error 5)"
+        ));
+        assert!(discovery_error_is_retryable(
+            "Could not inspect source database path /tmp/source: Operation timed out (os error 60)"
+        ));
+        assert!(!discovery_error_is_retryable(
+            "Database query failed: no such table: metadata"
+        ));
+        assert!(!discovery_error_is_retryable(
+            "SQLite returned an unexpected result"
+        ));
+        assert!(!discovery_error_is_retryable(
+            "Database query failed: database disk image is malformed"
+        ));
+        assert!(!discovery_error_is_retryable(
+            "Database query failed: malformed schema timeout while validating"
+        ));
+        assert!(!discovery_error_is_retryable(
+            "Database query failed: no such table: metadata (database is locked)"
+        ));
+        assert!(!discovery_error_is_retryable(
+            "SQLite returned an unexpected result: input/output error recorded in metadata"
+        ));
+        assert!(!discovery_error_is_retryable("operation timed out"));
+        assert!(!discovery_error_is_retryable("input/output error"));
+        assert!(!discovery_error_is_retryable("i/o error"));
+        assert!(!discovery_error_is_retryable(
+            "schema validation: database is locked"
+        ));
+    }
+
+    #[test]
+    fn ambiguous_discovery_errors_stay_repair_needed_without_retry_deadline() {
+        for error in [
+            "Database query failed: malformed schema timeout while validating",
+            "operation timed out",
+            "input/output error",
+            "i/o error",
+            "schema validation: database is locked",
+        ] {
+            let health = discovery_failure_health(error, 123);
+            assert_eq!(
+                health.state_for_test(),
+                SourceProcessingHealthState::ReconciliationFailed,
+                "error: {error}"
+            );
+            assert_eq!(health.retry_at_for_test(), None, "error: {error}");
+            assert_eq!(
+                health.failure_codes_for_test(),
+                ["reconciliation_failed"],
+                "error: {error}"
+            );
+        }
+    }
+}
+
 pub(super) fn scheduler_candidate_indices(
     candidates: &[RuntimeCandidate],
     external_scan_admitted: bool,
@@ -166,16 +290,13 @@ pub(super) fn discover_candidates(
             Err(error) => {
                 record_discovery_error(shared, source, &error);
                 let retry_at = now_epoch_seconds().saturating_add(SOURCE_DISCOVERY_RETRY_SECONDS);
-                shared.publish_source_health(
-                    SourceHealthSummary::reconciliation_failed_at(
-                        "reconciliation_failed",
-                        Some(retry_at),
-                    )
-                    .into_event(super::SourceProcessingLifecycle::new(
+                let health = discovery_failure_health(&error, retry_at);
+                shared.publish_source_health(health.into_event(
+                    super::SourceProcessingLifecycle::new(
                         source.id.as_str(),
                         in_flight_work.lifecycle_generation,
-                    )),
-                );
+                    ),
+                ));
                 source_stats.insert(
                     source.id.as_str().to_string(),
                     SourceDiscoveryStats {

--- a/src/native_app/source_processing/supervisor/health.rs
+++ b/src/native_app/source_processing/supervisor/health.rs
@@ -43,6 +43,17 @@ impl SourceHealthSummary {
         }
     }
 
+    pub(super) fn waiting_for_retry(code: impl Into<String>, retry_at: i64) -> Self {
+        Self {
+            state: SourceProcessingHealthState::WaitingForRetry,
+            source_generation: 0,
+            readiness_revision: 0,
+            stage_counts: BTreeMap::new(),
+            retry_at: Some(retry_at),
+            failure_codes: vec![code.into()],
+        }
+    }
+
     pub(super) fn into_event(
         self,
         lifecycle: SourceProcessingLifecycle,
@@ -56,6 +67,11 @@ impl SourceHealthSummary {
             retry_at: self.retry_at,
             failure_codes: self.failure_codes,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn state_for_test(&self) -> SourceProcessingHealthState {
+        self.state
     }
 
     #[cfg(test)]
@@ -219,6 +235,11 @@ mod tests {
         );
         assert_eq!(reconciliation_failed.retry_at, Some(84));
         assert_eq!(reconciliation_failed.failure_codes, ["sqlite_busy"]);
+
+        let retrying = SourceHealthSummary::waiting_for_retry("discovery_retry_pending", 91);
+        assert_eq!(retrying.state, SourceProcessingHealthState::WaitingForRetry);
+        assert_eq!(retrying.retry_at, Some(91));
+        assert_eq!(retrying.failure_codes, ["discovery_retry_pending"]);
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor/tests/lifecycle_retirement.rs
+++ b/src/native_app/source_processing/supervisor/tests/lifecycle_retirement.rs
@@ -372,15 +372,32 @@ fn busy_source_discovery_is_rescheduled_after_retry_deadline() {
     let lock = rusqlite::Connection::open(&database_path).expect("open lock connection");
     lock.execute_batch("BEGIN EXCLUSIVE")
         .expect("hold source database lock");
-    let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let mut supervisor = SourceProcessingSupervisor::start_with_playback_state_and_event_sink(
+        vec![source.clone()],
+        false,
+        Some(Arc::new(sender)),
+    );
 
+    let mut saw_waiting_for_retry = false;
     wait_until(Duration::from_secs(15), || {
+        for event in receiver.try_iter() {
+            if let SourceProcessingEvent::Health(health) = event
+                && health.lifecycle.source_id == source.id.as_str()
+                && health.state == SourceProcessingHealthState::WaitingForRetry
+            {
+                saw_waiting_for_retry = health.retry_at.is_some()
+                    && health.failure_codes == ["discovery_retry_pending"];
+            }
+        }
         let telemetry = supervisor.shared.telemetry();
         telemetry.failed > 0
             && telemetry
                 .retry_at_by_source
                 .contains_key(source.id.as_str())
+            && saw_waiting_for_retry
     });
+    assert!(saw_waiting_for_retry);
     let retry_at = supervisor
         .shared
         .telemetry()
@@ -394,7 +411,26 @@ fn busy_source_discovery_is_rescheduled_after_retry_deadline() {
 
     lock.execute_batch("ROLLBACK").expect("release source lock");
     drop(lock);
-    wait_until(Duration::from_secs(12), || source_is_hashed(&source));
+    let mut saw_recovered_health = false;
+    wait_until(Duration::from_secs(12), || {
+        for event in receiver.try_iter() {
+            if let SourceProcessingEvent::Health(health) = event
+                && health.lifecycle.source_id == source.id.as_str()
+                && matches!(
+                    health.state,
+                    SourceProcessingHealthState::Processing | SourceProcessingHealthState::Ready
+                )
+            {
+                assert!(!health
+                    .failure_codes
+                    .iter()
+                    .any(|code| code == "discovery_retry_pending"));
+                saw_recovered_health = true;
+            }
+        }
+        source_is_hashed(&source) && saw_recovered_health
+    });
+    assert!(saw_recovered_health);
     assert_eq!(supervisor.shutdown()["joined"], true);
 }
 


### PR DESCRIPTION
## Goal
Classify retryable source-discovery failures as retry-pending health instead of repair-needed.

## Scope and non-goals
- Scope: discovery failure classification, health summary construction, UI event mapping coverage, and busy-discovery regression coverage.
- Non-goals: scanner/reconciliation architecture, user libraries/live UI operation, nightly workflows, or the vendor/radiant gitlink.

## Definition of Done
- Busy/transient SQLite or I/O discovery failures publish `WaitingForRetry` with a stable `discovery_retry_pending` code and retry deadline.
- Unknown/schema-integrity failures remain `ReconciliationFailed` with stable `reconciliation_failed` context.
- Successful retry continues to publish normal Processing/Ready health and clears the transient suffix.
- Lifecycle/revision fencing remains unchanged.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- Focused classifier, health-summary, GUI mapping, busy-discovery retry, and duplicate-identity durable-health tests (all passing).

## Limitations
Classifier is intentionally conservative because the discovery boundary currently carries string errors; only known transient SQLite/OS markers are retry-pending.

User approval is required before merge.