### PR TITLE
fix: adopt Radiant timer wake API

### DIFF
--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -63,4 +63,22 @@ pub(in crate::native_app) struct NativeAppState {
         crate::native_app::audio::playback::FrameSurfaceRevisionTracker,
     pub(in crate::native_app) playhead_frame_diagnostics:
         crate::native_app::audio::playback::PlayheadFrameDiagnosticsState,
+    #[cfg(test)]
+    pub(in crate::native_app) scheduled_timer_messages: Vec<super::GuiMessage>,
+}
+
+#[cfg(test)]
+impl NativeAppState {
+    pub(in crate::native_app) fn record_scheduled_timer_message(
+        &mut self,
+        message: super::GuiMessage,
+    ) {
+        self.scheduled_timer_messages.push(message);
+    }
+
+    pub(in crate::native_app) fn take_scheduled_timer_messages(
+        &mut self,
+    ) -> Vec<super::GuiMessage> {
+        std::mem::take(&mut self.scheduled_timer_messages)
+    }
 }

--- a/src/native_app/audio/playback_history.rs
+++ b/src/native_app/audio/playback_history.rs
@@ -72,9 +72,20 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         self.audio.pending_last_played_persist = None;
-        context.after_latest(&mut self.audio.last_played_persist_task, delay, |ticket| {
-            GuiMessage::LastPlayedPersistReady { ticket, request }
-        });
+        #[cfg(test)]
+        let scheduled_request = request.clone();
+        context.after_latest(
+            &mut self.audio.last_played_persist_task,
+            delay,
+            move |ticket| GuiMessage::LastPlayedPersistReady { ticket, request },
+        );
+        #[cfg(test)]
+        if let Some(ticket) = self.audio.last_played_persist_task.active() {
+            self.record_scheduled_timer_message(GuiMessage::LastPlayedPersistReady {
+                ticket,
+                request: scheduled_request,
+            });
+        }
     }
 
     pub(in crate::native_app) fn start_last_played_persist(

--- a/src/native_app/audio/sample_load_actions/cache_start_tests.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start_tests.rs
@@ -8,12 +8,21 @@ use std::{
     time::SystemTime,
 };
 
-fn after_messages(command: Command<GuiMessage>) -> Vec<GuiMessage> {
-    match command {
-        Command::After { message, .. } => vec![message],
-        Command::Batch(commands) => commands.into_iter().flat_map(after_messages).collect(),
-        _ => Vec::new(),
-    }
+fn after_messages(
+    state: &mut crate::native_app::test_support::state::NativeAppState,
+    command: Command<GuiMessage>,
+) -> Vec<GuiMessage> {
+    let timer_count = match &command {
+        Command::Timer(..) => 1,
+        Command::Batch(commands) => commands
+            .iter()
+            .filter(|command| matches!(command, Command::Timer(..)))
+            .count(),
+        _ => 0,
+    };
+    let messages = state.take_scheduled_timer_messages();
+    assert_eq!(messages.len(), timer_count);
+    messages
 }
 
 fn starmap_state_with_wav_files(
@@ -664,7 +673,7 @@ fn starmap_drag_instant_audition_schedules_stable_target_promotion() {
         "starmap_drag",
         &mut context,
     );
-    let delayed = after_messages(context.into_command());
+    let delayed = after_messages(&mut state, context.into_command());
 
     assert!(delayed.iter().any(|message| matches!(
         message,
@@ -687,5 +696,5 @@ fn non_starmap_instant_audition_does_not_schedule_stable_target_promotion() {
         &mut context,
     );
 
-    assert!(after_messages(context.into_command()).is_empty());
+    assert!(after_messages(&mut state, context.into_command()).is_empty());
 }

--- a/src/native_app/audio/sample_load_actions/plan.rs
+++ b/src/native_app/audio/sample_load_actions/plan.rs
@@ -36,7 +36,7 @@ impl NativeAppState {
         context.after_latest(
             &mut self.background.deferred_sample_load_task,
             delay,
-            |ticket| GuiMessage::DeferredSampleLoad {
+            move |ticket| GuiMessage::DeferredSampleLoad {
                 ticket,
                 path,
                 autoplay,

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -92,6 +92,8 @@ impl NativeAppState {
             metadata: MetadataAppState::from_settings(&config.core),
             frame_surface_revision_tracker: Default::default(),
             playhead_frame_diagnostics: Default::default(),
+            #[cfg(test)]
+            scheduled_timer_messages: Vec::new(),
         };
         emit_gui_action(
             "runtime.startup.load_default_state",

--- a/src/native_app/shell/message_dispatch/navigation.rs
+++ b/src/native_app/shell/message_dispatch/navigation.rs
@@ -604,8 +604,18 @@ impl NativeAppState {
         context.after_latest(
             &mut self.background.starmap_audition_promotion_task,
             STARMAP_AUDITION_PROMOTION_DELAY,
-            |ticket| GuiMessage::PromoteStarmapAudition { ticket, path },
+            {
+                let scheduled_path = path.clone();
+                move |ticket| GuiMessage::PromoteStarmapAudition {
+                    ticket,
+                    path: scheduled_path,
+                }
+            },
         );
+        #[cfg(test)]
+        if let Some(ticket) = self.background.starmap_audition_promotion_task.active() {
+            self.record_scheduled_timer_message(GuiMessage::PromoteStarmapAudition { ticket, path });
+        }
     }
 
     fn promote_starmap_audition(

--- a/src/native_app/test_support/state.rs
+++ b/src/native_app/test_support/state.rs
@@ -82,6 +82,7 @@ impl NativeAppStateFixture {
             metadata: MetadataAppState::from_settings(&self.persisted_settings),
             frame_surface_revision_tracker: Default::default(),
             playhead_frame_diagnostics: Default::default(),
+            scheduled_timer_messages: Vec::new(),
         }
     }
 }

--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -212,7 +212,8 @@ fn recording_sample_last_played_updates_row_and_persists_source_history() {
         Some("Today")
     );
 
-    let delayed = run_first_after(context.into_command()).expect("last played delayed command");
+    let delayed =
+        run_first_after(&mut state, context.into_command()).expect("last played delayed command");
     let mut context = radiant::prelude::UiUpdateContext::default();
     state.apply_message(delayed, &mut context);
     let message = run_first_perform(context.into_command()).expect("last played persist command");
@@ -1662,7 +1663,7 @@ fn starmap_audition_promotion_only_loads_latest_stable_target() {
 
     state.schedule_starmap_audition_promotion(first_id, &mut context);
     state.schedule_starmap_audition_promotion(second_id.clone(), &mut context);
-    let delayed = run_after_commands(context.into_command());
+    let delayed = run_after_commands(&mut state, context.into_command());
     assert_eq!(delayed.len(), 2);
 
     let mut stale_context = radiant::prelude::UiUpdateContext::default();
@@ -1710,7 +1711,7 @@ fn starmap_drag_duplicate_active_hit_preserves_pending_promotion() {
     let mut schedule_context = radiant::prelude::UiUpdateContext::default();
 
     state.schedule_starmap_audition_promotion(sample_id.clone(), &mut schedule_context);
-    let delayed = run_after_commands(schedule_context.into_command());
+    let delayed = run_after_commands(&mut state, schedule_context.into_command());
     assert_eq!(delayed.len(), 1);
 
     state.apply_message(
@@ -2029,7 +2030,7 @@ fn starmap_drag_release_preserves_loaded_last_played_sample_not_latest_hit() {
         &mut release_context,
     );
     let (delayed, perform_count) =
-        collect_after_commands_and_perform_count(release_context.into_command());
+        collect_after_commands_and_perform_count(&mut state, release_context.into_command());
 
     assert_eq!(state.waveform.current.path(), second.as_path());
     assert!(state.waveform.current.has_loaded_sample());
@@ -2340,7 +2341,7 @@ fn starmap_drag_finish_cancels_pending_promotion() {
     );
     let mut schedule_context = radiant::prelude::UiUpdateContext::default();
     state.schedule_starmap_audition_promotion(sample_id.clone(), &mut schedule_context);
-    let delayed = run_after_commands(schedule_context.into_command());
+    let delayed = run_after_commands(&mut state, schedule_context.into_command());
     assert_eq!(delayed.len(), 1);
     state.apply_message(
         crate::native_app::test_support::state::GuiMessage::UpdateStarmapAuditionDrag {
@@ -2658,7 +2659,7 @@ fn starmap_drag_latest_hit_advances_without_zero_delay_message() {
     let mut context = radiant::prelude::UiUpdateContext::default();
 
     state.advance_starmap_drag_audition_latest_immediately(&mut context);
-    let delayed = run_after_commands(context.into_command());
+    let delayed = run_after_commands(&mut state, context.into_command());
 
     assert_eq!(
         state.library.folder_browser.selected_file_id(),
@@ -2828,7 +2829,7 @@ fn rapid_last_played_records_only_latest_delayed_persist() {
         .select_file(second_path_string.clone());
     state.record_sample_last_played(second_path_string.clone(), &mut context);
 
-    let delayed = run_after_commands(context.into_command());
+    let delayed = run_after_commands(&mut state, context.into_command());
     assert_eq!(delayed.len(), 2);
     let mut stale_context = radiant::prelude::UiUpdateContext::default();
     state.apply_message(delayed[0].clone(), &mut stale_context);
@@ -2872,12 +2873,13 @@ fn active_playback_defers_last_played_disk_persist_until_idle() {
     state.record_sample_last_played(sample_path_string.clone(), &mut context);
     state.waveform.current.start_playback(0.25);
 
-    let delayed = run_first_after(context.into_command()).expect("last played delayed command");
+    let delayed =
+        run_first_after(&mut state, context.into_command()).expect("last played delayed command");
     let mut active_context = radiant::prelude::UiUpdateContext::default();
     state.apply_message(delayed, &mut active_context);
 
     let (retry_messages, perform_count) =
-        collect_after_commands_and_perform_count(active_context.into_command());
+        collect_after_commands_and_perform_count(&mut state, active_context.into_command());
     assert_eq!(
         perform_count, 0,
         "active playback should defer last-played persistence before DB work starts"
@@ -2935,7 +2937,8 @@ fn stop_playback_flushes_deferred_last_played_after_clearing_runtime_state() {
         error: None,
     };
 
-    let delayed = run_first_after(context.into_command()).expect("last played delayed command");
+    let delayed =
+        run_first_after(&mut state, context.into_command()).expect("last played delayed command");
     let mut active_context = radiant::prelude::UiUpdateContext::default();
     state.apply_message(delayed, &mut active_context);
     assert!(
@@ -2970,39 +2973,60 @@ fn stop_playback_flushes_deferred_last_played_after_clearing_runtime_state() {
 }
 
 fn run_first_after(
+    state: &mut crate::native_app::test_support::state::NativeAppState,
     command: Command<crate::native_app::test_support::state::GuiMessage>,
 ) -> Option<crate::native_app::test_support::state::GuiMessage> {
-    run_after_commands(command).into_iter().next()
+    run_after_commands(state, command).into_iter().next()
 }
 
 fn run_after_commands(
+    state: &mut crate::native_app::test_support::state::NativeAppState,
     command: Command<crate::native_app::test_support::state::GuiMessage>,
 ) -> Vec<crate::native_app::test_support::state::GuiMessage> {
-    match command {
-        Command::After { message, .. } => vec![message],
-        Command::Batch(commands) => commands.into_iter().flat_map(run_after_commands).collect(),
-        _ => Vec::new(),
-    }
+    let timer_count = count_timer_commands(&command);
+    let messages = state.take_scheduled_timer_messages();
+    assert_eq!(
+        messages.len(),
+        timer_count,
+        "every queued timer should have a test-visible mapped message"
+    );
+    messages
 }
 
 fn collect_after_commands_and_perform_count(
+    state: &mut crate::native_app::test_support::state::NativeAppState,
     command: Command<crate::native_app::test_support::state::GuiMessage>,
 ) -> (
     Vec<crate::native_app::test_support::state::GuiMessage>,
     usize,
 ) {
+    let timer_count = count_timer_commands(&command);
+    let delayed = state.take_scheduled_timer_messages();
+    assert_eq!(
+        delayed.len(),
+        timer_count,
+        "every queued timer should have a test-visible mapped message"
+    );
+    (delayed, count_perform_commands(&command))
+}
+
+fn count_timer_commands(
+    command: &Command<crate::native_app::test_support::state::GuiMessage>,
+) -> usize {
     match command {
-        Command::After { message, .. } => (vec![message], 0),
-        Command::Perform { .. } => (Vec::new(), 1),
-        Command::Batch(commands) => commands
-            .into_iter()
-            .map(collect_after_commands_and_perform_count)
-            .fold((Vec::new(), 0), |mut collected, (messages, count)| {
-                collected.0.extend(messages);
-                collected.1 += count;
-                collected
-            }),
-        _ => (Vec::new(), 0),
+        Command::Timer(..) => 1,
+        Command::Batch(commands) => commands.iter().map(count_timer_commands).sum(),
+        _ => 0,
+    }
+}
+
+fn count_perform_commands(
+    command: &Command<crate::native_app::test_support::state::GuiMessage>,
+) -> usize {
+    match command {
+        Command::Perform { .. } => 1,
+        Command::Batch(commands) => commands.iter().map(count_perform_commands).sum(),
+        _ => 0,
     }
 }
 


### PR DESCRIPTION
## Goal
Adopt merged Radiant PR #1451 (`14c2e70818d6c7fb78ff3f19b06b017e99bdcfa3`) and keep Wavecrate timer scheduling behavior compatible with its opaque UI-local wake API.

## Scope
- Repin only `vendor/radiant` from `8a3cf8bf6551c76432536dc9798f74a5f178b3ae` to `14c2e70818d6c7fb78ff3f19b06b017e99bdcfa3`.
- Update the necessary Wavecrate timer call sites to own `after_latest` mapper captures (`move`) and replace removed `Command::After` test matching with opaque `Command::Timer`-compatible test capture.
- Preserve latest-ticket replacement, stale-ticket rejection, delayed persistence, and starmap promotion behavior.

## Non-goals
- No unrelated Radiant adoption, cleanup, or architecture changes.
- No changes to Radiant itself, Cargo manifests, or lockfiles.

## Definition of Done
- [x] Wavecrate compiles against the canonical Radiant PR #1451 merge commit.
- [x] Timer scheduling preserves latest/stale lifecycle behavior and delayed persistence semantics.
- [x] Complete diff is limited to the gitlink and affected timer call sites/tests.
- [ ] Maintainer reviews and explicitly approves before merge.

## Validation
- `git ls-remote https://github.com/PORTALSURFER/radiant.git 14c2e70818d6c7fb78ff3f19b06b017e99bdcfa3 refs/heads/main refs/pull/1451/head` — passed; canonical commit is `radiant` `main`.
- `cargo fmt --all -- --check` — passed.
- `cargo check --workspace --all-targets --locked` — passed.
- `cargo test -p wavecrate --lib last_played -- --test-threads=1` — passed, 12/12.
- `cargo test -p wavecrate --lib native_app::tests::sample_browser::starmap_audition_promotion_only_loads_latest_stable_target -- --test-threads=1` — passed.
- `cargo test -p wavecrate --lib starmap -- --test-threads=1` — 163/164 passed; one unrelated existing fixture failure in `native_app::sample_library::folder_browser::starmap::tests::starmap_projection_marks_cold_long_wavs_as_preview_candidates` (expected short-file preview flag differed).
- `git diff origin/main...HEAD --check` — passed; changed paths are the Radiant gitlink plus the focused timer migration/test files.

## Known limitation
The broader starmap-filtered test command retains the unrelated fixture failure noted above; all timer migration tests and the locked workspace compile pass.

Merge requires explicit user approval.