### PR TITLE
Adopt Radiant streaming business-effects revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "14c2e70818d6c7fb78ff3f19b06b017e99bdcfa3"
+revision = "a3a6c14b52acc45e547b3f4da9bf60914158c9d3"
 path = "../radiant"
 
 [package]

--- a/radiant-dependency.toml
+++ b/radiant-dependency.toml
@@ -4,5 +4,5 @@
 # sibling may remain on a feature branch or contain uncommitted work. Setup,
 # CI, and release helpers provision this exact revision into a clean checkout.
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "14c2e70818d6c7fb78ff3f19b06b017e99bdcfa3"
+revision = "a3a6c14b52acc45e547b3f4da9bf60914158c9d3"
 path = "../radiant"

--- a/tests/radiant_dependency_contract.rs
+++ b/tests/radiant_dependency_contract.rs
@@ -13,7 +13,7 @@ fn canonical_radiant_dependency_uses_the_standalone_sibling_contract() {
 
     assert!(manifest.contains("radiant = { path = \"../radiant\" }"));
     assert!(metadata.contains("repository = \"https://github.com/PORTALSURFER/radiant.git\""));
-    assert!(metadata.contains("revision = \"14c2e70818d6c7fb78ff3f19b06b017e99bdcfa3\""));
+    assert!(metadata.contains("revision = \"a3a6c14b52acc45e547b3f4da9bf60914158c9d3\""));
     assert!(metadata.contains("path = \"../radiant\""));
     assert!(!root.join(".gitmodules").exists());
     assert!(!root.join("vendor/radiant").exists());

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -487,7 +487,7 @@ edition = "2024"
             ),
         );
         self.write("Cargo.lock", "# fixture lockfile\n");
-        self.write("radiant-dependency.toml", "repository = \"https://github.com/PORTALSURFER/radiant.git\"\nrevision = \"14c2e70818d6c7fb78ff3f19b06b017e99bdcfa3\"\npath = \"../radiant\"\n");
+        self.write("radiant-dependency.toml", "repository = \"https://github.com/PORTALSURFER/radiant.git\"\nrevision = \"a3a6c14b52acc45e547b3f4da9bf60914158c9d3\"\npath = \"../radiant\"\n");
         self.write("src/lib.rs", "");
         self.write(".github/workflows/release-train-prepare.yml", "");
         self.write(".github/workflows/release-rc.yml", "");


### PR DESCRIPTION
## Goal
Adopt the merged Radiant streaming business-effects implementation in Wavecrate through the canonical sibling-checkout revision contract.

## Scope and non-goals
- Update the recorded Radiant revision in `Cargo.toml` workspace metadata and `radiant-dependency.toml` to `a3a6c14b52acc45e547b3f4da9bf60914158c9d3`.
- Update deterministic dependency/release fixture assertions that encode the canonical revision.
- No Wavecrate product/source refactors, Radiant source changes, dependency-layout changes, or unrelated cleanup.

## Definition of Done
- Canonical metadata and provisioning resolve the exact Radiant merge commit.
- Locked workspace/all-target compilation and release validation complete successfully.
- Dependency and release contract tests pass.
- No unrelated files are changed.

## Validation
- `bash scripts/radiant.sh provision --clean --path ../radiant` — pass; isolated sibling is detached, clean, and at `a3a6c14b52acc45e547b3f4da9bf60914158c9d3`.
- `bash scripts/radiant.sh locate` — pass; revision match confirmed.
- `cargo check --workspace --all-targets --locked` — pass.
- `cargo test --workspace --locked --no-run` — pass.
- `cargo test --test radiant_dependency_contract --locked -- --nocapture` — 1 passed.
- `cargo test --test release_orchestration --locked -- --nocapture` — 17 passed.
- `bash scripts/internal/release/run_release_validation.sh` — pass; Radiant test targets, 32 release-contract tests, 23 workflow-helper tests, and 193 scanner tests passed.
- `git diff --check` — pass.

## Known limitations
None for this dependency-only adoption. Interactive app/audible validation is outside the scope of a revision-only parent change.

User approval is required before merge.
