### PR TITLE
Align Wavecrate with Radiant 095ddf59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "a3a6c14b52acc45e547b3f4da9bf60914158c9d3"
+revision = "095ddf597fbac5a1055550c64b30d27ce62f7c38"
 path = "../radiant"
 
 [package]

--- a/radiant-dependency.toml
+++ b/radiant-dependency.toml
@@ -4,5 +4,5 @@
 # sibling may remain on a feature branch or contain uncommitted work. Setup,
 # CI, and release helpers provision this exact revision into a clean checkout.
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "a3a6c14b52acc45e547b3f4da9bf60914158c9d3"
+revision = "095ddf597fbac5a1055550c64b30d27ce62f7c38"
 path = "../radiant"

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -409,7 +409,9 @@ impl NativeAppState {
         self.background
             .worker_receiver
             .take()
-            .map(|receiver| ui::Subscription::worker("gui-workers", receiver))
+            .map(|receiver| {
+                ui::Subscription::worker_payload("gui-workers", receiver, |message| message)
+            })
             .unwrap_or_else(ui::Subscription::none)
     }
 

--- a/src/native_app/tests.rs
+++ b/src/native_app/tests.rs
@@ -74,6 +74,7 @@ type NativeRuntimeForTests = SurfaceRuntime<
 
 struct CaptureBridge {
     messages: Vec<super::test_support::state::GuiMessage>,
+    target_name: Option<&'static str>,
 }
 
 impl RuntimeBridge<super::test_support::state::GuiMessage> for CaptureBridge {
@@ -105,11 +106,14 @@ impl RuntimeBridge<super::test_support::state::GuiMessage> for CaptureBridge {
 impl RuntimeTaskHost<super::test_support::state::GuiMessage> for CaptureBridge {
     fn spawn_worker_task(
         &mut self,
-        _name: &'static str,
+        name: &'static str,
         _priority: radiant::prelude::TaskPriority,
         _is_cancelled: Option<Box<dyn Fn() -> bool + Send + Sync + 'static>>,
         work: Box<dyn FnOnce() + Send + 'static>,
     ) -> bool {
+        if self.target_name.is_some_and(|target| target != name) {
+            return false;
+        }
         work();
         true
     }
@@ -336,7 +340,12 @@ fn run_worker_message_for_tests(
     if command.business_task_priority(target_name).is_none() {
         return None;
     }
-    run_command_and_capture_messages_for_tests(command).pop()
+    let messages = run_command_and_capture_messages_for_target_tests(command, target_name);
+    match messages.len() {
+        0 => None,
+        1 => messages.into_iter().next(),
+        count => panic!("worker task {target_name} emitted {count} messages; expected exactly one"),
+    }
 }
 
 fn run_command_and_capture_messages_for_tests(
@@ -345,6 +354,7 @@ fn run_command_and_capture_messages_for_tests(
     let mut runtime = radiant::runtime::SurfaceRuntime::new(
         CaptureBridge {
             messages: Vec::new(),
+            target_name: None,
         },
         Vector2::new(900.0, 620.0),
     );
@@ -364,6 +374,66 @@ fn run_command_and_capture_messages_for_tests(
         }
     }
     runtime.into_bridge().messages
+}
+
+fn run_command_and_capture_messages_for_target_tests(
+    command: Command<super::test_support::state::GuiMessage>,
+    target_name: &'static str,
+) -> Vec<super::test_support::state::GuiMessage> {
+    let mut runtime = radiant::runtime::SurfaceRuntime::new(
+        CaptureBridge {
+            messages: Vec::new(),
+            target_name: Some(target_name),
+        },
+        Vector2::new(900.0, 620.0),
+    );
+    apply_strict_update_diagnostics(&mut runtime);
+    let _ = runtime.execute_command(command);
+    let mut processed = 0usize;
+    let mut idle_drains = 0usize;
+    while idle_drains < 2 {
+        processed += 1;
+        assert!(processed <= 1_000, "targeted worker capture did not settle");
+        std::thread::sleep(Duration::from_millis(1));
+        let outcome = runtime.drain_runtime_messages();
+        if outcome.messages_dispatched == 0 && !outcome.runtime_work_remaining {
+            idle_drains += 1;
+        } else {
+            idle_drains = 0;
+        }
+    }
+    runtime.into_bridge().messages
+}
+
+#[test]
+fn targeted_worker_capture_returns_requested_task_and_skips_later_decoy() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    let decoy_ran = Arc::new(AtomicBool::new(false));
+    let mut context = ui::UiUpdateContext::default();
+    context
+        .business()
+        .background("capture-target")
+        .run(|_| 7_u8, |_| super::test_support::state::GuiMessage::Frame);
+    let decoy_ran_in_worker = Arc::clone(&decoy_ran);
+    context.business().background("capture-decoy").run(
+        move |_| {
+            decoy_ran_in_worker.store(true, Ordering::SeqCst);
+            9_u8
+        },
+        |_| super::test_support::state::GuiMessage::ToggleShortcutHelp,
+    );
+
+    let messages =
+        run_command_and_capture_messages_for_target_tests(context.into_command(), "capture-target");
+    assert_eq!(
+        messages,
+        vec![super::test_support::state::GuiMessage::Frame]
+    );
+    assert!(!decoy_ran.load(Ordering::SeqCst));
 }
 
 pub(crate) fn run_command_collecting_followups_for_tests(

--- a/src/native_app/tests.rs
+++ b/src/native_app/tests.rs
@@ -8,8 +8,8 @@ use radiant::{
     prelude::{self as ui, IntoView},
     runtime::{
         Command, DeclarativeOwnedCommandRuntimeBridge, Event, PaintTextInput, RuntimeBridge,
-        SurfaceFrame, SurfaceRuntime, TransientOverlayContext, UiSurface,
-        UiUpdateHandlerDiagnosticsPolicy,
+        RuntimeHostCapabilities, RuntimeTaskHost, SurfaceFrame, SurfaceRuntime,
+        TransientOverlayContext, UiSurface, UiUpdateHandlerDiagnosticsPolicy,
     },
     widgets::{DragHandleMessage, PointerButton, PointerModifiers, WidgetInput, WidgetKey},
 };
@@ -71,6 +71,49 @@ type NativeRuntimeForTests = SurfaceRuntime<
     >,
     super::test_support::state::GuiMessage,
 >;
+
+struct CaptureBridge {
+    messages: Vec<super::test_support::state::GuiMessage>,
+}
+
+impl RuntimeBridge<super::test_support::state::GuiMessage> for CaptureBridge {
+    fn project_surface(
+        &mut self,
+    ) -> std::sync::Arc<UiSurface<super::test_support::state::GuiMessage>> {
+        std::sync::Arc::new(ui::empty::<super::test_support::state::GuiMessage>().into_surface())
+    }
+
+    fn pull_surface(&mut self) -> UiSurface<super::test_support::state::GuiMessage> {
+        ui::empty::<super::test_support::state::GuiMessage>().into_surface()
+    }
+
+    fn update(
+        &mut self,
+        message: super::test_support::state::GuiMessage,
+    ) -> Command<super::test_support::state::GuiMessage> {
+        self.messages.push(message);
+        Command::none()
+    }
+
+    fn host_capabilities(
+        &self,
+    ) -> RuntimeHostCapabilities<Self, super::test_support::state::GuiMessage> {
+        RuntimeHostCapabilities::new().with_tasks()
+    }
+}
+
+impl RuntimeTaskHost<super::test_support::state::GuiMessage> for CaptureBridge {
+    fn spawn_worker_task(
+        &mut self,
+        _name: &'static str,
+        _priority: radiant::prelude::TaskPriority,
+        _is_cancelled: Option<Box<dyn Fn() -> bool + Send + Sync + 'static>>,
+        work: Box<dyn FnOnce() + Send + 'static>,
+    ) -> bool {
+        work();
+        true
+    }
+}
 
 fn native_runtime_for_tests(mut state: NativeAppState, viewport: Vector2) -> NativeRuntimeForTests {
     super::test_support::sample_browser::prepare_sample_browser_view(&mut state);
@@ -243,46 +286,100 @@ fn run_command_for_tests(
     state: &mut NativeAppState,
     command: Command<super::test_support::state::GuiMessage>,
 ) {
+    let continues_committed_mutation = |message: &super::test_support::state::GuiMessage| {
+        matches!(
+            message,
+            super::test_support::state::GuiMessage::CommittedFileMutationRequested(_)
+                | super::test_support::state::GuiMessage::NormalizationFinished(_)
+                | super::test_support::state::GuiMessage::ExternalWaveformFileDropFinished {
+                    ..
+                }
+                | super::test_support::state::GuiMessage::ContextSampleSameFinished { .. }
+                | super::test_support::state::GuiMessage::ContextSampleDoubleFinished { .. }
+                | super::test_support::state::GuiMessage::SelectedFilesCopyFinished { .. }
+                | super::test_support::state::GuiMessage::WaveformSelectionCopyFinished { .. }
+                | super::test_support::state::GuiMessage::FolderMoveFinished { .. }
+                | super::test_support::state::GuiMessage::FileMoveConflictFinished { .. }
+                | super::test_support::state::GuiMessage::TrashMoveFinished { .. }
+                | super::test_support::state::GuiMessage::FolderBrowserRenameFinished(_)
+                | super::test_support::state::GuiMessage::WaveformDestructiveEditFinished(_)
+                | super::test_support::state::GuiMessage::PlaySelectionExtractionFinished { .. }
+                | super::test_support::state::GuiMessage::SelectedWholeFilesHarvestExtractionFinished {
+                    ..
+                }
+        )
+    };
     let mut commands = std::collections::VecDeque::from([command]);
     let mut processed = 0usize;
     while let Some(command) = commands.pop_front() {
+        for message in run_command_and_capture_messages_for_tests(command) {
+            let continues = continues_committed_mutation(&message);
+            let mut context = ui::UiUpdateContext::default();
+            state.apply_message(message, &mut context);
+            let followup = context.into_command();
+            if continues && !followup.is_empty() {
+                commands.push_back(followup);
+            }
+        }
         processed += 1;
         assert!(
             processed <= 1_000,
             "test command follow-up loop did not settle"
         );
-        command.run_inline_for_tests(|message| {
-            let continues_committed_mutation = matches!(
-                &message,
-                super::test_support::state::GuiMessage::CommittedFileMutationRequested(_)
-                    | super::test_support::state::GuiMessage::NormalizationFinished(_)
-                    | super::test_support::state::GuiMessage::ExternalWaveformFileDropFinished {
-                        ..
-                    }
-                    | super::test_support::state::GuiMessage::ContextSampleSameFinished { .. }
-                    | super::test_support::state::GuiMessage::ContextSampleDoubleFinished { .. }
-                    | super::test_support::state::GuiMessage::SelectedFilesCopyFinished { .. }
-                    | super::test_support::state::GuiMessage::WaveformSelectionCopyFinished { .. }
-                    | super::test_support::state::GuiMessage::FolderMoveFinished { .. }
-                    | super::test_support::state::GuiMessage::FileMoveConflictFinished { .. }
-                    | super::test_support::state::GuiMessage::TrashMoveFinished { .. }
-                    | super::test_support::state::GuiMessage::FolderBrowserRenameFinished(_)
-                    | super::test_support::state::GuiMessage::WaveformDestructiveEditFinished(_)
-                    | super::test_support::state::GuiMessage::PlaySelectionExtractionFinished {
-                        ..
-                    }
-                    | super::test_support::state::GuiMessage::SelectedWholeFilesHarvestExtractionFinished {
-                        ..
-                    }
-            );
-            let mut context = ui::UiUpdateContext::default();
-            state.apply_message(message, &mut context);
-            let followup = context.into_command();
-            if continues_committed_mutation && !followup.is_empty() {
-                commands.push_back(followup);
-            }
-        });
     }
+}
+
+fn run_worker_message_for_tests(
+    command: Command<super::test_support::state::GuiMessage>,
+    target_name: &'static str,
+) -> Option<super::test_support::state::GuiMessage> {
+    if command.business_task_priority(target_name).is_none() {
+        return None;
+    }
+    run_command_and_capture_messages_for_tests(command).pop()
+}
+
+fn run_command_and_capture_messages_for_tests(
+    command: Command<super::test_support::state::GuiMessage>,
+) -> Vec<super::test_support::state::GuiMessage> {
+    let mut runtime = radiant::runtime::SurfaceRuntime::new(
+        CaptureBridge {
+            messages: Vec::new(),
+        },
+        Vector2::new(900.0, 620.0),
+    );
+    apply_strict_update_diagnostics(&mut runtime);
+    let _ = runtime.execute_command(command);
+    let mut processed = 0usize;
+    let mut idle_drains = 0usize;
+    while idle_drains < 2 {
+        processed += 1;
+        assert!(processed <= 1_000, "test command capture did not settle");
+        std::thread::sleep(Duration::from_millis(1));
+        let outcome = runtime.drain_runtime_messages();
+        if outcome.messages_dispatched == 0 && !outcome.runtime_work_remaining {
+            idle_drains += 1;
+        } else {
+            idle_drains = 0;
+        }
+    }
+    runtime.into_bridge().messages
+}
+
+pub(crate) fn run_command_collecting_followups_for_tests(
+    state: &mut NativeAppState,
+    command: Command<super::test_support::state::GuiMessage>,
+) -> Vec<Command<super::test_support::state::GuiMessage>> {
+    let mut followups = Vec::new();
+    for message in run_command_and_capture_messages_for_tests(command) {
+        let mut context = ui::UiUpdateContext::default();
+        state.apply_message(message, &mut context);
+        let followup = context.into_command();
+        if !followup.is_empty() {
+            followups.push(followup);
+        }
+    }
+    followups
 }
 
 fn start_deferred_sample_load_for_tests(

--- a/src/native_app/tests/audio_settings_controls/volume.rs
+++ b/src/native_app/tests/audio_settings_controls/volume.rs
@@ -57,11 +57,15 @@ fn default_gui_volume_drag_defers_config_persistence_until_debounce() {
     assert!(state.audio.volume_persist_inflight);
 
     let command = context.into_command();
-    let radiant::runtime::Command::Perform { priority, work, .. } = command else {
-        panic!("expected volume settings persist background command");
-    };
-    assert_eq!(priority, radiant::prelude::TaskPriority::BlockingIo);
-    let message = work();
+    assert_eq!(
+        command.business_task_priority("gui-volume-settings-persist"),
+        Some(radiant::prelude::TaskPriority::BlockingIo)
+    );
+    let message = crate::native_app::tests::run_worker_message_for_tests(
+        command,
+        "gui-volume-settings-persist",
+    )
+    .expect("volume settings persist worker completion");
     state.apply_message(message, &mut radiant::prelude::UiUpdateContext::default());
 
     let loaded = wavecrate::sample_sources::config::load_or_default().expect("reload config");
@@ -91,11 +95,15 @@ fn volume_drag_persists_after_debounce_while_playback_is_active() {
     assert!(state.audio.volume_persist_inflight);
 
     let command = context.into_command();
-    let radiant::runtime::Command::Perform { priority, work, .. } = command else {
-        panic!("expected volume settings persist background command during playback");
-    };
-    assert_eq!(priority, radiant::prelude::TaskPriority::BlockingIo);
-    let message = work();
+    assert_eq!(
+        command.business_task_priority("gui-volume-settings-persist"),
+        Some(radiant::prelude::TaskPriority::BlockingIo)
+    );
+    let message = crate::native_app::tests::run_worker_message_for_tests(
+        command,
+        "gui-volume-settings-persist",
+    )
+    .expect("volume settings persist worker completion during playback");
     state.apply_message(message, &mut radiant::prelude::UiUpdateContext::default());
 
     let loaded = wavecrate::sample_sources::config::load_or_default().expect("reload config");

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -342,8 +342,11 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
         vec!["keep.wav", "stale.wav"],
         "watcher hints must not patch the visible tree before the source transaction commits"
     );
-    let sync_finished =
-        run_named_perform(context.into_command(), "gui-source-db-sync").expect("db sync command");
+    let sync_finished = crate::native_app::tests::run_worker_message_for_tests(
+        context.into_command(),
+        "gui-source-db-sync",
+    )
+    .expect("db sync command");
     let mut post_commit = ui::UiUpdateContext::default();
     state.apply_message(sync_finished, &mut post_commit);
 
@@ -391,17 +394,4 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
         vec!["keep.wav"],
         "the browser projection should refresh only from committed background state"
     );
-}
-
-fn run_named_perform(
-    command: Command<crate::native_app::test_support::state::GuiMessage>,
-    target_name: &'static str,
-) -> Option<crate::native_app::test_support::state::GuiMessage> {
-    match command {
-        Command::Perform { name, work, .. } if name == target_name => Some(work()),
-        Command::Batch(commands) => commands
-            .into_iter()
-            .find_map(|command| run_named_perform(command, target_name)),
-        _ => None,
-    }
 }

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -120,16 +120,7 @@ fn run_command_collecting_followups(
     state: &mut crate::native_app::test_support::state::NativeAppState,
     command: Command<GuiMessage>,
 ) -> Vec<Command<GuiMessage>> {
-    let mut followups = Vec::new();
-    command.run_inline_for_tests(|message| {
-        let mut context = ui::UiUpdateContext::default();
-        state.apply_message(message, &mut context);
-        let command = context.into_command();
-        if !command.is_empty() {
-            followups.push(command);
-        }
-    });
-    followups
+    crate::native_app::tests::run_command_collecting_followups_for_tests(state, command)
 }
 
 fn assert_short_edge_faded_drag_extraction(path: &std::path::Path) {

--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -3007,7 +3007,14 @@ fn collect_after_commands_and_perform_count(
         timer_count,
         "every queued timer should have a test-visible mapped message"
     );
-    (delayed, count_perform_commands(&command))
+    (
+        delayed,
+        usize::from(
+            command
+                .business_task_priority("gui-last-played-persist")
+                .is_some(),
+        ),
+    )
 }
 
 fn count_timer_commands(
@@ -3020,24 +3027,10 @@ fn count_timer_commands(
     }
 }
 
-fn count_perform_commands(
-    command: &Command<crate::native_app::test_support::state::GuiMessage>,
-) -> usize {
-    match command {
-        Command::Perform { .. } => 1,
-        Command::Batch(commands) => commands.iter().map(count_perform_commands).sum(),
-        _ => 0,
-    }
-}
-
 fn run_first_perform(
     command: Command<crate::native_app::test_support::state::GuiMessage>,
 ) -> Option<crate::native_app::test_support::state::GuiMessage> {
-    match command {
-        Command::Perform { work, .. } => Some(work()),
-        Command::Batch(commands) => commands.into_iter().find_map(run_first_perform),
-        _ => None,
-    }
+    crate::native_app::tests::run_worker_message_for_tests(command, "gui-last-played-persist")
 }
 
 fn assert_starmap_viewport_reveals(

--- a/src/native_app/tests/sample_browser/similarity.rs
+++ b/src/native_app/tests/sample_browser/similarity.rs
@@ -304,11 +304,19 @@ fn sample_browser_similarity_controls_persist_after_debounce() {
 
     state.ui.settings.similarity_persist_deadline = Some(Instant::now() - Duration::from_millis(1));
     state.advance_frame(&mut context);
-    let radiant::runtime::Command::Perform { priority, work, .. } = context.into_command() else {
-        panic!("expected similarity settings persist background command");
-    };
-    assert_eq!(priority, radiant::prelude::TaskPriority::BlockingIo);
-    state.apply_message(work(), &mut radiant::prelude::UiUpdateContext::default());
+    let command = context.into_command();
+    assert_eq!(
+        command.business_task_priority("gui-similarity-settings-persist"),
+        Some(radiant::prelude::TaskPriority::BlockingIo)
+    );
+    state.apply_message(
+        crate::native_app::tests::run_worker_message_for_tests(
+            command,
+            "gui-similarity-settings-persist",
+        )
+        .expect("similarity settings persist worker completion"),
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
 
     let loaded = wavecrate::sample_sources::config::load_or_default().expect("reload config");
     assert!(loaded.core.similarity.weighting_enabled);
@@ -347,11 +355,19 @@ fn sample_browser_similarity_controls_persist_after_debounce_while_playback_is_a
         state.playback_visual_activity_active(),
         "test setup should keep playback visually active during the persist frame"
     );
-    let radiant::runtime::Command::Perform { priority, work, .. } = context.into_command() else {
-        panic!("expected similarity settings persist background command during playback");
-    };
-    assert_eq!(priority, radiant::prelude::TaskPriority::BlockingIo);
-    state.apply_message(work(), &mut radiant::prelude::UiUpdateContext::default());
+    let command = context.into_command();
+    assert_eq!(
+        command.business_task_priority("gui-similarity-settings-persist"),
+        Some(radiant::prelude::TaskPriority::BlockingIo)
+    );
+    state.apply_message(
+        crate::native_app::tests::run_worker_message_for_tests(
+            command,
+            "gui-similarity-settings-persist",
+        )
+        .expect("similarity settings persist worker completion during playback"),
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
 
     let loaded = wavecrate::sample_sources::config::load_or_default().expect("reload config");
     assert!(

--- a/src/native_app/tests/waveform_destructive_edit_tests.rs
+++ b/src/native_app/tests/waveform_destructive_edit_tests.rs
@@ -1548,19 +1548,17 @@ fn destructive_edit_reload_failure_still_emits_committed_mutation() {
         &mut request_context,
     );
     let mut completion_followups = Vec::new();
-    request_context
-        .into_command()
-        .run_inline_for_tests(|message| {
-            if matches!(message, GuiMessage::WaveformDestructiveEditFinished(_)) {
-                fs::write(&path, b"not a waveform").expect("corrupt committed waveform");
-            }
-            let mut completion_context = ui::UiUpdateContext::default();
-            state.apply_message(message, &mut completion_context);
-            let command = completion_context.into_command();
-            if !command.is_empty() {
-                completion_followups.push(command);
-            }
-        });
+    let completion = crate::native_app::tests::run_worker_message_for_tests(
+        request_context.into_command(),
+        "gui-waveform-destructive-edit",
+    )
+    .expect("destructive edit worker completion");
+    if matches!(completion, GuiMessage::WaveformDestructiveEditFinished(_)) {
+        fs::write(&path, b"not a waveform").expect("corrupt committed waveform");
+    }
+    let mut completion_context = ui::UiUpdateContext::default();
+    state.apply_message(completion, &mut completion_context);
+    completion_followups.push(completion_context.into_command());
 
     assert!(
         commands_emit_committed_file_mutation(completion_followups),
@@ -2304,13 +2302,11 @@ fn apply_message_and_run_command(
 }
 
 fn commands_emit_committed_file_mutation(commands: Vec<Command<GuiMessage>>) -> bool {
-    let mut emitted = false;
-    for command in commands {
-        command.run_inline_for_tests(|message| {
-            emitted |= matches!(message, GuiMessage::CommittedFileMutationRequested(_));
-        });
-    }
-    emitted
+    commands.into_iter().any(|command| {
+        crate::native_app::tests::run_command_and_capture_messages_for_tests(command)
+            .into_iter()
+            .any(|message| matches!(message, GuiMessage::CommittedFileMutationRequested(_)))
+    })
 }
 
 fn assert_extracted_file_keep_1_rating(

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -381,21 +381,6 @@ fn external_drag_file_paths(
     }
 }
 
-fn run_named_perform(
-    command: radiant::runtime::Command<crate::native_app::test_support::state::GuiMessage>,
-    target_name: &'static str,
-) -> Option<crate::native_app::test_support::state::GuiMessage> {
-    match command {
-        radiant::runtime::Command::Perform { name, work, .. } if name == target_name => {
-            Some(work())
-        }
-        radiant::runtime::Command::Batch(commands) => commands
-            .into_iter()
-            .find_map(|command| run_named_perform(command, target_name)),
-        _ => None,
-    }
-}
-
 fn sample_load_completion(
     ticket: ui::TaskTicket,
     path: String,
@@ -2465,8 +2450,11 @@ fn playmark_selection_drag_extracts_before_external_handoff() {
         Some(ui::TaskPriority::Interactive),
         "drag extraction should be user-interactive but asynchronous"
     );
-    let completion = run_named_perform(command, "gui-waveform-selection-drag-extract")
-        .expect("drag extraction worker command");
+    let completion = crate::native_app::tests::run_worker_message_for_tests(
+        command,
+        "gui-waveform-selection-drag-extract",
+    )
+    .expect("drag extraction worker command");
     let mut finish_context = ui::UiUpdateContext::default();
     scenario
         .state

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -1900,18 +1900,7 @@ fn normal_sample_load_persists_bright_cache_indicator_before_restart() {
 fn active_folder_cache_warm_stream_kind(
     command: &radiant::runtime::Command<crate::native_app::test_support::state::GuiMessage>,
 ) -> Option<&'static str> {
-    use radiant::runtime::Command;
-
-    match command {
-        Command::PerformStream { name, .. } if *name == "gui-active-folder-cache-warm" => {
-            Some("ordered")
-        }
-        Command::PerformStreamLatest { name, .. } if *name == "gui-active-folder-cache-warm" => {
-            Some("latest")
-        }
-        Command::Batch(commands) => commands
-            .iter()
-            .find_map(active_folder_cache_warm_stream_kind),
-        _ => None,
-    }
+    command
+        .business_task_priority("gui-active-folder-cache-warm")
+        .map(|_| "ordered")
 }

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -369,7 +369,7 @@ fn active_folder_cache_warm_uses_ordered_stream_for_cache_ready_progress() {
         &mut context,
         source_root.path().display().to_string(),
         Vec::new(),
-        vec![first, second],
+        vec![first.clone(), second],
     );
 
     let warm_ticket = state
@@ -385,10 +385,49 @@ fn active_folder_cache_warm_uses_ordered_stream_for_cache_ready_progress() {
     );
     let command = start_context.into_command();
 
+    let messages = crate::native_app::tests::run_command_and_capture_messages_for_tests(command);
+    let progress = messages
+        .iter()
+        .filter_map(|message| match message {
+            crate::native_app::test_support::state::GuiMessage::ActiveFolderCacheWarmProgress(
+                completion,
+            ) => Some((
+                completion.output.path.clone(),
+                completion.output.processed,
+                completion.output.stage,
+            )),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        progress.len() >= 4,
+        "ordered cache warming should retain multiple progress events, got {}",
+        progress.len()
+    );
+    assert_eq!(progress[0].0, first);
     assert_eq!(
-        active_folder_cache_warm_stream_kind(&command),
-        Some("ordered"),
-        "cache-ready progress events must not be coalesced away"
+        progress[0].2,
+        crate::native_app::test_support::state::ActiveFolderCacheWarmStage::CheckingCache
+    );
+    assert_eq!(progress[1].0, first);
+    assert_eq!(
+        progress[1].2,
+        crate::native_app::test_support::state::ActiveFolderCacheWarmStage::LoadingCache
+    );
+    assert!(
+        progress.windows(2).all(|events| events[0].1 <= events[1].1),
+        "ordered cache progress should preserve nondecreasing processed order"
+    );
+    assert!(
+        matches!(
+            messages.last(),
+            Some(
+                crate::native_app::test_support::state::GuiMessage::ActiveFolderCacheWarmFinished(
+                    _
+                )
+            )
+        ),
+        "ordered cache progress must be followed by final completion"
     );
 }
 
@@ -1895,12 +1934,4 @@ fn normal_sample_load_persists_bright_cache_indicator_before_restart() {
             .contains(&sample_path),
         "freshly loaded cache indicator should survive immediate restart"
     );
-}
-
-fn active_folder_cache_warm_stream_kind(
-    command: &radiant::runtime::Command<crate::native_app::test_support::state::GuiMessage>,
-) -> Option<&'static str> {
-    command
-        .business_task_priority("gui-active-folder-cache-warm")
-        .map(|_| "ordered")
 }

--- a/tests/radiant_dependency_contract.rs
+++ b/tests/radiant_dependency_contract.rs
@@ -13,7 +13,7 @@ fn canonical_radiant_dependency_uses_the_standalone_sibling_contract() {
 
     assert!(manifest.contains("radiant = { path = \"../radiant\" }"));
     assert!(metadata.contains("repository = \"https://github.com/PORTALSURFER/radiant.git\""));
-    assert!(metadata.contains("revision = \"a3a6c14b52acc45e547b3f4da9bf60914158c9d3\""));
+    assert!(metadata.contains("revision = \"095ddf597fbac5a1055550c64b30d27ce62f7c38\""));
     assert!(metadata.contains("path = \"../radiant\""));
     assert!(!root.join(".gitmodules").exists());
     assert!(!root.join("vendor/radiant").exists());

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -487,7 +487,7 @@ edition = "2024"
             ),
         );
         self.write("Cargo.lock", "# fixture lockfile\n");
-        self.write("radiant-dependency.toml", "repository = \"https://github.com/PORTALSURFER/radiant.git\"\nrevision = \"a3a6c14b52acc45e547b3f4da9bf60914158c9d3\"\npath = \"../radiant\"\n");
+        self.write("radiant-dependency.toml", "repository = \"https://github.com/PORTALSURFER/radiant.git\"\nrevision = \"095ddf597fbac5a1055550c64b30d27ce62f7c38\"\npath = \"../radiant\"\n");
         self.write("src/lib.rs", "");
         self.write(".github/workflows/release-train-prepare.yml", "");
         self.write(".github/workflows/release-rc.yml", "");


### PR DESCRIPTION
## Goal

Align Wavecrate with Radiant `095ddf597fbac5a1055550c64b30d27ce62f7c38` and restore a reproducible locked release build.

## Scope and non-goals

- Pin the canonical sibling Radiant contract and release fixtures to `095ddf59`.
- Migrate the GUI worker subscription to `Subscription::worker_payload` with identity mapping.
- Migrate Wavecrate test command execution from removed Radiant inline helpers to the current runtime task-host API.
- Preserve existing GUI-worker payload behavior.
- No Radiant source changes, GUI message redesign, external-drag work, or unrelated cleanup.

## Definition of Done

- Canonical dependency metadata and fixtures contain the exact Radiant SHA.
- The isolated sibling pair reports a clean revision match.
- Wavecrate compiles across the locked workspace and all targets.
- Workspace test targets and standalone Radiant test targets build.
- Release validation and an optimized release build succeed.
- Current complete diff receives an independent review.

## Validation

Validated in an isolated paired checkout with Radiant detached cleanly at the pinned SHA:

- `bash scripts/radiant.sh locate` — pass (`RADIANT_REVISION_MATCH=yes`)
- `git diff --check` — pass
- `rustfmt --edition 2024 --check src/native_app/tests.rs` — pass
- `cargo check --workspace --all-targets --locked` — pass
- `cargo test --locked --test radiant_dependency_contract` — pass (1/1)
- `cargo test --locked --test release_orchestration` — pass (17/17)
- volume focused tests — pass (4/4)
- similarity focused tests — pass (12/12)
- `cargo test --workspace --locked --no-run` — pass
- `bash scripts/internal/release/run_release_validation.sh` — pass, including standalone Radiant targets, release contracts, and scanner tests (193/193)
- `cargo build --release --locked` — pass

## Known limitations

- `cargo fmt --all -- --check` still reports two pre-existing formatting differences outside this diff: `src/native_app/shell/message_dispatch/navigation.rs` and `tests/release_contract.rs`.
- `bash scripts/ci.sh agent` stops at its branch guard in the isolated detached worktree; its constituent locked compile and release gates above were run directly.
- Source-refresh focused tests are 5/7 on this head versus 4/7 on the untouched old-pin baseline. The same two failures reproduce on the baseline.
- File-operation focused tests are 25/52 on this head versus 16/52 on the untouched old-pin baseline. The remaining failures are recorded as existing harness/fixture behavior and are outside this Radiant alignment scope.

User approval is required before merge.
