### PR TITLE
Fix Playmark selection persistence stalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,6 +4315,7 @@ name = "radiant"
 version = "0.1.0"
 dependencies = [
  "arboard",
+ "block2 0.5.1",
  "kurbo",
  "lyon_tessellation",
  "objc2 0.5.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "095ddf597fbac5a1055550c64b30d27ce62f7c38"
+revision = "16ef95c6a3f2828aa824da16a818d970d5e3b9f5"
 path = "../radiant"
 
 [package]

--- a/crates/wavecrate-library/src/sample_sources/library.rs
+++ b/crates/wavecrate-library/src/sample_sources/library.rs
@@ -190,16 +190,37 @@ pub fn mark_harvest_seen(
 pub fn mark_harvest_touched(
     identity: &HarvestFileIdentity,
 ) -> Result<HarvestFileRecord, LibraryError> {
+    mark_harvest_touched_if_current(identity, || true)
+        .map(|record| record.expect("unconditional harvest touch must not be skipped"))
+}
+
+/// Mark a harvest file as touched when the caller's revision is still current.
+///
+/// The predicate is evaluated while the global library lock is held and immediately before the
+/// state update, allowing UI-owned revision fences to serialize correctly with manual harvest
+/// mutations.
+pub fn mark_harvest_touched_if_current(
+    identity: &HarvestFileIdentity,
+    current: impl Fn() -> bool,
+) -> Result<Option<HarvestFileRecord>, LibraryError> {
     let started_at = Instant::now();
     let _guard = lock_library();
+    if !current() {
+        return Ok(None);
+    }
     let db = LibraryDatabase::open()?;
+    // Re-check after opening the database so a superseding request that arrives while opening it
+    // cannot proceed to the serialized state mutation.
+    if !current() {
+        return Ok(None);
+    }
     let result = db.advance_harvest_state(identity, HarvestState::Touched);
     record_library_db_event(
         "library.harvest.mark_touched",
         started_at,
         result.as_ref().map(|_| ()),
     );
-    result
+    result.map(Some)
 }
 
 /// Manually set a harvest state, including explicit reset to `New`.

--- a/crates/wavecrate-library/src/sample_sources/library/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/tests.rs
@@ -298,6 +298,26 @@ fn harvest_state_auto_transitions_only_move_forward() {
 }
 
 #[test]
+fn current_harvest_touch_fence_rechecks_before_state_write() {
+    let temp = tempdir().unwrap();
+    with_config_home(temp.path(), || {
+        let identity = harvest_identity("source-fence", "drums/kick.wav");
+        upsert_harvest_file(&identity).unwrap();
+        let checks = std::sync::atomic::AtomicUsize::new(0);
+        let result = mark_harvest_touched_if_current(&identity, || {
+            checks.fetch_add(1, std::sync::atomic::Ordering::Relaxed) == 0
+        })
+        .unwrap();
+        assert!(result.is_none());
+        assert_eq!(checks.load(std::sync::atomic::Ordering::Relaxed), 2);
+        assert_eq!(
+            harvest_file(&identity.key).unwrap().unwrap().state,
+            HarvestState::New
+        );
+    });
+}
+
+#[test]
 fn harvest_file_batch_upsert_persists_every_identity() {
     let temp = tempdir().unwrap();
     with_config_home(temp.path(), || {

--- a/radiant-dependency.toml
+++ b/radiant-dependency.toml
@@ -4,5 +4,5 @@
 # sibling may remain on a feature branch or contain uncommitted work. Setup,
 # CI, and release helpers provision this exact revision into a clean checkout.
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "095ddf597fbac5a1055550c64b30d27ce62f7c38"
+revision = "16ef95c6a3f2828aa824da16a818d970d5e3b9f5"
 path = "../radiant"

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -190,6 +190,10 @@ pub(in crate::native_app) enum GuiMessage {
     },
     LastPlayedPersisted(LastPlayedPersistResult),
     HarvestSeenPersisted(HarvestSeenPersistResult),
+    HarvestTouchedPersisted(
+        ui::TaskCompletion<crate::native_app::app::HarvestTouchedPersistBatchResult>,
+    ),
+    HarvestTouchedPersistAdmissionPoll(ui::TaskTicket),
     VolumeSettingsPersisted(VolumeSettingsPersistResult),
     StopPlayback,
     ToggleLoopPlayback,

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -39,7 +39,8 @@ pub(in crate::native_app) use state::ReleaseUpdateStatus;
 pub(in crate::native_app) use state::{
     AudioAppState, AudioOpenCompletion, AudioOpenTaskCompletion, AudioOptionsRefreshResult,
     BackgroundTaskState, ChromeUiState, ClipboardHandoffTarget, CompletedTransientSamplePlayback,
-    CutFileClipboard, ExtractedFilePlaybackType, FolderScanWorkerEvent, LibraryAppState,
+    CutFileClipboard, ExtractedFilePlaybackType, FolderScanWorkerEvent,
+    HarvestTouchedPersistAdmission, HarvestTouchedPersistBatchResult, LibraryAppState,
     MAX_BEAT_GUIDE_COUNT, MIN_BEAT_GUIDE_COUNT, MetadataAppState, NativeAppState,
     OverflowFadeAnimations, PendingFolderDelete, PendingPlaySelectionRetargetCycle,
     PendingPlaybackStart, PendingProtectedExtractionAction, PendingProtectedExtractionTargetSource,

--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -6,10 +6,15 @@ use std::{
         atomic::AtomicU64,
         mpsc::{Receiver, Sender},
     },
+    time::Duration,
 };
 
 use radiant::{gui::frame as frame_ui, prelude as ui};
 use wavecrate::audio::AudioPlayer;
+use wavecrate::sample_sources::{
+    HarvestTouchedPersistRequest, HarvestTouchedPersistResult, SourceId,
+    persist_harvest_touched_if_current,
+};
 
 use crate::native_app::app::GuiSourceProcessingEventSink;
 use crate::native_app::app::{
@@ -27,6 +32,7 @@ pub(in crate::native_app) struct BackgroundTaskState {
     pub(in crate::native_app) sample_load_validation_task: ui::LatestTask,
     pub(in crate::native_app) deferred_sample_load_task: ui::LatestTask,
     pub(in crate::native_app) sample_load_tasks: ui::ResourceTasks,
+    pub(in crate::native_app) harvest_touched_persist: HarvestTouchedPersistOwner,
     pub(in crate::native_app) active_sample_load_key: Option<ui::ResourceKey>,
     pub(in crate::native_app) sample_load_cancel: Option<ui::CancellationToken>,
     pub(in crate::native_app) settled_sample_promotion_task: ui::LatestTask,
@@ -108,6 +114,7 @@ impl BackgroundTaskState {
             sample_load_validation_task: ui::LatestTask::new(),
             deferred_sample_load_task: ui::LatestTask::new(),
             sample_load_tasks: ui::ResourceTasks::new(),
+            harvest_touched_persist: HarvestTouchedPersistOwner::new(),
             active_sample_load_key: None,
             sample_load_cancel: None,
             settled_sample_promotion_task: ui::LatestTask::new(),
@@ -149,6 +156,655 @@ impl BackgroundTaskState {
     #[cfg(test)]
     pub(in crate::native_app) fn for_tests() -> Self {
         Self::new(std::sync::mpsc::channel().0, None, Vec::new())
+    }
+}
+
+const HARVEST_TOUCHED_QUEUE_CAPACITY: usize = 64;
+const HARVEST_TOUCHED_BATCH_LIMIT: usize = 32;
+const HARVEST_TOUCHED_ADMISSION_POLL_DELAY: Duration = Duration::from_millis(50);
+
+#[derive(Clone)]
+pub(in crate::native_app) struct HarvestTouchedPersistOwner {
+    task: ui::LatestTask,
+    admission_receipt: Option<HarvestTouchedPersistAdmissionReceipt>,
+    admission_poll_task: ui::LatestTask,
+    admission_retry_used: bool,
+    queue: Arc<Mutex<HarvestTouchedPersistQueue>>,
+}
+
+#[derive(Clone)]
+struct HarvestTouchedPersistAdmissionReceipt {
+    ticket: ui::TaskTicket,
+    receipt: ui::BusinessTaskAdmissionReceipt,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(in crate::native_app) struct HarvestTouchedPersistKey {
+    source_id: SourceId,
+    relative_path: PathBuf,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum HarvestTouchedPersistAdmission {
+    Queued,
+    Replaced,
+    Saturated,
+}
+
+struct HarvestTouchedPersistQueue {
+    entries: std::collections::HashMap<HarvestTouchedPersistKey, HarvestTouchedPersistEntry>,
+    order: VecDeque<HarvestTouchedPersistKey>,
+    next_revision: u64,
+    closed: bool,
+}
+
+struct HarvestTouchedPersistEntry {
+    request: HarvestTouchedPersistRequest,
+    revision: u64,
+    state: HarvestTouchedPersistEntryState,
+    retry_blocked: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HarvestTouchedPersistEntryState {
+    Pending,
+    InFlight,
+}
+
+struct HarvestTouchedPersistWork {
+    key: HarvestTouchedPersistKey,
+    request: HarvestTouchedPersistRequest,
+    revision: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct HarvestTouchedPersistBatchResult {
+    pub(in crate::native_app) results: Vec<HarvestTouchedPersistBatchItem>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct HarvestTouchedPersistBatchItem {
+    pub(in crate::native_app) key: HarvestTouchedPersistKey,
+    pub(in crate::native_app) revision: u64,
+    pub(in crate::native_app) result: Option<HarvestTouchedPersistResult>,
+}
+
+impl HarvestTouchedPersistOwner {
+    fn new() -> Self {
+        Self {
+            task: ui::LatestTask::new(),
+            admission_receipt: None,
+            admission_poll_task: ui::LatestTask::new(),
+            admission_retry_used: false,
+            queue: Arc::new(Mutex::new(HarvestTouchedPersistQueue {
+                entries: std::collections::HashMap::new(),
+                order: VecDeque::new(),
+                next_revision: 1,
+                closed: false,
+            })),
+        }
+    }
+
+    pub(in crate::native_app) fn enqueue(
+        &mut self,
+        request: HarvestTouchedPersistRequest,
+    ) -> HarvestTouchedPersistAdmission {
+        let key = HarvestTouchedPersistKey::from_request(&request);
+        let Ok(mut queue) = self.queue.lock() else {
+            tracing::warn!("harvest touched queue lock poisoned; rejecting request");
+            return HarvestTouchedPersistAdmission::Saturated;
+        };
+        if queue.closed {
+            return HarvestTouchedPersistAdmission::Saturated;
+        }
+        let revision = next_harvest_touched_revision(&mut queue);
+        if let Some(entry) = queue.entries.get_mut(&key) {
+            // A coalesced enqueue explicitly re-arms one admission recovery attempt.
+            self.admission_retry_used = false;
+            let was_retry_blocked = entry.retry_blocked;
+            entry.request = request;
+            entry.revision = revision;
+            entry.retry_blocked = false;
+            if entry.state == HarvestTouchedPersistEntryState::InFlight {
+                entry.state = HarvestTouchedPersistEntryState::Pending;
+                queue.order.push_back(key);
+            } else if was_retry_blocked {
+                queue.order.push_back(key);
+            }
+            return HarvestTouchedPersistAdmission::Replaced;
+        }
+        if queue.entries.len() >= HARVEST_TOUCHED_QUEUE_CAPACITY {
+            return HarvestTouchedPersistAdmission::Saturated;
+        }
+        // A fresh enqueue explicitly re-arms one admission recovery attempt.
+        self.admission_retry_used = false;
+        queue.order.push_back(key.clone());
+        queue.entries.insert(
+            key,
+            HarvestTouchedPersistEntry {
+                request,
+                revision,
+                state: HarvestTouchedPersistEntryState::Pending,
+                retry_blocked: false,
+            },
+        );
+        HarvestTouchedPersistAdmission::Queued
+    }
+
+    pub(in crate::native_app) fn schedule_if_idle(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        if self.task.active().is_some()
+            || self
+                .queue
+                .lock()
+                .ok()
+                .is_none_or(|queue| !queue.has_pending())
+        {
+            return;
+        }
+        let queue = Arc::clone(&self.queue);
+        let request = context
+            .business()
+            .blocking_io("gui-harvest-touched-persist")
+            .latest(&mut self.task);
+        let ticket = request.ticket();
+        let receipt = request.run_with_receipt(
+            move |_| persist_harvest_touched_queue(queue),
+            GuiMessage::HarvestTouchedPersisted,
+        );
+        self.admission_receipt = Some(HarvestTouchedPersistAdmissionReceipt { ticket, receipt });
+        self.schedule_admission_poll(context);
+    }
+
+    fn schedule_admission_poll(&mut self, context: &mut ui::UiUpdateContext<GuiMessage>) {
+        if self.admission_poll_task.active().is_some() {
+            return;
+        }
+        context.after_latest(
+            &mut self.admission_poll_task,
+            HARVEST_TOUCHED_ADMISSION_POLL_DELAY,
+            GuiMessage::HarvestTouchedPersistAdmissionPoll,
+        );
+    }
+
+    pub(in crate::native_app) fn poll_admission(
+        &mut self,
+        ticket: ui::TaskTicket,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        if !self.admission_poll_task.finish(ticket) {
+            return;
+        }
+        let Some(admission) = self.admission_receipt.as_ref() else {
+            // This is the one delayed recovery turn after a rejected admission.
+            self.schedule_if_idle(context);
+            return;
+        };
+        let state = admission.receipt.poll();
+        match state {
+            ui::BusinessTaskAdmission::Pending => self.schedule_admission_poll(context),
+            ui::BusinessTaskAdmission::Accepted => {}
+            ui::BusinessTaskAdmission::Rejected | ui::BusinessTaskAdmission::Closed => {
+                let rejected = state == ui::BusinessTaskAdmission::Rejected;
+                self.admission_receipt = None;
+                if rejected {
+                    if self.admission_retry_used {
+                        self.block_admission_retry_queue();
+                    } else {
+                        // The worker closure claims entries only after host admission. A
+                        // rejected receipt therefore leaves the queue untouched; arm exactly
+                        // one delayed recovery turn without recursively submitting a worker.
+                        self.admission_retry_used = true;
+                        self.schedule_admission_poll(context);
+                    }
+                }
+            }
+        }
+    }
+
+    pub(in crate::native_app) fn finish(
+        &mut self,
+        completion: ui::TaskCompletion<HarvestTouchedPersistBatchResult>,
+    ) -> Option<HarvestTouchedPersistBatchResult> {
+        let completion_ticket = completion.ticket;
+        let result = self.task.finish_completion(completion)?;
+        if self
+            .admission_receipt
+            .as_ref()
+            .is_some_and(|admission| admission.ticket == completion_ticket)
+        {
+            self.admission_receipt = None;
+            self.admission_poll_task.cancel();
+            self.admission_retry_used = false;
+        }
+        if let Ok(mut queue) = self.queue.lock() {
+            for item in &result.results {
+                queue.acknowledge(item);
+            }
+        }
+        Some(result)
+    }
+
+    pub(in crate::native_app) fn invalidate(&mut self, request: &HarvestTouchedPersistRequest) {
+        let key = HarvestTouchedPersistKey::from_request(request);
+        if let Ok(mut queue) = self.queue.lock() {
+            queue.entries.remove(&key);
+            queue.order.retain(|candidate| candidate != &key);
+        }
+    }
+
+    fn block_admission_retry_queue(&mut self) {
+        let Ok(mut queue) = self.queue.lock() else {
+            return;
+        };
+        for entry in queue.entries.values_mut() {
+            entry.retry_blocked = true;
+            entry.state = HarvestTouchedPersistEntryState::Pending;
+        }
+    }
+
+    pub(in crate::native_app) fn close(&mut self) -> usize {
+        self.task.cancel();
+        self.admission_poll_task.cancel();
+        self.admission_receipt = None;
+        let Ok(mut queue) = self.queue.lock() else {
+            return 0;
+        };
+        queue.closed = true;
+        let count = queue.entries.len();
+        queue.entries.clear();
+        queue.order.clear();
+        count
+    }
+}
+
+fn persist_harvest_touched_queue(
+    queue: Arc<Mutex<HarvestTouchedPersistQueue>>,
+) -> HarvestTouchedPersistBatchResult {
+    let work = queue
+        .lock()
+        .map(|mut queue| queue.claim_batch())
+        .unwrap_or_default();
+    let mut results = Vec::with_capacity(work.len());
+    for item in work {
+        let key = item.key.clone();
+        let revision = item.revision;
+        let current_queue = Arc::clone(&queue);
+        let result = persist_harvest_touched_if_current(item.request, move || {
+            current_queue
+                .lock()
+                .ok()
+                .is_some_and(|queue| queue.is_current(&key, revision))
+        });
+        results.push(HarvestTouchedPersistBatchItem {
+            key: item.key,
+            revision,
+            result,
+        });
+    }
+    HarvestTouchedPersistBatchResult { results }
+}
+
+fn next_harvest_touched_revision(queue: &mut HarvestTouchedPersistQueue) -> u64 {
+    let revision = queue.next_revision;
+    queue.next_revision = queue.next_revision.saturating_add(1);
+    revision
+}
+
+impl HarvestTouchedPersistKey {
+    fn from_request(request: &HarvestTouchedPersistRequest) -> Self {
+        Self {
+            source_id: request.source.id.clone(),
+            relative_path: request.relative_path.clone(),
+        }
+    }
+}
+
+impl HarvestTouchedPersistQueue {
+    fn has_pending(&self) -> bool {
+        self.entries.values().any(|entry| {
+            entry.state == HarvestTouchedPersistEntryState::Pending && !entry.retry_blocked
+        })
+    }
+
+    fn claim_batch(&mut self) -> Vec<HarvestTouchedPersistWork> {
+        let mut claimed = Vec::with_capacity(HARVEST_TOUCHED_BATCH_LIMIT);
+        while claimed.len() < HARVEST_TOUCHED_BATCH_LIMIT {
+            let Some(key) = self.order.pop_front() else {
+                break;
+            };
+            let Some(entry) = self.entries.get_mut(&key) else {
+                continue;
+            };
+            if entry.state != HarvestTouchedPersistEntryState::Pending || entry.retry_blocked {
+                continue;
+            }
+            entry.state = HarvestTouchedPersistEntryState::InFlight;
+            claimed.push(HarvestTouchedPersistWork {
+                key,
+                request: entry.request.clone(),
+                revision: entry.revision,
+            });
+        }
+        claimed
+    }
+
+    fn is_current(&self, key: &HarvestTouchedPersistKey, revision: u64) -> bool {
+        self.entries.get(key).is_some_and(|entry| {
+            entry.revision == revision && entry.state == HarvestTouchedPersistEntryState::InFlight
+        })
+    }
+
+    fn acknowledge(&mut self, item: &HarvestTouchedPersistBatchItem) {
+        let Some(entry) = self.entries.get_mut(&item.key) else {
+            return;
+        };
+        if entry.revision != item.revision
+            || entry.state != HarvestTouchedPersistEntryState::InFlight
+        {
+            return;
+        }
+        if item
+            .result
+            .as_ref()
+            .is_some_and(|result| result.result.is_ok())
+        {
+            self.entries.remove(&item.key);
+        } else {
+            entry.state = HarvestTouchedPersistEntryState::Pending;
+            entry.retry_blocked = true;
+            self.order.push_back(item.key.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod harvest_touched_owner_tests {
+    use super::*;
+    use radiant::prelude::IntoView;
+
+    struct RejectingWorkerBridge;
+
+    impl radiant::runtime::RuntimeBridge<GuiMessage> for RejectingWorkerBridge {
+        fn project_surface(&mut self) -> std::sync::Arc<radiant::runtime::UiSurface<GuiMessage>> {
+            std::sync::Arc::new(radiant::prelude::empty::<GuiMessage>().into_surface())
+        }
+
+        fn host_capabilities(&self) -> radiant::runtime::RuntimeHostCapabilities<Self, GuiMessage> {
+            radiant::runtime::RuntimeHostCapabilities::new().with_tasks()
+        }
+    }
+
+    impl radiant::runtime::RuntimeTaskHost<GuiMessage> for RejectingWorkerBridge {
+        fn schedule_timer(
+            &mut self,
+            _delay: Duration,
+            _wake: radiant::runtime::RuntimeTimerWake,
+        ) -> bool {
+            true
+        }
+
+        fn spawn_worker_task(
+            &mut self,
+            _name: &'static str,
+            _priority: radiant::prelude::TaskPriority,
+            _is_cancelled: Option<Box<dyn Fn() -> bool + Send + Sync + 'static>>,
+            _work: Box<dyn FnOnce() + Send + 'static>,
+        ) -> bool {
+            false
+        }
+    }
+
+    fn request(source_id: &str, path: &str) -> HarvestTouchedPersistRequest {
+        HarvestTouchedPersistRequest {
+            file_id: format!("/tmp/{source_id}/{path}"),
+            source: wavecrate::sample_sources::SampleSource::new_with_id(
+                SourceId::from_string(source_id),
+                PathBuf::from(format!("/tmp/{source_id}")),
+            ),
+            relative_path: PathBuf::from(path),
+        }
+    }
+
+    fn successful(item: &HarvestTouchedPersistWork) -> HarvestTouchedPersistBatchItem {
+        HarvestTouchedPersistBatchItem {
+            key: item.key.clone(),
+            revision: item.revision,
+            result: Some(HarvestTouchedPersistResult {
+                file_id: item.request.file_id.clone(),
+                result: Ok(()),
+            }),
+        }
+    }
+
+    fn failed(item: &HarvestTouchedPersistWork) -> HarvestTouchedPersistBatchItem {
+        HarvestTouchedPersistBatchItem {
+            key: item.key.clone(),
+            revision: item.revision,
+            result: Some(HarvestTouchedPersistResult {
+                file_id: item.request.file_id.clone(),
+                result: Err(String::from("transient")),
+            }),
+        }
+    }
+
+    #[test]
+    fn pending_enqueue_coalesces_to_latest_revision() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        assert_eq!(
+            owner.enqueue(request("source", "kick.wav")),
+            HarvestTouchedPersistAdmission::Queued
+        );
+        assert_eq!(
+            owner.enqueue(request("source", "kick.wav")),
+            HarvestTouchedPersistAdmission::Replaced
+        );
+
+        let work = owner.queue.lock().expect("queue lock").claim_batch();
+        assert_eq!(work.len(), 1);
+        assert_eq!(work[0].request.file_id, "/tmp/source/kick.wav");
+        assert_eq!(work[0].revision, 2);
+    }
+
+    #[test]
+    fn inflight_enqueue_supersedes_without_losing_capacity() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        owner.enqueue(request("source", "kick.wav"));
+        let first = owner.queue.lock().expect("queue lock").claim_batch();
+        assert_eq!(first.len(), 1);
+
+        assert_eq!(
+            owner.enqueue(request("source", "kick.wav")),
+            HarvestTouchedPersistAdmission::Replaced
+        );
+        let queue = owner.queue.lock().expect("queue lock");
+        assert_eq!(queue.entries.len(), 1);
+        assert!(!queue.is_current(&first[0].key, first[0].revision));
+        drop(queue);
+        assert_eq!(
+            owner.queue.lock().expect("queue lock").claim_batch().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn stale_completion_cannot_remove_replacement() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        owner.enqueue(request("source", "kick.wav"));
+        let first = owner.queue.lock().expect("queue lock").claim_batch();
+        owner.enqueue(request("source", "kick.wav"));
+        owner
+            .queue
+            .lock()
+            .expect("queue lock")
+            .acknowledge(&successful(&first[0]));
+        assert_eq!(owner.queue.lock().expect("queue lock").entries.len(), 1);
+    }
+
+    #[test]
+    fn capacity_counts_inflight_and_pending_entries() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        for index in 0..HARVEST_TOUCHED_QUEUE_CAPACITY {
+            assert_eq!(
+                owner.enqueue(request("source", &format!("{index}.wav"))),
+                HarvestTouchedPersistAdmission::Queued
+            );
+        }
+        let _ = owner.queue.lock().expect("queue lock").claim_batch();
+        assert_eq!(
+            owner.enqueue(request("source", "overflow.wav")),
+            HarvestTouchedPersistAdmission::Saturated
+        );
+        assert_eq!(
+            owner.enqueue(request("source", "0.wav")),
+            HarvestTouchedPersistAdmission::Replaced
+        );
+    }
+
+    #[test]
+    fn finite_batches_preserve_fifo_and_limit() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        for index in 0..(HARVEST_TOUCHED_BATCH_LIMIT + 1) {
+            owner.enqueue(request("source", &format!("{index}.wav")));
+        }
+        let mut queue = owner.queue.lock().expect("queue lock");
+        let first = queue.claim_batch();
+        assert_eq!(first.len(), HARVEST_TOUCHED_BATCH_LIMIT);
+        assert_eq!(first[0].request.relative_path, PathBuf::from("0.wav"));
+        assert_eq!(queue.claim_batch().len(), 1);
+    }
+
+    #[test]
+    fn close_rejects_late_enqueue_and_reports_admitted_work() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        owner.enqueue(request("source", "kick.wav"));
+        assert_eq!(owner.close(), 1);
+        assert_eq!(
+            owner.enqueue(request("source", "snare.wav")),
+            HarvestTouchedPersistAdmission::Saturated
+        );
+    }
+
+    #[test]
+    fn failed_revision_is_retained_without_immediate_retry_loop() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        owner.enqueue(request("source", "kick.wav"));
+        let work = owner.queue.lock().expect("queue lock").claim_batch();
+        owner
+            .queue
+            .lock()
+            .expect("queue lock")
+            .acknowledge(&failed(&work[0]));
+        let queue = owner.queue.lock().expect("queue lock");
+        assert_eq!(queue.entries.len(), 1);
+        assert!(!queue.has_pending());
+    }
+
+    #[test]
+    fn harvest_persist_uses_blocking_io_lane() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        owner.enqueue(request("source", "kick.wav"));
+        let mut context = ui::UiUpdateContext::default();
+        owner.schedule_if_idle(&mut context);
+        assert_eq!(
+            context
+                .into_command()
+                .business_task_priority("gui-harvest-touched-persist"),
+            Some(ui::TaskPriority::BlockingIo)
+        );
+    }
+
+    #[test]
+    fn rejected_receipt_retries_later_without_reclaiming_before_admission() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        owner.enqueue(request("source", "kick.wav"));
+        let mut context = ui::UiUpdateContext::default();
+        owner.schedule_if_idle(&mut context);
+        let command = context.into_command();
+
+        let mut runtime = radiant::runtime::SurfaceRuntime::new(
+            RejectingWorkerBridge,
+            radiant::gui::types::Vector2::new(80.0, 40.0),
+        );
+        runtime.execute_command(command);
+        let poll_ticket = owner
+            .admission_poll_task
+            .active()
+            .expect("admission poll timer should be retained");
+        assert!(owner.queue.lock().expect("queue lock").has_pending());
+
+        let mut delayed_retry_context = ui::UiUpdateContext::default();
+        owner.poll_admission(poll_ticket, &mut delayed_retry_context);
+        let delayed_retry = delayed_retry_context.into_command();
+        assert_eq!(
+            delayed_retry.business_task_priority("gui-harvest-touched-persist"),
+            None
+        );
+
+        let retry_poll_ticket = owner
+            .admission_poll_task
+            .active()
+            .expect("one delayed recovery poll should be retained");
+        let mut retry_context = ui::UiUpdateContext::default();
+        owner.poll_admission(retry_poll_ticket, &mut retry_context);
+        let retry_command = retry_context.into_command();
+        assert_eq!(
+            retry_command.business_task_priority("gui-harvest-touched-persist"),
+            Some(ui::TaskPriority::BlockingIo)
+        );
+        assert!(owner.task.active().is_some());
+        assert!(owner.queue.lock().expect("queue lock").has_pending());
+
+        runtime.execute_command(retry_command);
+        let second_reject_poll = owner
+            .admission_poll_task
+            .active()
+            .expect("second admission should arm one poll");
+        let mut blocked_context = ui::UiUpdateContext::default();
+        owner.poll_admission(second_reject_poll, &mut blocked_context);
+        assert_eq!(
+            blocked_context
+                .into_command()
+                .business_task_priority("gui-harvest-touched-persist"),
+            None
+        );
+        assert!(owner.task.active().is_none());
+        assert!(!owner.queue.lock().expect("queue lock").has_pending());
+
+        owner.enqueue(request("source", "snare.wav"));
+        let mut rearm_context = ui::UiUpdateContext::default();
+        owner.schedule_if_idle(&mut rearm_context);
+        assert_eq!(
+            rearm_context
+                .into_command()
+                .business_task_priority("gui-harvest-touched-persist"),
+            Some(ui::TaskPriority::BlockingIo)
+        );
+    }
+
+    #[test]
+    fn stale_receipt_poll_and_completion_cannot_replace_latest_work() {
+        let mut owner = HarvestTouchedPersistOwner::new();
+        owner.enqueue(request("source", "kick.wav"));
+        let first = owner.queue.lock().expect("queue lock").claim_batch();
+        owner.enqueue(request("source", "kick.wav"));
+        let stale = HarvestTouchedPersistBatchResult {
+            results: vec![successful(&first[0])],
+        };
+        let stale_ticket = owner.task.begin();
+        let _latest_ticket = owner.task.begin();
+        let stale_completion = ui::TaskCompletion {
+            ticket: stale_ticket,
+            output: stale,
+        };
+        assert!(owner.finish(stale_completion).is_none());
+        let stale_poll_ticket = owner.admission_poll_task.begin();
+        let _latest_poll_ticket = owner.admission_poll_task.begin();
+        owner.poll_admission(stale_poll_ticket, &mut ui::UiUpdateContext::default());
+        assert!(owner.admission_poll_task.active().is_some());
+        assert_eq!(owner.queue.lock().expect("queue lock").entries.len(), 1);
     }
 }
 

--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -22,6 +22,7 @@ pub(in crate::native_app) use audio::{
 };
 pub(in crate::native_app) use background::{
     AudioOpenCompletion, AudioOpenTaskCompletion, BackgroundTaskState,
+    HarvestTouchedPersistAdmission, HarvestTouchedPersistBatchResult,
     WaveformDestructiveEditUiContext,
 };
 pub(in crate::native_app) use library::LibraryAppState;

--- a/src/native_app/audio/normalization_actions.rs
+++ b/src/native_app/audio/normalization_actions.rs
@@ -404,7 +404,7 @@ impl NativeAppState {
         self.background.progress_tick = 0.0;
 
         self.evict_waveform_cache_paths(&result.normalized);
-        self.mark_harvest_touched_for_paths(&result.normalized);
+        self.schedule_harvest_touched_for_paths(&result.normalized, context);
         self.record_harvest_derivations_for_finished_normalization_copies(
             &result.normalized,
             &result.skipped,

--- a/src/native_app/metadata/assignment.rs
+++ b/src/native_app/metadata/assignment.rs
@@ -238,7 +238,7 @@ impl NativeAppState {
             return;
         }
         let touched_paths = changed_files.iter().map(PathBuf::from).collect::<Vec<_>>();
-        self.mark_harvest_touched_for_paths(&touched_paths);
+        self.schedule_harvest_touched_for_paths(&touched_paths, context);
         self.finish_metadata_tag_curation_change(&changed_files, previous_visible_ids);
         let status_tags = added_metadata_tag_status_tags(&requests, &tags);
         self.ui.status.sample = metadata_tag_added_status(&status_tags, changed_files.len());
@@ -360,7 +360,7 @@ impl NativeAppState {
             self.metadata.selected_tag = None;
         }
         let touched_paths = changed_files.iter().map(PathBuf::from).collect::<Vec<_>>();
-        self.mark_harvest_touched_for_paths(&touched_paths);
+        self.schedule_harvest_touched_for_paths(&touched_paths, context);
         self.finish_metadata_tag_curation_change(&changed_files, previous_visible_ids);
         self.ui.status.sample = metadata_tag_removed_status(&tag, changed_files.len());
         if requests.len() == 1 {

--- a/src/native_app/sample_library/drag_drop_actions/external.rs
+++ b/src/native_app/sample_library/drag_drop_actions/external.rs
@@ -68,10 +68,11 @@ impl NativeAppState {
         count: usize,
         started_at: Instant,
         result: Result<(), String>,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         match result {
             Ok(()) => {
-                let rating_error = self.add_keep_rating_to_handoff_paths(&paths).err();
+                let rating_error = self.add_keep_rating_to_handoff_paths(&paths, context).err();
                 self.ui.status.sample = match (count, rating_error) {
                     (1, None) => String::from("Copied selected file"),
                     (count, None) => format!("Copied {count} selected files"),
@@ -438,7 +439,8 @@ impl NativeAppState {
                 radiant::runtime::ExternalDragEffect::Copy
                 | radiant::runtime::ExternalDragEffect::Link => {
                     let rating_error = if handoff_adds_keep_rating {
-                        self.add_keep_rating_to_handoff_paths(&handoff_paths).err()
+                        self.add_keep_rating_to_handoff_paths(&handoff_paths, context)
+                            .err()
                     } else {
                         None
                     };

--- a/src/native_app/sample_library/harvest_tracking/mutation.rs
+++ b/src/native_app/sample_library/harvest_tracking/mutation.rs
@@ -41,6 +41,7 @@ impl NativeAppState {
         };
         let mut applied_any = false;
         for target in &targets {
+            self.invalidate_harvest_touched_for_path(&target.path);
             if let Err(error) =
                 wavecrate::sample_sources::library::upsert_harvest_file(&target.identity)
             {
@@ -107,6 +108,7 @@ impl NativeAppState {
 
         let mut changed = false;
         for target in &targets {
+            self.invalidate_harvest_touched_for_path(&target.path);
             if let Err(error) =
                 wavecrate::sample_sources::library::upsert_harvest_file(&target.identity)
             {

--- a/src/native_app/sample_library/harvest_tracking/persistence.rs
+++ b/src/native_app/sample_library/harvest_tracking/persistence.rs
@@ -3,8 +3,16 @@ use super::{
     HarvestSourceRange, NativeAppState, NewHarvestDerivation, Path, PathBuf, SelectionRange,
     persist_harvest_seen,
 };
+use radiant::prelude as ui;
 
 impl NativeAppState {
+    pub(in crate::native_app) fn invalidate_harvest_touched_for_path(&mut self, path: &Path) {
+        let Some(request) = self.harvest_touched_persist_request_for_path(path) else {
+            return;
+        };
+        self.background.harvest_touched_persist.invalidate(&request);
+    }
+
     pub(in crate::native_app) fn schedule_harvest_seen_for_path(
         &self,
         path: &Path,
@@ -37,22 +45,69 @@ impl NativeAppState {
         }
     }
 
-    pub(in crate::native_app) fn mark_harvest_touched_for_path(&self, path: &Path) {
-        let Some(identity) = self.harvest_identity_for_path(path) else {
+    pub(in crate::native_app) fn schedule_harvest_touched_for_path(
+        &mut self,
+        path: &Path,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        let Some(request) = self.harvest_touched_persist_request_for_path(path) else {
             return;
         };
-        if let Err(error) = wavecrate::sample_sources::library::mark_harvest_touched(&identity) {
-            tracing::warn!(path = %path.display(), "failed to mark harvest file as touched: {error}");
+        match self.background.harvest_touched_persist.enqueue(request) {
+            crate::native_app::app::HarvestTouchedPersistAdmission::Saturated => {
+                tracing::warn!(path = %path.display(), "harvest touched persistence queue saturated; request deferred");
+            }
+            crate::native_app::app::HarvestTouchedPersistAdmission::Queued
+            | crate::native_app::app::HarvestTouchedPersistAdmission::Replaced => {}
         }
+        self.background
+            .harvest_touched_persist
+            .schedule_if_idle(context);
     }
 
-    pub(in crate::native_app) fn mark_harvest_touched_for_paths<I>(&self, paths: I)
-    where
+    pub(in crate::native_app) fn finish_harvest_touched_persist(
+        &mut self,
+        completion: ui::TaskCompletion<crate::native_app::app::HarvestTouchedPersistBatchResult>,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        let Some(result) = self.background.harvest_touched_persist.finish(completion) else {
+            return;
+        };
+        for persisted in result.results {
+            if let Some(persisted) = persisted.result {
+                if let Err(error) = persisted.result {
+                    tracing::warn!(
+                        file_id = %persisted.file_id,
+                        "failed to mark harvest file as touched in background: {error}"
+                    );
+                }
+            }
+        }
+        self.background
+            .harvest_touched_persist
+            .schedule_if_idle(context);
+    }
+
+    pub(in crate::native_app) fn poll_harvest_touched_persist_admission(
+        &mut self,
+        ticket: ui::TaskTicket,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        self.background
+            .harvest_touched_persist
+            .poll_admission(ticket, context);
+    }
+
+    pub(in crate::native_app) fn schedule_harvest_touched_for_paths<I>(
+        &mut self,
+        paths: I,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) where
         I: IntoIterator,
         I::Item: AsRef<Path>,
     {
         for path in paths {
-            self.mark_harvest_touched_for_path(path.as_ref());
+            self.schedule_harvest_touched_for_path(path.as_ref(), context);
         }
     }
 

--- a/src/native_app/sample_library/harvest_tracking/query.rs
+++ b/src/native_app/sample_library/harvest_tracking/query.rs
@@ -3,6 +3,7 @@ use super::{
     HarvestSeenPersistRequest, HarvestState, NativeAppState, Path, PathBuf, SampleSource, WavEntry,
     tagged_playback_mode_for_tag,
 };
+use wavecrate::sample_sources::HarvestTouchedPersistRequest;
 
 impl NativeAppState {
     pub(in crate::native_app) fn selected_harvest_family_summary(
@@ -126,6 +127,21 @@ impl NativeAppState {
             source_id: source.id,
             source_root: source.root,
             source_database_root,
+            relative_path,
+        })
+    }
+
+    pub(super) fn harvest_touched_persist_request_for_path(
+        &self,
+        path: &Path,
+    ) -> Option<HarvestTouchedPersistRequest> {
+        let (source, relative_path) = self
+            .library
+            .folder_browser
+            .sample_source_for_file_path(path)?;
+        Some(HarvestTouchedPersistRequest {
+            file_id: path.display().to_string(),
+            source: source.clone(),
             relative_path,
         })
     }

--- a/src/native_app/sample_library/sample_ratings.rs
+++ b/src/native_app/sample_library/sample_ratings.rs
@@ -55,6 +55,7 @@ impl NativeAppState {
     pub(in crate::native_app) fn add_keep_rating_to_handoff_paths(
         &mut self,
         paths: &[PathBuf],
+        context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Result<usize, String> {
         let plan = self.rating_adjustment_plan_for_paths(paths, 1);
         if plan.is_empty() {
@@ -67,12 +68,15 @@ impl NativeAppState {
             .collect::<Vec<_>>();
         let applied = self.apply_rating_update_states(&plan.updates, RatingUpdateMode::After)?;
         if applied > 0 {
-            self.mark_harvest_touched_for_paths(&touched_paths);
+            self.schedule_harvest_touched_for_paths(&touched_paths, context);
         }
         Ok(applied)
     }
 
-    pub(in crate::native_app) fn unlock_context_sample(&mut self) {
+    pub(in crate::native_app) fn unlock_context_sample(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
         let started_at = Instant::now();
         let Some(menu) = self.ui.browser_interaction.context_menu.take() else {
             return;
@@ -165,7 +169,7 @@ impl NativeAppState {
             return;
         }
         self.ui.status.sample = format!("Unlocked {}", sample_path_label(&loaded_path));
-        self.mark_harvest_touched_for_paths(std::slice::from_ref(&loaded_path));
+        self.schedule_harvest_touched_for_paths(std::slice::from_ref(&loaded_path), context);
         self.register_rating_transaction_with_label("Unlock sample", vec![update]);
         self.library
             .folder_browser
@@ -265,7 +269,7 @@ impl NativeAppState {
                 .iter()
                 .map(|update| update.absolute_path.clone())
                 .collect::<Vec<_>>();
-            self.mark_harvest_touched_for_paths(&touched_paths);
+            self.schedule_harvest_touched_for_paths(&touched_paths, context);
             self.register_rating_transaction(delta, plan.updates);
         }
 

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -448,11 +448,19 @@ impl NativeAppState {
     pub(in crate::native_app) fn shutdown(&mut self) -> Option<serde_json::Value> {
         let started_at = Instant::now();
         let source_processing = self.background.source_processing.shutdown();
+        let harvest_touched_unflushed = self.background.harvest_touched_persist.close();
+        if harvest_touched_unflushed != 0 {
+            tracing::warn!(
+                count = harvest_touched_unflushed,
+                "discarding admitted harvest-touch work during shutdown"
+            );
+        }
         crate::native_app::waveform::flush_background_waveform_cache_stores_for_shutdown();
         let elapsed = started_at.elapsed();
         Some(serde_json::json!({
             "waveform_cache_shutdown_flush_ms": duration_ms(elapsed),
             "source_processing": source_processing,
+            "harvest_touched_unflushed": harvest_touched_unflushed,
         }))
     }
 }

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -132,6 +132,8 @@ impl NativeAppState {
             | GuiMessage::LastPlayedPersistReady { .. }
             | GuiMessage::LastPlayedPersisted(_)
             | GuiMessage::HarvestSeenPersisted(_)
+            | GuiMessage::HarvestTouchedPersisted(_)
+            | GuiMessage::HarvestTouchedPersistAdmissionPoll(_)
             | GuiMessage::VolumeSettingsPersisted(_)
             | GuiMessage::StopPlayback
             | GuiMessage::ToggleLoopPlayback
@@ -353,6 +355,8 @@ fn gui_message_profile_label(message: &GuiMessage) -> &'static str {
         GuiMessage::LastPlayedPersistReady { .. } => "LastPlayedPersistReady",
         GuiMessage::LastPlayedPersisted(_) => "LastPlayedPersisted",
         GuiMessage::HarvestSeenPersisted(_) => "HarvestSeenPersisted",
+        GuiMessage::HarvestTouchedPersisted(_) => "HarvestTouchedPersisted",
+        GuiMessage::HarvestTouchedPersistAdmissionPoll(_) => "HarvestTouchedPersistAdmissionPoll",
         GuiMessage::WaveformCacheIndicatorRefreshFinished(_) => {
             "WaveformCacheIndicatorRefreshFinished"
         }

--- a/src/native_app/shell/message_dispatch/files.rs
+++ b/src/native_app/shell/message_dispatch/files.rs
@@ -72,7 +72,7 @@ impl NativeAppState {
                 count,
                 started_at,
                 result,
-            } => self.finish_copy_selected_files(paths, count, started_at, result),
+            } => self.finish_copy_selected_files(paths, count, started_at, result, context),
             GuiMessage::WaveformSelectionCopyExtracted {
                 completion,
                 playback_type,
@@ -146,7 +146,7 @@ impl NativeAppState {
                 result,
             } => self.finish_context_folder_create(parent_id, started_at, result, context),
             GuiMessage::MoveContextTargetToTrash => self.move_context_target_to_trash(context),
-            GuiMessage::UnlockContextSample => self.unlock_context_sample(),
+            GuiMessage::UnlockContextSample => self.unlock_context_sample(context),
             GuiMessage::ToggleContextFolderLock => self.toggle_context_folder_lock(),
             GuiMessage::RequestDeleteContextFolder => self.request_delete_context_folder(),
             GuiMessage::ConfirmContextFolderDelete => self.confirm_context_folder_delete(context),

--- a/src/native_app/shell/message_dispatch/navigation.rs
+++ b/src/native_app/shell/message_dispatch/navigation.rs
@@ -614,7 +614,10 @@ impl NativeAppState {
         );
         #[cfg(test)]
         if let Some(ticket) = self.background.starmap_audition_promotion_task.active() {
-            self.record_scheduled_timer_message(GuiMessage::PromoteStarmapAudition { ticket, path });
+            self.record_scheduled_timer_message(GuiMessage::PromoteStarmapAudition {
+                ticket,
+                path,
+            });
         }
     }
 

--- a/src/native_app/shell/message_dispatch/playback.rs
+++ b/src/native_app/shell/message_dispatch/playback.rs
@@ -35,6 +35,12 @@ impl NativeAppState {
             }
             GuiMessage::LastPlayedPersisted(result) => self.finish_last_played_persist(result),
             GuiMessage::HarvestSeenPersisted(result) => self.finish_harvest_seen_persist(result),
+            GuiMessage::HarvestTouchedPersisted(completion) => {
+                self.finish_harvest_touched_persist(completion, context)
+            }
+            GuiMessage::HarvestTouchedPersistAdmissionPoll(ticket) => {
+                self.poll_harvest_touched_persist_admission(ticket, context)
+            }
             GuiMessage::VolumeSettingsPersisted(result) => {
                 self.finish_volume_settings_persist(result)
             }

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -127,7 +127,11 @@ impl NativeAppState {
         {
             self.request_slide_loaded_sample_audio(frame_offset, context);
         }
-        self.mark_harvest_touched_after_waveform_mark_change(harvest_mark_before);
+        self.mark_harvest_touched_after_waveform_mark_change(
+            &message,
+            harvest_mark_before,
+            context,
+        );
         if let Some(before) = play_selection_before {
             self.waveform.pending_play_selection_transaction =
                 (matches!(
@@ -357,8 +361,10 @@ impl NativeAppState {
     }
 
     fn mark_harvest_touched_after_waveform_mark_change(
-        &self,
+        &mut self,
+        interaction: &WaveformInteraction,
         before: Option<WaveformHarvestMarkSnapshot>,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let Some(before) = before else {
             return;
@@ -366,8 +372,10 @@ impl NativeAppState {
         let Some(after) = WaveformHarvestMarkSnapshot::from_state(self) else {
             return;
         };
-        if before.path == after.path && before.marks_changed(&after) {
-            self.mark_harvest_touched_for_path(&after.path);
+        if (before.path == after.path && before.marks_changed(&after))
+            || matches!(interaction, WaveformInteraction::FinishSelection { .. })
+        {
+            self.schedule_harvest_touched_for_path(&after.path, context);
         }
     }
 }

--- a/src/native_app/tests.rs
+++ b/src/native_app/tests.rs
@@ -307,6 +307,7 @@ fn run_command_for_tests(
                 | super::test_support::state::GuiMessage::TrashMoveFinished { .. }
                 | super::test_support::state::GuiMessage::FolderBrowserRenameFinished(_)
                 | super::test_support::state::GuiMessage::WaveformDestructiveEditFinished(_)
+                | super::test_support::state::GuiMessage::WaveformSelectionCopyExtracted { .. }
                 | super::test_support::state::GuiMessage::PlaySelectionExtractionFinished { .. }
                 | super::test_support::state::GuiMessage::SelectedWholeFilesHarvestExtractionFinished {
                     ..

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -207,7 +207,14 @@ fn successful_selected_file_copy_adds_keep_rating() {
         .folder_browser
         .select_file(kick.display().to_string());
 
-    state.finish_copy_selected_files(vec![kick.clone()], 1, std::time::Instant::now(), Ok(()));
+    let mut context = ui::UiUpdateContext::default();
+    state.finish_copy_selected_files(
+        vec![kick.clone()],
+        1,
+        std::time::Instant::now(),
+        Ok(()),
+        &mut context,
+    );
 
     assert_sample_rating(&state, &kick, Rating::KEEP_1, false);
 }
@@ -242,7 +249,14 @@ fn successful_selected_file_copy_increments_existing_keep_rating() {
             .set_file_rating_state(&kick, Rating::KEEP_1, false)
     );
 
-    state.finish_copy_selected_files(vec![kick.clone()], 1, std::time::Instant::now(), Ok(()));
+    let mut context = ui::UiUpdateContext::default();
+    state.finish_copy_selected_files(
+        vec![kick.clone()],
+        1,
+        std::time::Instant::now(),
+        Ok(()),
+        &mut context,
+    );
 
     assert_sample_rating(&state, &kick, Rating::new(2), false);
 }

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -794,7 +794,20 @@ fn playmark_selection_copy_extracts_into_current_folder_before_clipboard_handoff
 
     let mut context = ui::UiUpdateContext::default();
     scenario.state.copy_selected_files(&mut context);
-    run_command_for_tests(&mut scenario.state, context.into_command());
+    let extraction_message = run_worker_message_for_tests(
+        context.into_command(),
+        "gui-copy-waveform-selection",
+    )
+    .expect("playmark copy extraction should complete");
+    let mut extraction_context = ui::UiUpdateContext::default();
+    scenario
+        .state
+        .apply_message(extraction_message, &mut extraction_context);
+    assert_eq!(
+        platform_copy_file_paths(extraction_context.into_command()),
+        Some(vec![extracted.clone()]),
+        "clipboard handoff should be queued before extracted-file metadata bookkeeping"
+    );
 
     assert!(extracted.is_file());
     assert!(
@@ -823,8 +836,8 @@ fn playmark_selection_copy_extracts_into_current_folder_before_clipboard_handoff
         Some(ui::TaskPriority::Background),
         "extracted rating persistence should not block clipboard completion"
     );
-    assert_extracted_file_metadata(&scenario.state, &extracted, &["one-shot"]);
     run_command_for_tests(&mut scenario.state, metadata_command);
+    assert_extracted_file_tags(&scenario.state, &extracted, &["one-shot"]);
     assert_persisted_extracted_file_keep_1_rating(&scenario.state, &extracted);
     assert_source_file_not_keep_rated(&scenario.state, &source_path);
     let parent = wavecrate::sample_sources::library::harvest_file(&harvest_key)
@@ -2236,6 +2249,14 @@ fn assert_extracted_file_metadata(
     assert_extracted_file_keep_1_rating(state, extracted);
 }
 
+fn assert_extracted_file_tags(
+    state: &crate::native_app::test_support::state::NativeAppState,
+    extracted: &std::path::Path,
+    tags: &[&str],
+) {
+    assert_extracted_metadata_tags(state, extracted, tags);
+}
+
 fn assert_extracted_metadata_tags(
     state: &crate::native_app::test_support::state::NativeAppState,
     extracted: &std::path::Path,
@@ -2633,6 +2654,8 @@ fn playmark_selection_change_marks_harvest_file_touched() {
 
     scenario.select_play_range(0.20, 0.50);
 
+    scenario.flush_background_work();
+
     assert_harvest_file_touched_without_derivatives(&harvest_key);
 }
 
@@ -2663,6 +2686,7 @@ fn editmark_selection_change_marks_harvest_file_touched() {
             &mut context,
         );
     }
+    run_command_for_tests(&mut scenario.state, context.into_command());
 
     assert_harvest_file_touched_without_derivatives(&harvest_key);
 }

--- a/src/native_app/tests/waveform_playback/fixture.rs
+++ b/src/native_app/tests/waveform_playback/fixture.rs
@@ -76,6 +76,11 @@ impl WaveformPlaybackScenario {
         self.finish_play_range_drag(end);
     }
 
+    pub(super) fn flush_background_work(&mut self) {
+        let context = std::mem::take(&mut self.context);
+        run_command_for_tests(&mut self.state, context.into_command());
+    }
+
     pub(super) fn begin_play_range(&mut self, start: f32) {
         self.apply_waveform(WaveformInteraction::BeginSelection {
             kind: WaveformSelectionKind::Play,

--- a/src/native_app/waveform_edits/completion.rs
+++ b/src/native_app/waveform_edits/completion.rs
@@ -58,7 +58,7 @@ impl NativeAppState {
                 operation.clone(),
             );
         } else {
-            self.mark_harvest_touched_for_path(&active.request.absolute_path);
+            self.schedule_harvest_touched_for_path(&active.request.absolute_path, context);
         }
         let extracted_metadata_error = if let Some(extracted_path) = applied
             .extracted

--- a/src/sample_sources/harvest_touched.rs
+++ b/src/sample_sources/harvest_touched.rs
@@ -1,0 +1,116 @@
+use std::path::PathBuf;
+
+use crate::sample_sources::{
+    HarvestFileIdentity, HarvestFileKey, SampleSource, SourceDatabase, harvest_file_ops, library,
+};
+
+/// Result of persisting a harvest file's touched identity in the library database.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HarvestTouchedPersistResult {
+    /// Absolute file id/path that the native browser scheduled for persistence.
+    pub file_id: String,
+    /// Persistence outcome with a user-loggable error string on failure.
+    pub result: Result<(), String>,
+}
+
+/// Background request for marking a harvest file as touched.
+#[derive(Clone, Debug)]
+pub struct HarvestTouchedPersistRequest {
+    /// Absolute file id/path used to correlate the background result.
+    pub file_id: String,
+    /// Owned source descriptor. Database-root resolution is deferred to the worker.
+    pub source: SampleSource,
+    /// Path to the sample relative to the owning source root.
+    pub relative_path: PathBuf,
+}
+
+/// Persist a harvest-touched marker using file metadata and the owning source database.
+pub fn persist_harvest_touched(
+    request: HarvestTouchedPersistRequest,
+) -> HarvestTouchedPersistResult {
+    let result = match persist_harvest_touched_inner(&request, || true) {
+        Ok(Some(())) => Ok(()),
+        Ok(None) => Ok(()),
+        Err(error) => Err(error),
+    };
+    HarvestTouchedPersistResult {
+        file_id: request.file_id,
+        result,
+    }
+}
+
+/// Persist a touched marker only while the owning revision remains current.
+///
+/// The currentness callback is checked before filesystem/source-database work and again while the
+/// global harvest library lock is held immediately before the state mutation. A superseded request
+/// returns `None` without touching the filesystem or database.
+pub fn persist_harvest_touched_if_current(
+    request: HarvestTouchedPersistRequest,
+    current: impl Fn() -> bool,
+) -> Option<HarvestTouchedPersistResult> {
+    let file_id = request.file_id.clone();
+    match persist_harvest_touched_inner(&request, current) {
+        Ok(Some(())) => Some(HarvestTouchedPersistResult {
+            file_id,
+            result: Ok(()),
+        }),
+        Ok(None) => None,
+        Err(error) => Some(HarvestTouchedPersistResult {
+            file_id,
+            result: Err(error),
+        }),
+    }
+}
+
+fn persist_harvest_touched_inner(
+    request: &HarvestTouchedPersistRequest,
+    current: impl Fn() -> bool,
+) -> Result<Option<()>, String> {
+    if !current() {
+        return Ok(None);
+    }
+    let path = request.source.root.join(&request.relative_path);
+    let (file_size, modified_ns) = harvest_file_ops::file_identity_metadata(&path);
+    let entry = SourceDatabase::open_for_ui_read_with_database_root(
+        &request.source.root,
+        &request
+            .source
+            .database_root()
+            .map_err(|err| err.to_string())?,
+    )
+    .ok()
+    .and_then(|db| db.entry_for_path(&request.relative_path).ok().flatten());
+    let identity = HarvestFileIdentity {
+        key: HarvestFileKey::new(request.source.id.clone(), request.relative_path.clone()),
+        file_size: file_size.or_else(|| entry.as_ref().map(|entry| entry.file_size)),
+        modified_ns: modified_ns.or_else(|| entry.as_ref().map(|entry| entry.modified_ns)),
+        content_hash: entry.and_then(|entry| entry.content_hash),
+    };
+    library::mark_harvest_touched_if_current(&identity, current)
+        .map(|record| record.map(|_| ()))
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn stale_revision_skips_filesystem_and_library_work() {
+        let checks = AtomicUsize::new(0);
+        let request = HarvestTouchedPersistRequest {
+            file_id: "/tmp/stale-touch.wav".to_owned(),
+            source: SampleSource::new(PathBuf::from("/tmp/stale-touch-source")),
+            relative_path: PathBuf::from("stale-touch.wav"),
+        };
+        assert!(
+            persist_harvest_touched_if_current(request, || {
+                checks.fetch_add(1, Ordering::Relaxed);
+                false
+            })
+            .is_none()
+        );
+        assert_eq!(checks.load(Ordering::Relaxed), 1);
+    }
+}

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -13,6 +13,7 @@ mod file_move_metadata;
 #[doc(hidden)]
 pub mod harvest_file_ops;
 mod harvest_seen;
+mod harvest_touched;
 mod starmap_layout;
 /// Scan tracking state to avoid duplicate work.
 pub mod scan_state {
@@ -65,9 +66,10 @@ pub mod library {
         harvest_derivations_for_parent, harvest_derivative_count,
         harvest_derivative_counts_for_source, harvest_file, harvest_files_for_source,
         harvest_parents_for_child, load, lookup_retained_source_for_root,
-        lookup_source_id_for_root, mark_harvest_seen, mark_harvest_touched, open_connection,
-        record_harvest_derivation, remap_harvest_file_key, remap_harvest_file_prefix,
-        retained_sources, save, set_harvest_state, upsert_harvest_file, upsert_harvest_files,
+        lookup_source_id_for_root, mark_harvest_seen, mark_harvest_touched,
+        mark_harvest_touched_if_current, open_connection, record_harvest_derivation,
+        remap_harvest_file_key, remap_harvest_file_prefix, retained_sources, save,
+        set_harvest_state, upsert_harvest_file, upsert_harvest_files,
     };
 }
 
@@ -83,6 +85,10 @@ pub use file_move_metadata::{
     SourcedFileMoveMetadata, persist_copied_file_metadata, persist_sourced_moved_file_metadata,
 };
 pub use harvest_seen::{HarvestSeenPersistRequest, HarvestSeenPersistResult, persist_harvest_seen};
+pub use harvest_touched::{
+    HarvestTouchedPersistRequest, HarvestTouchedPersistResult, persist_harvest_touched,
+    persist_harvest_touched_if_current,
+};
 pub use starmap_layout::{
     STARMAP_LAYOUT_UMAP_VERSION, StarmapLayoutLoadRequest, StarmapLayoutLoadResult,
     StarmapLayoutPoint, StarmapLayoutSample, StarmapSourceLayoutRequest, load_starmap_layout,

--- a/tests/radiant_dependency_contract.rs
+++ b/tests/radiant_dependency_contract.rs
@@ -13,7 +13,7 @@ fn canonical_radiant_dependency_uses_the_standalone_sibling_contract() {
 
     assert!(manifest.contains("radiant = { path = \"../radiant\" }"));
     assert!(metadata.contains("repository = \"https://github.com/PORTALSURFER/radiant.git\""));
-    assert!(metadata.contains("revision = \"095ddf597fbac5a1055550c64b30d27ce62f7c38\""));
+    assert!(metadata.contains("revision = \"16ef95c6a3f2828aa824da16a818d970d5e3b9f5\""));
     assert!(metadata.contains("path = \"../radiant\""));
     assert!(!root.join(".gitmodules").exists());
     assert!(!root.join("vendor/radiant").exists());

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -487,7 +487,7 @@ edition = "2024"
             ),
         );
         self.write("Cargo.lock", "# fixture lockfile\n");
-        self.write("radiant-dependency.toml", "repository = \"https://github.com/PORTALSURFER/radiant.git\"\nrevision = \"095ddf597fbac5a1055550c64b30d27ce62f7c38\"\npath = \"../radiant\"\n");
+        self.write("radiant-dependency.toml", "repository = \"https://github.com/PORTALSURFER/radiant.git\"\nrevision = \"16ef95c6a3f2828aa824da16a818d970d5e3b9f5\"\npath = \"../radiant\"\n");
         self.write("src/lib.rs", "");
         self.write(".github/workflows/release-train-prepare.yml", "");
         self.write(".github/workflows/release-rc.yml", "");


### PR DESCRIPTION
## Goal
Keep Playmark and Editmark commits responsive while harvest persistence is contended.

## Scope
- Move harvest touch filesystem/source-DB/library-DB work to a bounded `BlockingIo` worker.
- Use the merged Radiant pollable admission receipt to retain unclaimed work after host rejection.
- Fence stale revisions and manual resets; bound retry to one recovery attempt per batch.
- Repin Wavecrate to merged Radiant `16ef95c6`.

## Non-goals
No scanner/readiness lifecycle redesign or audio-runtime change.

## Definition of Done
Selection, playback, and undo commit on release without waiting for harvest I/O; retry cannot spin under repeated rejection; stale work cannot overwrite a manual harvest state.

## Validation
Paired clean worktrees with Radiant `16ef95c6`:
- `cargo check --tests --locked`
- `cargo test --lib harvest_touched_owner_tests -- --nocapture` (10 passed)
- `cargo test --test radiant_dependency_contract`
- `cargo test --test release_orchestration` (17 passed)
- `git diff --check`

## Known limitations
A retry-blocked batch remains retained until a new/coalesced enqueue re-arms one recovery attempt.

User approval is required before merge.