### PR TITLE
Stop marking copied files as kept

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -250,7 +250,6 @@ pub(in crate::native_app) enum GuiMessage {
         result: Result<wavecrate::sample_sources::ContextSampleDoubleResult, String>,
     },
     SelectedFilesCopyFinished {
-        paths: Vec<PathBuf>,
         count: usize,
         started_at: Instant,
         result: Result<(), String>,

--- a/src/native_app/sample_library/drag_drop_actions/external.rs
+++ b/src/native_app/sample_library/drag_drop_actions/external.rs
@@ -53,9 +53,7 @@ impl NativeAppState {
             1 => String::from("Copying selected file"),
             count => format!("Copying {count} selected files"),
         };
-        let copied_paths = paths.clone();
         context.copy_file_paths(paths, move |result| GuiMessage::SelectedFilesCopyFinished {
-            paths: copied_paths,
             count,
             started_at,
             result: result.into_completed(),
@@ -64,24 +62,15 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn finish_copy_selected_files(
         &mut self,
-        paths: Vec<PathBuf>,
         count: usize,
         started_at: Instant,
         result: Result<(), String>,
-        context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         match result {
             Ok(()) => {
-                let rating_error = self.add_keep_rating_to_handoff_paths(&paths, context).err();
-                self.ui.status.sample = match (count, rating_error) {
-                    (1, None) => String::from("Copied selected file"),
-                    (count, None) => format!("Copied {count} selected files"),
-                    (1, Some(error)) => {
-                        format!("Copied selected file; rating update failed: {error}")
-                    }
-                    (count, Some(error)) => {
-                        format!("Copied {count} selected files; rating update failed: {error}")
-                    }
+                self.ui.status.sample = match count {
+                    1 => String::from("Copied selected file"),
+                    count => format!("Copied {count} selected files"),
                 };
                 emit_gui_action(
                     "browser.copy_selected_files",

--- a/src/native_app/shell/message_dispatch/files.rs
+++ b/src/native_app/shell/message_dispatch/files.rs
@@ -68,11 +68,10 @@ impl NativeAppState {
                 result,
             } => self.finish_context_sample_double(source_path, started_at, result, context),
             GuiMessage::SelectedFilesCopyFinished {
-                paths,
                 count,
                 started_at,
                 result,
-            } => self.finish_copy_selected_files(paths, count, started_at, result, context),
+            } => self.finish_copy_selected_files(count, started_at, result),
             GuiMessage::WaveformSelectionCopyExtracted {
                 completion,
                 playback_type,

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -78,6 +78,24 @@ fn assert_sample_rating(
     assert_eq!(persisted.locked, locked);
 }
 
+fn assert_loaded_sample_rating(
+    state: &crate::native_app::test_support::state::NativeAppState,
+    path: &Path,
+    rating: Rating,
+    locked: bool,
+) {
+    let file_id = path.display().to_string();
+    let row = state
+        .library
+        .folder_browser
+        .loaded_source_audio_files()
+        .into_iter()
+        .find(|file| file.id == file_id)
+        .expect("rated file should be loaded");
+    assert_eq!(row.rating, rating);
+    assert_eq!(row.rating_locked, locked);
+}
+
 fn assert_sample_not_keep_rated(
     state: &crate::native_app::test_support::state::NativeAppState,
     path: &Path,
@@ -184,7 +202,7 @@ fn file_move_conflict_dialog_renders_resolution_choices() {
 }
 
 #[test]
-fn successful_selected_file_copy_adds_keep_rating() {
+fn successful_selected_file_copy_leaves_neutral_rating_unchanged() {
     let mut state = gui_state_for_span_tests();
     let source_root = tempfile::tempdir().expect("source root");
     let drums = source_root.path().join("drums");
@@ -207,20 +225,13 @@ fn successful_selected_file_copy_adds_keep_rating() {
         .folder_browser
         .select_file(kick.display().to_string());
 
-    let mut context = ui::UiUpdateContext::default();
-    state.finish_copy_selected_files(
-        vec![kick.clone()],
-        1,
-        std::time::Instant::now(),
-        Ok(()),
-        &mut context,
-    );
+    state.finish_copy_selected_files(1, std::time::Instant::now(), Ok(()));
 
-    assert_sample_rating(&state, &kick, Rating::KEEP_1, false);
+    assert_sample_not_keep_rated(&state, &kick);
 }
 
 #[test]
-fn successful_selected_file_copy_increments_existing_keep_rating() {
+fn successful_selected_file_copy_leaves_existing_keep_rating_unchanged() {
     let mut state = gui_state_for_span_tests();
     let source_root = tempfile::tempdir().expect("source root");
     let drums = source_root.path().join("drums");
@@ -249,16 +260,9 @@ fn successful_selected_file_copy_increments_existing_keep_rating() {
             .set_file_rating_state(&kick, Rating::KEEP_1, false)
     );
 
-    let mut context = ui::UiUpdateContext::default();
-    state.finish_copy_selected_files(
-        vec![kick.clone()],
-        1,
-        std::time::Instant::now(),
-        Ok(()),
-        &mut context,
-    );
+    state.finish_copy_selected_files(1, std::time::Instant::now(), Ok(()));
 
-    assert_sample_rating(&state, &kick, Rating::new(2), false);
+    assert_loaded_sample_rating(&state, &kick, Rating::KEEP_1, false);
 }
 
 #[test]


### PR DESCRIPTION
Goal:
Stop selected-file clipboard copies from automatically creating or incrementing a Keep rating.

Scope and non-goals:
Removes only the selected-file copy completion rating side effect and its unused payload plumbing. External drag-out and waveform-selection behaviors are unchanged.

Definition of Done:
- Neutral ratings remain neutral after selected-file copy.
- Existing Keep ratings remain unchanged after selected-file copy.
- Copy status and telemetry remain intact.

Validation:
- cargo test --locked successful_selected_file_copy (2 passed)
- cargo test --locked accepted_external_file_drag_adds_keep_rating (1 passed)
- git diff --check
- Independent Terra review: APPROVE

Known limitations:
The full formatting check has unrelated existing diffs in waveform_playback.rs and release_contract.rs. An unchanged waveform external-drag test has a pre-existing row-load setup failure, outside this diff.

User approval was received for merge.