### PR TITLE
Remove rating filter swatch borders

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
@@ -40,10 +40,16 @@ const RATING_FILTER_TRASH_COLOR: ui::Rgba8 = ui::Rgba8 {
     b: 67,
     a: 235,
 };
-const RATING_FILTER_UNRATED_COLOR: ui::Rgba8 = ui::Rgba8 {
-    r: 154,
-    g: 158,
-    b: 164,
+const RATING_FILTER_UNRATED_ACTIVE_COLOR: ui::Rgba8 = ui::Rgba8 {
+    r: 184,
+    g: 188,
+    b: 194,
+    a: 235,
+};
+const RATING_FILTER_UNRATED_INACTIVE_COLOR: ui::Rgba8 = ui::Rgba8 {
+    r: 138,
+    g: 142,
+    b: 148,
     a: 220,
 };
 const RATING_FILTER_KEEP_COLOR: ui::Rgba8 = ui::Rgba8 {
@@ -51,6 +57,13 @@ const RATING_FILTER_KEEP_COLOR: ui::Rgba8 = ui::Rgba8 {
     g: 226,
     b: 96,
     a: 235,
+};
+/// Golden marker used for the top (locked) keep rating in the sample browser.
+const RATING_FILTER_TOP_KEEP_COLOR: ui::Rgba8 = ui::Rgba8 {
+    r: 232,
+    g: 188,
+    b: 56,
+    a: 245,
 };
 pub(super) const NAME_FILTER_INPUT_ID: u64 = widget_ids::NAME_FILTER_INPUT_ID;
 pub(super) const TAG_FILTER_INPUT_ID: u64 = widget_ids::TAG_FILTER_INPUT_ID;
@@ -425,42 +438,39 @@ fn rating_filter_toggle(
     help_tooltips_enabled: bool,
 ) -> ui::View<GuiMessage> {
     let level = toggle.level;
-    ui::selectable("", toggle.active)
-        .style(ui::WidgetStyle::subtle(rating_filter_tone(level)))
-        .color_marker(Some(rating_filter_swatch_color(level, toggle.active)))
-        .color_marker_side(RATING_FILTER_SWATCH_SIZE)
-        .color_marker_inset(0)
-        .color_marker_align(ui::ColorMarkerAlign::Center)
-        .message(move |enabled| {
-            GuiMessage::FolderBrowser(FolderBrowserMessage::ToggleRatingFilter(level, enabled))
-        })
+    let visible = ui::color_marker(Some(rating_filter_swatch_color(level, toggle.active)))
+        .side(RATING_FILTER_SWATCH_SIZE)
+        .inset(0)
+        .align(ui::ColorMarkerAlign::Center)
+        .view()
+        .size(RATING_FILTER_TOGGLE_WIDTH, FILTER_ROW_CONTROL_HEIGHT);
+    let input = ui::button("")
+        .active(toggle.active)
+        .message(GuiMessage::FolderBrowser(
+            FolderBrowserMessage::ToggleRatingFilter(level, !toggle.active),
+        ))
         .id(automation_rating_filter_toggle_id(toggle.label))
         .size(RATING_FILTER_TOGGLE_WIDTH, FILTER_ROW_CONTROL_HEIGHT)
-        .tooltip_if(help_tooltips_enabled, rating_filter_tooltip(level))
-}
-
-fn rating_filter_tone(level: i8) -> ui::WidgetTone {
-    if level < 0 {
-        ui::WidgetTone::Danger
-    } else if level > 0 {
-        ui::WidgetTone::Accent
-    } else {
-        ui::WidgetTone::Neutral
-    }
+        .tooltip_if(help_tooltips_enabled, rating_filter_tooltip(level));
+    ui::input_underlay(visible, input.input_only())
 }
 
 pub(super) fn rating_filter_swatch_color(level: i8, active: bool) -> ui::Rgba8 {
-    let color = if level < 0 {
+    let color = if level == 4 {
+        RATING_FILTER_TOP_KEEP_COLOR
+    } else if level < 0 {
         RATING_FILTER_TRASH_COLOR
     } else if level > 0 {
         RATING_FILTER_KEEP_COLOR
+    } else if active {
+        RATING_FILTER_UNRATED_ACTIVE_COLOR
     } else {
-        RATING_FILTER_UNRATED_COLOR
+        RATING_FILTER_UNRATED_INACTIVE_COLOR
     };
     if active {
         color
     } else {
-        color.with_alpha(color.a.saturating_sub(68))
+        color.with_alpha(color.a.saturating_sub(128))
     }
 }
 

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
@@ -19,7 +19,7 @@ use crate::native_app::ui::ids::RETIRED_HARVEST_FILTER_ARROW_TOGGLE_ID;
 use radiant::gui::types::Rgba8;
 use radiant::prelude::IntoView;
 use radiant::runtime::{SurfaceFrame, SurfacePaintPlan};
-use radiant::widgets::{ButtonMessage, SelectableMessage, TextInputMessage};
+use radiant::widgets::{ButtonMessage, TextInputMessage};
 
 const FILTER_SECTION_TEST_FRAME_HEIGHT: f32 = 220.0;
 

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -710,23 +710,25 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
         240.0,
         FILTER_SECTION_TEST_FRAME_HEIGHT,
     ));
+    let layout = filter_section(&model)
+        .view_layout_at_size(ui::Vector2::new(240.0, FILTER_SECTION_TEST_FRAME_HEIGHT));
 
     assert!(
-        frame
-            .paint_plan
-            .first_widget_rect(automation_rating_filter_toggle_id("T3"))
+        layout
+            .rects
+            .get(&automation_rating_filter_toggle_id("T3"))
             .is_some()
     );
     assert!(
-        frame
-            .paint_plan
-            .first_widget_rect(automation_rating_filter_toggle_id("U"))
+        layout
+            .rects
+            .get(&automation_rating_filter_toggle_id("U"))
             .is_some()
     );
     assert!(
-        frame
-            .paint_plan
-            .first_widget_rect(automation_rating_filter_toggle_id("K4"))
+        layout
+            .rects
+            .get(&automation_rating_filter_toggle_id("K4"))
             .is_some()
     );
     assert!(frame.paint_plan.fill_rects().any(|fill| {
@@ -739,6 +741,25 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
             .fill_rects()
             .any(|fill| fill.color == rating_filter_swatch_color(1, false))
     );
+    for label in ["T3", "U", "K4"] {
+        let widget_id = automation_rating_filter_toggle_id(label);
+        assert!(
+            frame
+                .paint_plan
+                .fill_rects_for_widget(widget_id)
+                .next()
+                .is_none(),
+            "rating swatch input {label} must not paint a button surface"
+        );
+        assert!(
+            frame
+                .paint_plan
+                .stroke_rects_for_widget(widget_id)
+                .next()
+                .is_none(),
+            "rating swatch input {label} must not paint a border"
+        );
+    }
     assert!(
         !frame
             .paint_plan
@@ -748,7 +769,7 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_rating_filter_toggle_id("K4"),
-            ui::WidgetOutput::typed(SelectableMessage::SelectionChanged { selected: true }),
+            ui::WidgetOutput::typed(ButtonMessage::Activate),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ToggleRatingFilter(4, true)
@@ -757,7 +778,7 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_rating_filter_toggle_id("U"),
-            ui::WidgetOutput::typed(SelectableMessage::SelectionChanged { selected: false }),
+            ui::WidgetOutput::typed(ButtonMessage::Activate),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ToggleRatingFilter(0, false)
@@ -766,10 +787,69 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_rating_filter_toggle_id("T3"),
-            ui::WidgetOutput::typed(SelectableMessage::SelectionChanged { selected: false }),
+            ui::WidgetOutput::typed(ButtonMessage::Activate),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ToggleRatingFilter(-3, false)
         ))
     );
+}
+
+#[test]
+fn inactive_rating_filter_swatches_are_toned_down_without_changing_active_colors() {
+    for (level, expected_active) in [
+        (
+            -3,
+            Rgba8 {
+                r: 238,
+                g: 77,
+                b: 67,
+                a: 235,
+            },
+        ),
+        (
+            0,
+            Rgba8 {
+                r: 184,
+                g: 188,
+                b: 194,
+                a: 235,
+            },
+        ),
+        (
+            4,
+            Rgba8 {
+                r: 232,
+                g: 188,
+                b: 56,
+                a: 245,
+            },
+        ),
+    ] {
+        let active = rating_filter_swatch_color(level, true);
+        let inactive = rating_filter_swatch_color(level, false);
+
+        assert_eq!(active, expected_active);
+        if level == 0 {
+            assert_eq!(
+                inactive,
+                Rgba8 {
+                    r: 138,
+                    g: 142,
+                    b: 148,
+                    a: 92,
+                }
+            );
+            assert!(inactive.r < active.r && inactive.g < active.g && inactive.b < active.b);
+        } else {
+            assert_eq!(
+                (inactive.r, inactive.g, inactive.b),
+                (active.r, active.g, active.b)
+            );
+        }
+        assert!(
+            inactive.a <= active.a.saturating_sub(120),
+            "inactive rating swatch for {level} should be materially dimmer"
+        );
+    }
 }


### PR DESCRIPTION
Goal
Make rating filter cues clearer with borderless cubes and strong active/inactive contrast.

Scope and non-goals
- Rating swatches use a passive color marker with a transparent input target.
- Active unrated swatch is brighter; inactive swatches are muted; Keep 4 uses the browser-column gold.
- Does not change filter semantics, sample-row fills, selection behavior, or other filter controls.

Definition of Done
- Swatches paint no selectable border/surface and remain clickable.
- Active/inactive state contrast is clear.
- Keep 4 is visually distinct in gold.

Validation
- cargo test -p wavecrate native_app::app_chrome::library_browser::library_sidebar::filter_section --lib (29 passed)
- cargo test -p wavecrate native_app::app_chrome::library_browser::sample_browser_view --lib (132 passed)
- git diff --check
- cargo fmt --all --check reports only known unrelated baseline files.

Known limitations
- Manual visual confirmation remains useful.

User approval is required before merge.