### PR TITLE
Flush pending ratings during shutdown

### DIFF
--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -72,11 +72,19 @@ pub(in crate::native_app) struct BackgroundTaskState {
 #[cfg(test)]
 mod rating_persist_owner_tests {
     use super::*;
+    use wavecrate::sample_sources::SourceDatabase;
+
+    fn owner() -> RatingPersistOwner {
+        RatingPersistOwner::new_with_lifecycle_generations(BTreeMap::from([(
+            String::from("one"),
+            7,
+        )]))
+    }
 
     fn request(source: &str, path: &str, rating: i8) -> RatingPersistRequest {
         RatingPersistRequest {
             source_id: source.to_owned(),
-            lifecycle_generation: None,
+            lifecycle_generation: Some(7),
             root: PathBuf::from(format!("/tmp/{source}")),
             database_root: PathBuf::from(format!("/tmp/{source}/.db")),
             relative_path: PathBuf::from(path),
@@ -88,7 +96,7 @@ mod rating_persist_owner_tests {
 
     #[test]
     fn rapid_same_path_enqueue_keeps_latest_revision() {
-        let mut owner = RatingPersistOwner::new();
+        let mut owner = owner();
         owner.enqueue(request("one", "kick.wav", 1));
         owner.enqueue(request("one", "kick.wav", 2));
         let work = owner.queue.lock().expect("queue lock").claim_all();
@@ -99,7 +107,7 @@ mod rating_persist_owner_tests {
 
     #[test]
     fn replacement_makes_inflight_completion_stale() {
-        let mut owner = RatingPersistOwner::new();
+        let mut owner = owner();
         owner.enqueue(request("one", "kick.wav", 1));
         let first = owner.queue.lock().expect("queue lock").claim_all();
         owner.enqueue(request("one", "kick.wav", 2));
@@ -114,7 +122,7 @@ mod rating_persist_owner_tests {
 
     #[test]
     fn failed_completion_does_not_erase_newer_projection() {
-        let mut owner = RatingPersistOwner::new();
+        let mut owner = owner();
         owner.enqueue(request("one", "kick.wav", 1));
         let first = owner.queue.lock().expect("queue lock").claim_all();
         owner.enqueue(request("one", "kick.wav", 2));
@@ -143,7 +151,7 @@ mod rating_persist_owner_tests {
 
     #[test]
     fn same_source_rekey_after_claim_fences_old_completion() {
-        let mut owner = RatingPersistOwner::new();
+        let mut owner = owner();
         owner.enqueue(request("one", "old/kick.wav", 1));
         let work = owner.queue.lock().expect("queue lock").claim_all();
         let old_revision = work[0].revision;
@@ -182,7 +190,7 @@ mod rating_persist_owner_tests {
 
     #[test]
     fn cross_source_rekey_after_claim_fences_old_completion() {
-        let mut owner = RatingPersistOwner::new();
+        let mut owner = owner();
         owner
             .queue
             .lock()
@@ -228,6 +236,155 @@ mod rating_persist_owner_tests {
         assert_eq!(
             queue.deferred_auto_trash[&new_key].1,
             PathBuf::from("/tmp/two/moved/kick.wav")
+        );
+    }
+
+    #[test]
+    fn close_flushes_latest_inflight_supersession_including_lock() {
+        let source_root = tempfile::tempdir().expect("source root");
+        let database_root = tempfile::tempdir().expect("database root");
+        let relative_path = PathBuf::from("kick.wav");
+        let absolute_path = source_root.path().join(&relative_path);
+        std::fs::write(&absolute_path, b"fixture").expect("sample fixture");
+        let source_id = String::from("one");
+        let mut owner = owner();
+
+        owner.enqueue(RatingPersistRequest {
+            source_id: source_id.clone(),
+            lifecycle_generation: Some(7),
+            root: source_root.path().to_path_buf(),
+            database_root: database_root.path().to_path_buf(),
+            relative_path: relative_path.clone(),
+            absolute_path: absolute_path.clone(),
+            rating: wavecrate::sample_sources::Rating::new(1),
+            locked: false,
+        });
+        let _inflight = owner.queue.lock().expect("queue lock").claim_all();
+        owner.enqueue(RatingPersistRequest {
+            source_id,
+            lifecycle_generation: Some(7),
+            root: source_root.path().to_path_buf(),
+            database_root: database_root.path().to_path_buf(),
+            relative_path: relative_path.clone(),
+            absolute_path,
+            rating: wavecrate::sample_sources::Rating::KEEP_3,
+            locked: true,
+        });
+
+        assert_eq!(owner.close(), 0);
+        let database = SourceDatabase::open_for_user_metadata_write_with_database_root(
+            source_root.path(),
+            database_root.path(),
+        )
+        .expect("reopen source database");
+        assert_eq!(
+            database.tag_for_path(&relative_path).expect("read rating"),
+            Some(wavecrate::sample_sources::Rating::KEEP_3)
+        );
+        assert_eq!(
+            database.locked_for_path(&relative_path).expect("read lock"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn close_reports_failed_requests_and_clears_closed_queue() {
+        let source_root = tempfile::tempdir().expect("source root");
+        let database_root = tempfile::tempdir().expect("database root");
+        let mut owner = owner();
+        owner.enqueue(RatingPersistRequest {
+            source_id: String::from("one"),
+            lifecycle_generation: Some(7),
+            root: source_root.path().to_path_buf(),
+            database_root: database_root.path().to_path_buf(),
+            relative_path: PathBuf::from("missing.wav"),
+            absolute_path: source_root.path().join("missing.wav"),
+            rating: wavecrate::sample_sources::Rating::KEEP_3,
+            locked: true,
+        });
+
+        assert_eq!(owner.close(), 1);
+        let queue = owner.queue.lock().expect("queue lock");
+        assert!(queue.closed);
+        assert!(queue.entries.is_empty());
+        assert!(queue.desired.is_empty());
+    }
+
+    #[test]
+    fn worker_persists_current_generation_rating_and_lock() {
+        let source_root = tempfile::tempdir().expect("source root");
+        let database_root = tempfile::tempdir().expect("database root");
+        let relative_path = PathBuf::from("kick.wav");
+        let absolute_path = source_root.path().join(&relative_path);
+        std::fs::write(&absolute_path, b"fixture").expect("sample fixture");
+        let mut owner = owner();
+        owner.enqueue(RatingPersistRequest {
+            source_id: String::from("one"),
+            lifecycle_generation: Some(7),
+            root: source_root.path().to_path_buf(),
+            database_root: database_root.path().to_path_buf(),
+            relative_path: relative_path.clone(),
+            absolute_path: absolute_path.clone(),
+            rating: wavecrate::sample_sources::Rating::KEEP_3,
+            locked: true,
+        });
+
+        let result =
+            persist_rating_queue(Arc::clone(&owner.queue), Arc::clone(&owner.persist_gate));
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].result, Some(Ok(())));
+
+        let database = SourceDatabase::open_for_user_metadata_write_with_database_root(
+            source_root.path(),
+            database_root.path(),
+        )
+        .expect("reopen source database");
+        assert_eq!(
+            database.tag_for_path(&relative_path).expect("read rating"),
+            Some(wavecrate::sample_sources::Rating::KEEP_3)
+        );
+        assert_eq!(
+            database.locked_for_path(&relative_path).expect("read lock"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn worker_rejects_generation_mismatch_without_persisting() {
+        let source_root = tempfile::tempdir().expect("source root");
+        let database_root = tempfile::tempdir().expect("database root");
+        let relative_path = PathBuf::from("kick.wav");
+        let absolute_path = source_root.path().join(&relative_path);
+        std::fs::write(&absolute_path, b"fixture").expect("sample fixture");
+        let mut owner = owner();
+        owner.enqueue(RatingPersistRequest {
+            source_id: String::from("one"),
+            lifecycle_generation: Some(8),
+            root: source_root.path().to_path_buf(),
+            database_root: database_root.path().to_path_buf(),
+            relative_path: relative_path.clone(),
+            absolute_path,
+            rating: wavecrate::sample_sources::Rating::KEEP_3,
+            locked: true,
+        });
+
+        let result =
+            persist_rating_queue(Arc::clone(&owner.queue), Arc::clone(&owner.persist_gate));
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].result, None);
+
+        let database = SourceDatabase::open_for_user_metadata_write_with_database_root(
+            source_root.path(),
+            database_root.path(),
+        )
+        .expect("reopen source database");
+        assert_eq!(
+            database.tag_for_path(&relative_path).expect("read rating"),
+            None
+        );
+        assert_eq!(
+            database.locked_for_path(&relative_path).expect("read lock"),
+            None
         );
     }
 }
@@ -282,7 +439,9 @@ impl BackgroundTaskState {
             deferred_sample_load_task: ui::LatestTask::new(),
             sample_load_tasks: ui::ResourceTasks::new(),
             harvest_touched_persist: HarvestTouchedPersistOwner::new(),
-            rating_persist: RatingPersistOwner::new(),
+            rating_persist: RatingPersistOwner::new_with_lifecycle_generations(
+                source_lifecycle_generations.clone(),
+            ),
             active_sample_load_key: None,
             sample_load_cancel: None,
             settled_sample_promotion_task: ui::LatestTask::new(),
@@ -335,6 +494,9 @@ const HARVEST_TOUCHED_ADMISSION_POLL_DELAY: Duration = Duration::from_millis(50)
 pub(in crate::native_app) struct RatingPersistOwner {
     task: ui::LatestTask,
     queue: Arc<Mutex<RatingPersistQueue>>,
+    /// Serializes source-database writes between the background worker and the
+    /// synchronous shutdown flush.  The UI path never takes this lock.
+    persist_gate: Arc<Mutex<()>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -386,18 +548,19 @@ struct RatingPersistWork {
 }
 
 impl RatingPersistOwner {
-    fn new() -> Self {
+    fn new_with_lifecycle_generations(lifecycle_generations: BTreeMap<String, u64>) -> Self {
         Self {
             task: ui::LatestTask::new(),
             queue: Arc::new(Mutex::new(RatingPersistQueue {
                 entries: std::collections::HashMap::new(),
                 desired: std::collections::HashMap::new(),
                 deferred_auto_trash: std::collections::HashMap::new(),
-                lifecycle_generations: BTreeMap::new(),
+                lifecycle_generations,
                 order: VecDeque::new(),
                 next_revision: 1,
                 closed: false,
             })),
+            persist_gate: Arc::new(Mutex::new(())),
         }
     }
 
@@ -774,12 +937,13 @@ impl RatingPersistOwner {
             return;
         }
         let queue = Arc::clone(&self.queue);
+        let persist_gate = Arc::clone(&self.persist_gate);
         context
             .business()
             .background("gui-rating-persist")
             .latest(&mut self.task)
             .run(
-                move |_| persist_rating_queue(queue),
+                move |_| persist_rating_queue(queue, persist_gate),
                 GuiMessage::RatingPersisted,
             );
     }
@@ -822,20 +986,87 @@ impl RatingPersistOwner {
 
     pub(in crate::native_app) fn close(&mut self) -> usize {
         self.task.cancel();
-        if let Ok(mut queue) = self.queue.lock() {
-            let lost = queue.entries.len();
+        let requests = {
+            let Ok(mut queue) = self.queue.lock() else {
+                tracing::error!("rating persistence queue lock poisoned during shutdown flush");
+                return 0;
+            };
+            if queue.closed {
+                return 0;
+            }
+            // Fence new UI requests before waiting for a worker that may still
+            // be finishing an older batch.  The worker's final current check
+            // observes this flag while holding the same persistence gate.
             queue.closed = true;
+            queue
+                .entries
+                .values()
+                .filter(|entry| {
+                    entry.request.lifecycle_generation.is_none_or(|generation| {
+                        queue.lifecycle_generations.get(&entry.request.source_id)
+                            == Some(&generation)
+                    })
+                })
+                .map(|entry| entry.request.clone())
+                .collect::<Vec<_>>()
+        };
+
+        if requests.is_empty() {
+            if let Ok(mut queue) = self.queue.lock() {
+                queue.entries.clear();
+                queue.order.clear();
+                queue.desired.clear();
+                queue.deferred_auto_trash.clear();
+            }
+            return 0;
+        }
+
+        // Shutdown is the one path allowed to synchronously wait for source
+        // database I/O.  This gate also ensures a worker that was already in
+        // flight cannot run after this flush and overwrite its latest state.
+        let Ok(_persist_gate) = self.persist_gate.lock() else {
+            tracing::error!(
+                count = requests.len(),
+                "rating persistence gate poisoned during shutdown flush"
+            );
+            return requests.len();
+        };
+        let persisted = persist_rating_requests(&requests, |_| true);
+        let mut unflushed = 0;
+        for (request, result) in requests.iter().zip(persisted) {
+            match result {
+                Some(Ok(())) => {}
+                Some(Err(error)) => {
+                    unflushed += 1;
+                    tracing::error!(
+                        path = %request.absolute_path.display(),
+                        error = %error,
+                        "rating persistence shutdown flush failed"
+                    );
+                }
+                None => {
+                    unflushed += 1;
+                    tracing::error!(
+                        path = %request.absolute_path.display(),
+                        "rating persistence shutdown flush did not attempt request"
+                    );
+                }
+            }
+        }
+        if let Ok(mut queue) = self.queue.lock() {
             queue.entries.clear();
             queue.order.clear();
             queue.desired.clear();
             queue.deferred_auto_trash.clear();
-            return lost;
         }
-        0
+        unflushed
     }
 }
 
-fn persist_rating_queue(queue: Arc<Mutex<RatingPersistQueue>>) -> RatingPersistBatchResult {
+fn persist_rating_queue(
+    queue: Arc<Mutex<RatingPersistQueue>>,
+    persist_gate: Arc<Mutex<()>>,
+) -> RatingPersistBatchResult {
     let work = queue
         .lock()
         .map(|mut queue| queue.claim_all())
@@ -844,6 +1075,20 @@ fn persist_rating_queue(queue: Arc<Mutex<RatingPersistQueue>>) -> RatingPersistB
         .iter()
         .map(|item| item.request.clone())
         .collect::<Vec<_>>();
+    let Ok(_persist_gate) = persist_gate.lock() else {
+        let results = work
+            .into_iter()
+            .map(|item| RatingPersistBatchItem {
+                key: item.key,
+                revision: item.revision,
+                absolute_path: item.request.absolute_path,
+                result: Some(Err(String::from(
+                    "rating persistence gate poisoned before database write",
+                ))),
+            })
+            .collect();
+        return RatingPersistBatchResult { results };
+    };
     let persisted = persist_rating_requests(&requests, |request| {
         let Some(item) = work.iter().find(|item| {
             item.request.source_id == request.source_id
@@ -852,13 +1097,15 @@ fn persist_rating_queue(queue: Arc<Mutex<RatingPersistQueue>>) -> RatingPersistB
             return false;
         };
         queue.lock().ok().is_some_and(|queue| {
-            queue.entries.get(&item.key).is_some_and(|entry| {
-                entry.revision == item.revision
-                    && entry.state == RatingPersistEntryState::InFlight
-                    && entry.request.lifecycle_generation.is_none_or(|generation| {
-                        queue.lifecycle_generations.get(&item.key.source_id) == Some(&generation)
-                    })
-            })
+            !queue.closed
+                && queue.entries.get(&item.key).is_some_and(|entry| {
+                    entry.revision == item.revision
+                        && entry.state == RatingPersistEntryState::InFlight
+                        && entry.request.lifecycle_generation.is_none_or(|generation| {
+                            queue.lifecycle_generations.get(&item.key.source_id)
+                                == Some(&generation)
+                        })
+                })
         })
     });
     let mut results = Vec::with_capacity(work.len());

--- a/src/native_app/sample_library/folder_browser/folder_entry.rs
+++ b/src/native_app/sample_library/folder_browser/folder_entry.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     FileEntry, file_entry, folder_label, path_id, rewrite_path_id,
-    scanning::{upsert_file, upsert_folder},
+    scanning::{RatingSnapshot, upsert_file, upsert_folder},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -180,6 +180,31 @@ impl FolderEntry {
             .collect::<Vec<_>>();
         let changed = previous_name != self.name || previous_children != next_children;
         self.children = next_children;
+        changed
+    }
+
+    pub(super) fn apply_rating_snapshot(
+        &mut self,
+        source_root: &Path,
+        snapshot: &RatingSnapshot,
+    ) -> bool {
+        let mut changed = false;
+        for file in &mut self.files {
+            let (rating, locked) = Path::new(&file.id)
+                .strip_prefix(source_root)
+                .ok()
+                .and_then(|relative| snapshot.get(relative))
+                .copied()
+                .unwrap_or((wavecrate::sample_sources::Rating::NEUTRAL, false));
+            if file.rating != rating || file.rating_locked != locked {
+                file.rating = rating;
+                file.rating_locked = locked;
+                changed = true;
+            }
+        }
+        for child in &mut self.children {
+            changed |= child.apply_rating_snapshot(source_root, snapshot);
+        }
         changed
     }
 
@@ -373,6 +398,10 @@ mod tests {
         }
     }
 
+    fn file(path: &str) -> FileEntry {
+        file_entry(&PathBuf::from(path))
+    }
+
     #[test]
     fn find_path_mut_follows_only_matching_path_branch() {
         let mut root = folder(
@@ -411,5 +440,33 @@ mod tests {
             .expect("component-exact sibling");
 
         assert_eq!(found.id, "/samples/drum-long");
+    }
+
+    #[test]
+    fn apply_rating_snapshot_recurses_and_resets_absent_files() {
+        let mut root = folder(
+            "/samples",
+            vec![FolderEntry {
+                files: vec![file("/samples/drums/kick.wav")],
+                ..folder("/samples/drums", Vec::new())
+            }],
+        );
+        root.files.push(file("/samples/old.wav"));
+        root.files[0].rating = wavecrate::sample_sources::Rating::KEEP_1;
+        root.files[0].rating_locked = true;
+
+        let snapshot = RatingSnapshot::from([(
+            PathBuf::from("drums/kick.wav"),
+            (wavecrate::sample_sources::Rating::KEEP_3, true),
+        )]);
+
+        assert!(root.apply_rating_snapshot(Path::new("/samples"), &snapshot));
+        let kick = root.find_file("/samples/drums/kick.wav").expect("kick");
+        assert_eq!(kick.rating, wavecrate::sample_sources::Rating::KEEP_3);
+        assert!(kick.rating_locked);
+        let old = root.find_file("/samples/old.wav").expect("old");
+        assert_eq!(old.rating, wavecrate::sample_sources::Rating::NEUTRAL);
+        assert!(!old.rating_locked);
+        assert!(!root.apply_rating_snapshot(Path::new("/samples"), &snapshot));
     }
 }

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use super::source_scan_cache::FolderScanCacheUpdate;
-use super::{FileEntry, FolderEntry, collections::MissingCollectionSnapshot};
+use super::{
+    FileEntry, FolderEntry, collections::MissingCollectionSnapshot, scanning::RatingSnapshot,
+};
 use wavecrate::sample_sources::{
     config::DEFAULT_RATING_DECAY_WEEKS, scanner::CommittedSourceDelta,
 };
@@ -285,6 +287,13 @@ pub(in crate::native_app) struct FolderTreeRefreshResult {
     pub(in crate::native_app) folder: FolderEntry,
     pub(in crate::native_app) folder_count: usize,
     pub(in crate::native_app) source_root_available: bool,
+    pub(in crate::native_app) rating_hydration: RatingHydrationStatus,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum RatingHydrationStatus {
+    Complete { snapshot: RatingSnapshot },
+    Failed { error: String },
 }
 
 /// Request for verifying that a selected folder still matches its cached child state.

--- a/src/native_app/sample_library/folder_browser/scanning.rs
+++ b/src/native_app/sample_library/folder_browser/scanning.rs
@@ -11,7 +11,7 @@ pub(super) use entry::{BrowserEntryKind, classify_path_without_following};
 pub(super) use file_entry_metadata::file_entry;
 pub(in crate::native_app) use file_entry_metadata::file_entry_with_snapshot_metadata;
 pub(in crate::native_app::sample_library::folder_browser) use metadata::refreshed_file_entries_for_paths;
-pub(super) use metadata::{SourceMetadataMap, file_entry_for_source_path};
+pub(super) use metadata::{RatingSnapshot, SourceMetadataMap, file_entry_for_source_path};
 #[cfg(test)]
 pub(in crate::native_app) use progress::INDEX_PROGRESS_REPORT_INTERVAL;
 #[cfg(test)]

--- a/src/native_app/sample_library/folder_browser/scanning/metadata.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/metadata.rs
@@ -12,7 +12,7 @@ use super::{
     file_entry_metadata::file_entry_with_metadata,
 };
 use wavecrate::sample_sources::{
-    BrowserMetadataSnapshot, Rating, SampleCollection, SourceDatabase,
+    BrowserMetadataSnapshot, Rating, SampleCollection, SourceDatabase, SourceDatabaseConnectionRole,
 };
 
 pub(in crate::native_app::sample_library::folder_browser) type SourceMetadataMap = HashMap<
@@ -25,6 +25,8 @@ pub(in crate::native_app::sample_library::folder_browser) type SourceMetadataMap
         Option<i64>,
     ),
 >;
+
+pub(crate) type RatingSnapshot = HashMap<PathBuf, (Rating, bool)>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum SourceMetadataHydrationError {
@@ -66,6 +68,26 @@ pub(super) fn source_rating_map(
         })
         .collect();
     Ok((metadata, revision))
+}
+
+pub(super) fn source_rating_snapshot(
+    root: &Path,
+    database_root: &Path,
+) -> Result<RatingSnapshot, SourceMetadataHydrationError> {
+    let db = SourceDatabase::open_with_role_and_database_root(
+        root,
+        database_root,
+        SourceDatabaseConnectionRole::BackgroundRead,
+    )
+    .map_err(|error| SourceMetadataHydrationError::Open(error.to_string()))?;
+    let BrowserMetadataSnapshot { files, .. } = db
+        .browser_metadata_snapshot()
+        .map_err(|error| SourceMetadataHydrationError::Snapshot(error.to_string()))?;
+    let ratings = files
+        .into_iter()
+        .map(|entry| (entry.relative_path, (entry.rating, entry.locked)))
+        .collect();
+    Ok(ratings)
 }
 
 pub(in crate::native_app::sample_library::folder_browser) fn file_entry_for_source_path(

--- a/src/native_app/sample_library/folder_browser/scanning/traversal.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/traversal.rs
@@ -11,7 +11,7 @@ use super::{
         BrowserEntryKind, classify_path_without_following, read_sorted_entries,
         source_traversal_policy,
     },
-    metadata::{SourceMetadataMap, rated_file_entry, source_rating_map},
+    metadata::{SourceMetadataMap, rated_file_entry, source_rating_map, source_rating_snapshot},
 };
 
 pub(in crate::native_app::sample_library::folder_browser) struct LoadedSourceSnapshot {
@@ -59,6 +59,15 @@ pub(in crate::native_app) fn refresh_folder_tree_only(
     let mut folder_count = 0;
     let folder = load_folder_tree_only(&request.root, &request.root, policy, &mut folder_count)
         .unwrap_or_else(|| placeholder_folder(&request.root));
+    let rating_hydration = match source_rating_snapshot(&request.root, &request.database_root) {
+        Ok(snapshot) => super::super::scan_types::RatingHydrationStatus::Complete { snapshot },
+        Err(error) => {
+            tracing::warn!(source = %request.root.display(), %error, "Folder tree rating hydration failed");
+            super::super::scan_types::RatingHydrationStatus::Failed {
+                error: error.to_string(),
+            }
+        }
+    };
     FolderTreeRefreshResult {
         source_id: request.source_id,
         label: request.label,
@@ -66,6 +75,7 @@ pub(in crate::native_app) fn refresh_folder_tree_only(
         folder_count,
         source_root_available: classify_path_without_following(&request.root)
             == Some(BrowserEntryKind::Directory),
+        rating_hydration,
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -7,6 +7,7 @@ use super::super::{
     path_helpers::{folder_label, path_id},
     scan_types::{
         FolderScanDiscoveryBatch, FolderScanRequest, FolderScanResult, FolderTreeRefreshResult,
+        RatingHydrationStatus,
     },
     scanning::{merge_scan_discovery, placeholder_folder},
 };
@@ -469,14 +470,37 @@ impl FolderBrowserState {
         if root_folder.id != result.folder.id {
             return false;
         }
-        if !root_folder.replace_folder_structure(result.folder) {
+        let structure_changed = root_folder.replace_folder_structure(result.folder);
+        let ratings_changed = match result.rating_hydration {
+            RatingHydrationStatus::Complete { snapshot } => root_folder
+                .apply_rating_snapshot(&self.source.sources[source_index].root, &snapshot),
+            RatingHydrationStatus::Failed { error } => {
+                tracing::warn!(source_id = %result.source_id, %error, "Keeping cached browser ratings after folder refresh hydration failure");
+                false
+            }
+        };
+        let changed = structure_changed || ratings_changed;
+        if changed {
+            self.retain_tree_state_after_selected_source_refresh();
+            self.bump_file_content_revision();
+            self.mark_scan_content_refresh_pending();
+            self.refresh_missing_collection_state();
+        }
+        changed
+    }
+
+    pub(in crate::native_app) fn folder_tree_refresh_result_is_current(
+        &self,
+        result: &FolderTreeRefreshResult,
+    ) -> bool {
+        if self.source.selected_source != result.source_id {
             return false;
         }
-        self.retain_tree_state_after_selected_source_refresh();
-        self.bump_file_content_revision();
-        self.mark_scan_content_refresh_pending();
-        self.refresh_missing_collection_state();
-        true
+        self.source
+            .sources
+            .iter()
+            .find(|source| source.id == result.source_id)
+            .is_some_and(|source| path_id(&source.root) == result.folder.id)
     }
 
     #[cfg(test)]

--- a/src/native_app/sample_library/folder_browser/tests/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_browser/tests/filesystem_refresh.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::native_app::sample_library::folder_browser::scan_types::FolderScanItem;
+use crate::native_app::sample_library::folder_browser::scan_types::{
+    FolderScanItem, RatingHydrationStatus,
+};
 use crate::native_app::sample_library::folder_browser::{
     refreshed_file_entries_for_paths, scan::verify_direct_folder,
 };
@@ -358,6 +360,79 @@ fn folder_tree_refresh_prunes_deleted_folders_and_preserves_files() {
         vec!["keep.wav"],
         "folder-only refresh should preserve cached file rows for folders that still exist"
     );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn folder_tree_refresh_hydrates_cached_file_rating_and_lock_from_source_db() {
+    let root = temp_source_root("wavecrate-gui-folder-tree-refresh-rating-hydration");
+    let kick = root.join("kick.wav");
+    fs::write(&kick, [0_u8; 8]).expect("write kick");
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    let database = SourceDatabase::open_for_source_write(&root).expect("open source db");
+    database
+        .upsert_file(std::path::Path::new("kick.wav"), 8, 0)
+        .expect("index kick");
+    database
+        .set_tag(std::path::Path::new("kick.wav"), Rating::KEEP_3)
+        .expect("persist kick rating");
+    database
+        .set_locked(std::path::Path::new("kick.wav"), true)
+        .expect("persist kick lock");
+
+    let result = refresh_folder_tree_only(FolderTreeRefreshRequest {
+        source_id: browser.selected_source_id().to_string(),
+        label: String::from("Assets"),
+        root: root.clone(),
+        database_root: root.clone(),
+    });
+    assert!(browser.apply_folder_tree_refresh_result(result));
+
+    let refreshed = browser
+        .selected_audio_files()
+        .into_iter()
+        .find(|file| file.id == path_id(&kick))
+        .expect("hydrated kick row");
+    assert_eq!(refreshed.rating, Rating::KEEP_3);
+    assert!(refreshed.rating_locked);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn folder_tree_refresh_missing_db_fails_hydration_without_creating_schema() {
+    let root = temp_source_root("wavecrate-gui-folder-tree-refresh-missing-db");
+    let kick = root.join("kick.wav");
+    fs::write(&kick, [0_u8; 8]).expect("write kick");
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    assert!(browser.set_file_rating_state(&kick, Rating::KEEP_3, true));
+    let db_path = root.join(wavecrate::sample_sources::DB_FILE_NAME);
+    assert!(
+        !db_path.exists(),
+        "test setup should have no source database"
+    );
+
+    let result = refresh_folder_tree_only(FolderTreeRefreshRequest {
+        source_id: browser.selected_source_id().to_string(),
+        label: String::from("Assets"),
+        root: root.clone(),
+        database_root: root.clone(),
+    });
+    assert!(matches!(
+        result.rating_hydration,
+        RatingHydrationStatus::Failed { .. }
+    ));
+    assert!(
+        !db_path.exists(),
+        "background hydration must not create a database"
+    );
+    assert!(!browser.apply_folder_tree_refresh_result(result));
+    let cached = browser
+        .selected_audio_files()
+        .into_iter()
+        .find(|file| file.id == path_id(&kick))
+        .expect("cached kick row");
+    assert_eq!(cached.rating, Rating::KEEP_3);
+    assert!(cached.rating_locked);
     let _ = fs::remove_dir_all(root);
 }
 

--- a/src/native_app/sample_library/folder_scan_actions/source_commands.rs
+++ b/src/native_app/sample_library/folder_scan_actions/source_commands.rs
@@ -53,7 +53,18 @@ impl NativeAppState {
                 );
                 return;
             }
-            SourceSelectionRequest::Settled => {}
+            SourceSelectionRequest::Settled => {
+                if self.library.folder_browser.selected_source_id() == requested_id
+                    && self.library.folder_browser.selected_source_loaded()
+                    && !self.library.folder_browser.source_is_missing(&requested_id)
+                {
+                    self.queue_selected_source_folder_tree_refresh(
+                        context,
+                        "folder_browser.source_selection_folder_tree_refresh",
+                        "gui-source-selection-folder-tree-refresh",
+                    );
+                }
+            }
         }
         if self.library.folder_browser.selected_source_id() == requested_id
             && self.library.folder_browser.selected_source_loaded()

--- a/src/native_app/sample_library/folder_tree_refresh_actions.rs
+++ b/src/native_app/sample_library/folder_tree_refresh_actions.rs
@@ -72,6 +72,10 @@ impl NativeAppState {
             return;
         };
         let source_id = result.source_id.clone();
+        let current = self
+            .library
+            .folder_browser
+            .folder_tree_refresh_result_is_current(&result);
         let changed = self
             .library
             .folder_browser
@@ -80,12 +84,14 @@ impl NativeAppState {
         if changed {
             self.persist_user_configuration("folder_browser.folder_tree_refresh", started_at);
         }
-        self.queue_source_prep(
-            source_id.clone(),
-            VERIFIED_SOURCE_PREP_INTENTS,
-            VERIFIED_SOURCE_PREP_REASON,
-            context,
-        );
+        if current {
+            self.queue_source_prep(
+                source_id.clone(),
+                VERIFIED_SOURCE_PREP_INTENTS,
+                VERIFIED_SOURCE_PREP_REASON,
+                context,
+            );
+        }
         emit_gui_action(
             "folder_browser.folder_tree_refresh",
             Some("folder_browser"),

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -483,6 +483,7 @@ impl NativeAppState {
             "waveform_cache_shutdown_flush_ms": duration_ms(elapsed),
             "source_processing": source_processing,
             "harvest_touched_unflushed": harvest_touched_unflushed,
+            "rating_persist_unflushed": rating_persist_unflushed,
         }))
     }
 }

--- a/src/native_app/tests/config_sources/cache.rs
+++ b/src/native_app/tests/config_sources/cache.rs
@@ -91,6 +91,469 @@ fn cached_startup_queues_folder_tree_refresh_without_foreground_scan() {
 }
 
 #[test]
+fn cached_startup_folder_refresh_hydrates_rating_and_persists_cache_for_restart() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let source_root = tempfile::tempdir().expect("source root");
+    let kick = source_root.path().join("kick.wav");
+    fs::write(&kick, [0_u8; 8]).expect("write sample");
+    let source = wavecrate::sample_sources::SampleSource::new_with_id(
+        wavecrate::sample_sources::SourceId::from_string("source_id::rating-cache-restart"),
+        source_root.path().to_path_buf(),
+    );
+    wavecrate::sample_sources::config::save(&crate::native_app::test_support::config::AppConfig {
+        sources: vec![source.clone()],
+        core: crate::native_app::test_support::config::AppSettingsCore::default(),
+    })
+    .expect("seed config");
+    crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[source])
+        .save_source_scan_cache()
+        .expect("persist neutral cache");
+
+    let database =
+        wavecrate::sample_sources::SourceDatabase::open_for_source_write(source_root.path())
+            .expect("open source db");
+    database
+        .upsert_file(std::path::Path::new("kick.wav"), 8, 0)
+        .expect("index sample");
+    database
+        .set_tag(
+            std::path::Path::new("kick.wav"),
+            wavecrate::sample_sources::Rating::KEEP_3,
+        )
+        .expect("persist rating");
+    database
+        .set_locked(std::path::Path::new("kick.wav"), true)
+        .expect("persist lock");
+
+    let mut state = NativeAppState::load_default().expect("load cached state");
+    let mut context = ui::UiUpdateContext::default();
+    assert!(state.queue_selected_source_folder_tree_refresh(
+        &mut context,
+        "test.folder_tree_refresh",
+        "test-folder-tree-refresh",
+    ));
+    let ticket = state
+        .background
+        .folder_tree_refresh_task
+        .active()
+        .expect("refresh task ticket");
+    let request = state
+        .library
+        .folder_browser
+        .selected_source_folder_tree_refresh_request()
+        .expect("refresh request");
+    let result =
+        crate::native_app::sample_library::folder_browser::scan::refresh_folder_tree_only(request);
+    state.finish_folder_tree_refresh(
+        ui::TaskCompletion {
+            ticket,
+            output: result,
+        },
+        &mut context,
+    );
+    assert_eq!(
+        state
+            .library
+            .folder_browser
+            .selected_audio_files()
+            .into_iter()
+            .find(|file| file.id == kick.display().to_string())
+            .expect("hydrated kick")
+            .rating,
+        wavecrate::sample_sources::Rating::KEEP_3
+    );
+
+    let reloaded = NativeAppState::load_default().expect("reload persisted cache");
+    let cached = reloaded
+        .library
+        .folder_browser
+        .selected_audio_files()
+        .into_iter()
+        .find(|file| file.id == kick.display().to_string())
+        .expect("cached kick after restart");
+    assert_eq!(cached.rating, wavecrate::sample_sources::Rating::KEEP_3);
+    assert!(cached.rating_locked);
+}
+
+#[test]
+fn selecting_cached_second_source_hydrates_rating_and_persists_cache_for_restart() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let first_root = tempfile::tempdir().expect("first source root");
+    let second_root = tempfile::tempdir().expect("second source root");
+    let first_file = first_root.path().join("first.wav");
+    let second_file = second_root.path().join("second.wav");
+    fs::write(&first_file, [0_u8; 8]).expect("write first sample");
+    fs::write(&second_file, [0_u8; 8]).expect("write second sample");
+    let sources = vec![
+        wavecrate::sample_sources::SampleSource::new_with_id(
+            wavecrate::sample_sources::SourceId::from_string("source-a"),
+            first_root.path().to_path_buf(),
+        ),
+        wavecrate::sample_sources::SampleSource::new_with_id(
+            wavecrate::sample_sources::SourceId::from_string("source-b"),
+            second_root.path().to_path_buf(),
+        ),
+    ];
+    wavecrate::sample_sources::config::save(&crate::native_app::test_support::config::AppConfig {
+        sources: sources.clone(),
+        core: crate::native_app::test_support::config::AppSettingsCore::default(),
+    })
+    .expect("seed config");
+    let mut seeded_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&sources);
+    let second_scan = seeded_browser
+        .begin_source_scan(String::from("source-b"), 1)
+        .expect("seed second source cache");
+    assert!(seeded_browser.apply_scan_finished(
+        crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+            second_scan,
+            |_| {},
+            |_| {},
+        )
+    ));
+    seeded_browser
+        .save_source_scan_cache()
+        .expect("persist neutral source scan cache");
+
+    let database =
+        wavecrate::sample_sources::SourceDatabase::open_for_source_write(second_root.path())
+            .expect("open second source db");
+    database
+        .upsert_file(std::path::Path::new("second.wav"), 8, 0)
+        .expect("index second sample");
+    database
+        .set_tag(
+            std::path::Path::new("second.wav"),
+            wavecrate::sample_sources::Rating::KEEP_3,
+        )
+        .expect("persist second rating");
+    database
+        .set_locked(std::path::Path::new("second.wav"), true)
+        .expect("persist second lock");
+
+    let mut state = NativeAppState::load_default().expect("load cached state");
+    assert_eq!(
+        state.library.folder_browser.selected_source_id(),
+        "source-a"
+    );
+    let mut context = ui::UiUpdateContext::default();
+    state.select_source(String::from("source-b"), &mut context);
+
+    assert_eq!(
+        state.library.folder_browser.selected_source_id(),
+        "source-b"
+    );
+    assert!(state.library.folder_browser.selected_source_loaded());
+    assert!(state.library.folder_progress().is_none());
+    let ticket = state
+        .background
+        .folder_tree_refresh_task
+        .active()
+        .expect("cached source selection should queue a tree refresh");
+    let request = state
+        .library
+        .folder_browser
+        .selected_source_folder_tree_refresh_request()
+        .expect("selected source refresh request");
+    let result =
+        crate::native_app::sample_library::folder_browser::scan::refresh_folder_tree_only(request);
+    state.finish_folder_tree_refresh(
+        ui::TaskCompletion {
+            ticket,
+            output: result,
+        },
+        &mut context,
+    );
+
+    let hydrated = state
+        .library
+        .folder_browser
+        .selected_audio_files()
+        .into_iter()
+        .find(|file| file.id == second_file.display().to_string())
+        .expect("hydrated second sample");
+    assert_eq!(hydrated.rating, wavecrate::sample_sources::Rating::KEEP_3);
+    assert!(hydrated.rating_locked);
+
+    let mut reloaded = NativeAppState::load_default().expect("reload persisted cache");
+    reloaded.select_source(
+        String::from("source-b"),
+        &mut ui::UiUpdateContext::default(),
+    );
+    assert_eq!(
+        reloaded.library.folder_browser.selected_source_id(),
+        "source-b"
+    );
+    let cached = reloaded
+        .library
+        .folder_browser
+        .selected_audio_files()
+        .into_iter()
+        .find(|file| file.id == second_file.display().to_string())
+        .expect("cached second sample after restart");
+    assert_eq!(cached.rating, wavecrate::sample_sources::Rating::KEEP_3);
+    assert!(cached.rating_locked);
+}
+
+#[test]
+fn stale_cached_source_refresh_cannot_apply_after_rapid_source_switch_back() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let first_root = tempfile::tempdir().expect("first source root");
+    let second_root = tempfile::tempdir().expect("second source root");
+    let first_file = first_root.path().join("first.wav");
+    let second_file = second_root.path().join("second.wav");
+    fs::write(&first_file, [0_u8; 8]).expect("write first sample");
+    fs::write(&second_file, [0_u8; 8]).expect("write second sample");
+    let sources = vec![
+        wavecrate::sample_sources::SampleSource::new_with_id(
+            wavecrate::sample_sources::SourceId::from_string("source-a-rapid"),
+            first_root.path().to_path_buf(),
+        ),
+        wavecrate::sample_sources::SampleSource::new_with_id(
+            wavecrate::sample_sources::SourceId::from_string("source-b-rapid"),
+            second_root.path().to_path_buf(),
+        ),
+    ];
+    wavecrate::sample_sources::config::save(&crate::native_app::test_support::config::AppConfig {
+        sources: sources.clone(),
+        core: crate::native_app::test_support::config::AppSettingsCore::default(),
+    })
+    .expect("seed config");
+    let mut seeded_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&sources);
+    let second_scan = seeded_browser
+        .begin_source_scan(String::from("source-b-rapid"), 1)
+        .expect("seed second source cache");
+    assert!(seeded_browser.apply_scan_finished(
+        crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+            second_scan,
+            |_| {},
+            |_| {},
+        )
+    ));
+    seeded_browser
+        .save_source_scan_cache()
+        .expect("persist neutral source scan cache");
+
+    let mut state = NativeAppState::load_default().expect("load cached state");
+    let mut context = ui::UiUpdateContext::default();
+    state.select_source(String::from("source-b-rapid"), &mut context);
+    let b_ticket = state
+        .background
+        .folder_tree_refresh_task
+        .active()
+        .expect("source B refresh ticket");
+    let b_request = state
+        .library
+        .folder_browser
+        .selected_source_folder_tree_refresh_request()
+        .expect("source B refresh request");
+    let b_result =
+        crate::native_app::sample_library::folder_browser::scan::refresh_folder_tree_only(
+            b_request,
+        );
+
+    state.select_source(String::from("source-a-rapid"), &mut context);
+    let a_ticket = state
+        .background
+        .folder_tree_refresh_task
+        .active()
+        .expect("source A refresh ticket");
+    assert_ne!(a_ticket, b_ticket, "latest refresh should replace source B");
+    let a_request = state
+        .library
+        .folder_browser
+        .selected_source_folder_tree_refresh_request()
+        .expect("source A refresh request");
+    let a_result =
+        crate::native_app::sample_library::folder_browser::scan::refresh_folder_tree_only(
+            a_request,
+        );
+
+    state.finish_folder_tree_refresh(
+        ui::TaskCompletion {
+            ticket: b_ticket,
+            output: b_result,
+        },
+        &mut context,
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_source_id(),
+        "source-a-rapid"
+    );
+    let first_visible = state
+        .library
+        .folder_browser
+        .selected_audio_files()
+        .into_iter()
+        .find(|file| file.id == first_file.display().to_string())
+        .expect("source A remains visible after stale source B completion");
+    assert_eq!(
+        first_visible.rating,
+        wavecrate::sample_sources::Rating::NEUTRAL
+    );
+    assert!(!first_visible.rating_locked);
+
+    state.finish_folder_tree_refresh(
+        ui::TaskCompletion {
+            ticket: a_ticket,
+            output: a_result,
+        },
+        &mut context,
+    );
+    assert!(
+        state
+            .library
+            .folder_browser
+            .selected_audio_files()
+            .into_iter()
+            .any(|file| file.id == first_file.display().to_string())
+    );
+}
+
+#[test]
+fn stale_cached_refresh_does_not_prepare_cached_source_after_switch_to_uncached_source() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let first_root = tempfile::tempdir().expect("first source root");
+    let cached_root = tempfile::tempdir().expect("cached source root");
+    let uncached_root = tempfile::tempdir().expect("uncached source root");
+    fs::write(first_root.path().join("first.wav"), [0_u8; 8]).expect("write first sample");
+    fs::write(cached_root.path().join("cached.wav"), [0_u8; 8]).expect("write cached sample");
+    fs::write(uncached_root.path().join("uncached.wav"), [0_u8; 8]).expect("write uncached sample");
+    let sources = vec![
+        wavecrate::sample_sources::SampleSource::new_with_id(
+            wavecrate::sample_sources::SourceId::from_string("source-a-stale"),
+            first_root.path().to_path_buf(),
+        ),
+        wavecrate::sample_sources::SampleSource::new_with_id(
+            wavecrate::sample_sources::SourceId::from_string("source-b-stale"),
+            cached_root.path().to_path_buf(),
+        ),
+        wavecrate::sample_sources::SampleSource::new_with_id(
+            wavecrate::sample_sources::SourceId::from_string("source-c-stale"),
+            uncached_root.path().to_path_buf(),
+        ),
+    ];
+    wavecrate::sample_sources::config::save(&crate::native_app::test_support::config::AppConfig {
+        sources: sources.clone(),
+        core: crate::native_app::test_support::config::AppSettingsCore::default(),
+    })
+    .expect("seed config");
+    let mut seeded_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&sources);
+    let cached_scan = seeded_browser
+        .begin_source_scan(String::from("source-b-stale"), 1)
+        .expect("seed cached source");
+    assert!(seeded_browser.apply_scan_finished(
+        crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+            cached_scan,
+            |_| {},
+            |_| {},
+        )
+    ));
+    seeded_browser
+        .save_source_scan_cache()
+        .expect("persist cached source");
+
+    let mut state = NativeAppState::load_default().expect("load cached sources");
+    let mut context = ui::UiUpdateContext::default();
+    state.select_source(String::from("source-b-stale"), &mut context);
+    let b_ticket = state
+        .background
+        .folder_tree_refresh_task
+        .active()
+        .expect("cached source refresh ticket");
+    let b_request = state
+        .library
+        .folder_browser
+        .selected_source_folder_tree_refresh_request()
+        .expect("cached source refresh request");
+    let b_result =
+        crate::native_app::sample_library::folder_browser::scan::refresh_folder_tree_only(
+            b_request,
+        );
+    state
+        .metadata
+        .persisted_tag_sources_pending
+        .remove("source-b-stale");
+
+    state.apply_folder_browser_message(
+        crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage::SelectSource(
+            String::from("source-c-stale"),
+        ),
+        &mut context,
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_source_id(),
+        "source-c-stale"
+    );
+    assert_eq!(
+        state
+            .background
+            .source_processing
+            .selected_source_priority_for_tests()
+            .as_deref(),
+        Some("source-c-stale")
+    );
+    assert!(
+        state
+            .library
+            .folder_progress()
+            .is_some_and(|progress| progress.source_id == "source-c-stale")
+    );
+    assert!(
+        state
+            .metadata
+            .persisted_tag_sources_pending
+            .contains("source-c-stale")
+    );
+    assert!(
+        !state
+            .metadata
+            .persisted_tag_sources_pending
+            .contains("source-b-stale")
+    );
+
+    state.finish_folder_tree_refresh(
+        ui::TaskCompletion {
+            ticket: b_ticket,
+            output: b_result,
+        },
+        &mut context,
+    );
+    assert_eq!(
+        state
+            .background
+            .source_processing
+            .selected_source_priority_for_tests()
+            .as_deref(),
+        Some("source-c-stale")
+    );
+    assert!(
+        !state
+            .metadata
+            .persisted_tag_sources_pending
+            .contains("source-b-stale")
+    );
+    assert!(
+        state
+            .metadata
+            .persisted_tag_sources_pending
+            .contains("source-c-stale")
+    );
+    assert!(
+        state
+            .library
+            .folder_progress()
+            .is_some_and(|progress| progress.source_id == "source-c-stale")
+    );
+}
+
+#[test]
 fn moved_files_do_not_reappear_from_source_scan_cache_after_restart() {
     let config_base = tempfile::tempdir().expect("config base");
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -168,12 +168,10 @@ fn selecting_loaded_cached_source_keeps_tree_visible_and_reconciles_in_backgroun
         second_source_id
     );
     let task_id = state.next_folder_task_id();
-    let SourceSelectionRequest::Queued(request) = state
+    let selection = state
         .library
-        .begin_select_source(first_source_id.clone(), task_id)
-    else {
-        panic!("selecting a cached source should queue reconciliation");
-    };
+        .begin_select_source(first_source_id.clone(), task_id);
+    assert!(matches!(selection, SourceSelectionRequest::Settled));
 
     assert_eq!(
         state.library.folder_browser.selected_source_id(),
@@ -182,19 +180,11 @@ fn selecting_loaded_cached_source_keeps_tree_visible_and_reconciles_in_backgroun
     assert!(state.library.folder_browser.selected_source_loaded());
     assert!(
         state.background.folder_tree_refresh_task.active().is_none(),
-        "source switching should reconcile through the source scan worker"
+        "library source selection should not queue UI work directly"
     );
-    state.library.start_folder_scan(&request);
-    let progress = state
-        .library
-        .folder_progress()
-        .expect("selecting a loaded cached source should start a background scan");
     assert!(
-        state
-            .library
-            .folder_browser
-            .scan_is_active(&first_source_id, progress.task_id),
-        "the selected source should own the queued reconciliation scan"
+        state.library.folder_progress().is_none(),
+        "cached source selection must not queue a foreground scan"
     );
 }
 


### PR DESCRIPTION
Goal
Make sample ratings survive restart both durably and visibly for every cached source, including locked Keep 4.

Scope and non-goals
- Seeds rating persistence with initial source lifecycle generations and flushes latest lifecycle-valid rating intents during normal shutdown.
- Reads authoritative rating/lock metadata in the existing background folder refresh, then overlays it on cached file entries.
- Selecting any cached available source queues that source’s bounded background refresh; stale completions cannot schedule follow-on source prep.
- Uses a non-creating read-only DB role; failed hydration preserves cached state.
- Does not add database/filesystem work to the UI rating interaction or app construction, change rating transitions, scanner policy, or Radiant.

Definition of Done
- Current-generation Keep 3 plus lock persists through worker/shutdown and source DB reopen.
- A stale neutral cache for a second selected source converges to DB Keep 3 plus lock through queued refresh, cache save, and reload.
- Missing DB preserves cache and creates no schema; rapid cached-source changes cannot apply/schedule stale work.

Validation
- cargo test --lib rating_persist_owner_tests -- --nocapture (9 passed)
- cargo test --lib folder_tree_refresh -- --nocapture (9 passed)
- config_sources cache tests (8 passed), including second-source restart and stale-completion cases
- cargo check --locked
- git diff --check
- Independent review approved.
- Repository-wide cargo fmt --check reports only unrelated baseline files: src/native_app/tests/waveform_playback.rs and tests/release_contract.rs.

Known limitations
- Real-library acceptance remains required: build exact head, launch with --log, select inbox, wait for its background refresh, confirm Keep 4, quit/relaunch, reselect inbox, and confirm again.

User approval is required before merge.