### PR TITLE
Sync Radiant to latest main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "16ef95c6a3f2828aa824da16a818d970d5e3b9f5"
+revision = "82043f13510fb60c4bf0114159d38e43e7df8987"
 path = "../radiant"
 
 [package]

--- a/radiant-dependency.toml
+++ b/radiant-dependency.toml
@@ -4,5 +4,5 @@
 # sibling may remain on a feature branch or contain uncommitted work. Setup,
 # CI, and release helpers provision this exact revision into a clean checkout.
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "16ef95c6a3f2828aa824da16a818d970d5e3b9f5"
+revision = "82043f13510fb60c4bf0114159d38e43e7df8987"
 path = "../radiant"

--- a/tests/radiant_dependency_contract.rs
+++ b/tests/radiant_dependency_contract.rs
@@ -13,7 +13,7 @@ fn canonical_radiant_dependency_uses_the_standalone_sibling_contract() {
 
     assert!(manifest.contains("radiant = { path = \"../radiant\" }"));
     assert!(metadata.contains("repository = \"https://github.com/PORTALSURFER/radiant.git\""));
-    assert!(metadata.contains("revision = \"16ef95c6a3f2828aa824da16a818d970d5e3b9f5\""));
+    assert!(metadata.contains("revision = \"82043f13510fb60c4bf0114159d38e43e7df8987\""));
     assert!(metadata.contains("path = \"../radiant\""));
     assert!(!root.join(".gitmodules").exists());
     assert!(!root.join("vendor/radiant").exists());

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -487,7 +487,7 @@ edition = "2024"
             ),
         );
         self.write("Cargo.lock", "# fixture lockfile\n");
-        self.write("radiant-dependency.toml", "repository = \"https://github.com/PORTALSURFER/radiant.git\"\nrevision = \"16ef95c6a3f2828aa824da16a818d970d5e3b9f5\"\npath = \"../radiant\"\n");
+        self.write("radiant-dependency.toml", "repository = \"https://github.com/PORTALSURFER/radiant.git\"\nrevision = \"82043f13510fb60c4bf0114159d38e43e7df8987\"\npath = \"../radiant\"\n");
         self.write("src/lib.rs", "");
         self.write(".github/workflows/release-train-prepare.yml", "");
         self.write(".github/workflows/release-rc.yml", "");


### PR DESCRIPTION
## Goal
Sync Wavecrate’s canonical paired Radiant revision to the current public `main` head.

## Scope and non-goals
Updates only the recorded revision and matching contract fixtures. Keeps the `../radiant` path dependency; does not migrate additive Radiant revision/identity APIs because Wavecrate has no broken or deprecated call sites at this head.

## Definition of Done
- Canonical revision and contract fixtures use `82043f13510fb60c4bf0114159d38e43e7df8987`.
- The sibling provisioning contract remains path-based and resolves the recorded revision.
- Focused dependency and release-contract checks pass.

## Validation
- `scripts/radiant.sh locate` (`RADIANT_REVISION_MATCH=yes`)
- `cargo check --workspace --locked --all-targets`
- `cargo test --test radiant_dependency_contract`
- `cargo test --test release_orchestration`
- `cargo metadata --locked --format-version 1`
- `git diff --check`

## Known limitations
The shared Radiant checkout contained an unrelated uncommitted change, so local compilation includes it; Wavecrate does not modify that checkout and its `HEAD` matches the pinned SHA.

User approval is required before merge.