### PR TITLE
Fix context-menu unlock for selected samples

### DIFF
--- a/src/native_app/sample_library/sample_ratings.rs
+++ b/src/native_app/sample_library/sample_ratings.rs
@@ -170,11 +170,11 @@ impl NativeAppState {
             );
             return;
         }
-        let Some((root, database_root, relative_path)) = self
-            .library
-            .folder_browser
-            .source_database_relative_file_path(&loaded_path)
-        else {
+        let Some(update) = self.unlock_rating_update_for_loaded_row(
+            loaded_path.clone(),
+            previous_rating,
+            previous_locked,
+        ) else {
             self.ui.status.sample = String::from("Sample is unavailable");
             emit_gui_action(
                 "browser.context_menu.sample.unlock",
@@ -186,37 +186,42 @@ impl NativeAppState {
             );
             return;
         };
-        let Some(source_id) = self
+        let target_is_in_explicit_multi_selection = self
             .library
             .folder_browser
-            .source_id_for_file_path(&loaded_path)
-        else {
-            self.ui.status.sample = String::from("Sample is unavailable");
-            return;
-        };
-        let update = RatingUpdate {
-            source_id: source_id.clone(),
-            lifecycle_generation: self
-                .background
-                .source_lifecycle_generations
-                .get(&source_id)
-                .copied(),
-            root,
-            database_root,
-            relative_path,
-            absolute_path: loaded_path.clone(),
-            previous_rating,
-            previous_locked,
-            rating: previous_rating,
-            locked: false,
-        };
+            .explicit_multi_file_selection_active()
+            && self
+                .library
+                .folder_browser
+                .explicit_selected_file_paths()
+                .iter()
+                .any(|path| normalized_rating_path(path) == path_key);
+        let mut updates = vec![update];
+        if target_is_in_explicit_multi_selection {
+            for path in self.library.folder_browser.explicit_selected_file_paths() {
+                if normalized_rating_path(&path) == path_key {
+                    continue;
+                }
+                let Some((loaded_path, rating, locked)) =
+                    self.rating_row_state_for_path(&normalized_rating_path(&path))
+                else {
+                    continue;
+                };
+                if rating != Rating::KEEP_3 || !locked {
+                    continue;
+                }
+                if let Some(update) =
+                    self.unlock_rating_update_for_loaded_row(loaded_path, rating, locked)
+                {
+                    updates.push(update);
+                }
+            }
+        }
         let previous_visible_ids = self
             .library
             .folder_browser
             .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
-        let applied = match self
-            .apply_rating_update_states(std::slice::from_ref(&update), RatingUpdateMode::After)
-        {
+        let applied = match self.apply_rating_update_states(&updates, RatingUpdateMode::After) {
             Ok(applied) => applied,
             Err(error) => {
                 self.ui.status.sample = format!("Unlock failed: {error}");
@@ -244,9 +249,22 @@ impl NativeAppState {
             );
             return;
         }
-        self.ui.status.sample = format!("Unlocked {}", sample_path_label(&loaded_path));
-        self.schedule_harvest_touched_for_paths(std::slice::from_ref(&loaded_path), context);
-        self.register_rating_transaction_with_label("Unlock sample", vec![update]);
+        if applied == 1 {
+            self.ui.status.sample = format!("Unlocked {}", sample_path_label(&loaded_path));
+        } else {
+            self.ui.status.sample = format!("Unlocked {applied} samples");
+        }
+        let touched_paths = updates
+            .iter()
+            .map(|update| update.absolute_path.clone())
+            .collect::<Vec<_>>();
+        self.schedule_harvest_touched_for_paths(&touched_paths, context);
+        let transaction_label = if applied == 1 {
+            "Unlock sample"
+        } else {
+            "Unlock selected samples"
+        };
+        self.register_rating_transaction_with_label(transaction_label, updates);
         self.library
             .folder_browser
             .reconcile_visible_file_selection_after_tag_filter(
@@ -261,6 +279,38 @@ impl NativeAppState {
             started_at,
             None,
         );
+    }
+
+    fn unlock_rating_update_for_loaded_row(
+        &self,
+        loaded_path: PathBuf,
+        previous_rating: Rating,
+        previous_locked: bool,
+    ) -> Option<RatingUpdate> {
+        let (root, database_root, relative_path) = self
+            .library
+            .folder_browser
+            .source_database_relative_file_path(&loaded_path)?;
+        let source_id = self
+            .library
+            .folder_browser
+            .source_id_for_file_path(&loaded_path)?;
+        Some(RatingUpdate {
+            lifecycle_generation: self
+                .background
+                .source_lifecycle_generations
+                .get(&source_id)
+                .copied(),
+            source_id,
+            root,
+            database_root,
+            relative_path,
+            absolute_path: loaded_path,
+            previous_rating,
+            previous_locked,
+            rating: previous_rating,
+            locked: false,
+        })
     }
 
     fn adjust_selected_rating_with_policy(

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -2246,6 +2246,121 @@ fn context_menu_unlock_drops_locked_keep_sample_to_keep_three() {
 }
 
 #[test]
+fn context_menu_unlock_selected_samples_unlocks_the_complete_selection() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    let kick = source_root.path().join("kick.wav");
+    let snare = source_root.path().join("snare.wav");
+    let hat = source_root.path().join("hat.wav");
+    for file in [&kick, &snare, &hat] {
+        fs::write(file, []).expect("write sample");
+    }
+    state.library.folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+    state.library.folder_browser.select_file_with_modifiers(
+        snare.display().to_string(),
+        PointerModifiers {
+            command: true,
+            ..PointerModifiers::default()
+        },
+    );
+    for file in [&kick, &snare] {
+        assert!(
+            state
+                .library
+                .folder_browser
+                .set_file_rating_state(file, Rating::KEEP_3, true,)
+        );
+    }
+
+    state.open_sample_context_menu(kick.display().to_string(), Point::new(40.0, 120.0));
+    let mut context = radiant::prelude::UiUpdateContext::default();
+    state.apply_message(GuiMessage::UnlockContextSample, &mut context);
+    run_command_for_tests(&mut state, context.into_command());
+
+    assert_sample_rating(&state, &kick, Rating::KEEP_3, false);
+    assert_sample_rating(&state, &snare, Rating::KEEP_3, false);
+    assert_loaded_sample_rating(&state, &hat, Rating::NEUTRAL, false);
+    assert_eq!(
+        state.library.folder_browser.selected_file_paths(),
+        vec![kick.clone(), snare.clone()]
+    );
+    assert_eq!(state.transactions.history.list_items().len(), 1);
+    assert_eq!(
+        state.transactions.history.list_items()[0].label,
+        "Unlock selected samples"
+    );
+    assert!(state.ui.status.sample.contains("Unlocked 2 samples"));
+
+    let mut undo_context = radiant::prelude::UiUpdateContext::default();
+    state.apply_message(GuiMessage::UndoTransaction, &mut undo_context);
+    run_command_for_tests(&mut state, undo_context.into_command());
+    assert_sample_rating(&state, &kick, Rating::KEEP_3, true);
+    assert_sample_rating(&state, &snare, Rating::KEEP_3, true);
+
+    let mut redo_context = radiant::prelude::UiUpdateContext::default();
+    state.apply_message(GuiMessage::RedoTransaction, &mut redo_context);
+    run_command_for_tests(&mut state, redo_context.into_command());
+    assert_sample_rating(&state, &kick, Rating::KEEP_3, false);
+    assert_sample_rating(&state, &snare, Rating::KEEP_3, false);
+}
+
+#[test]
+fn context_menu_unlock_unselected_sample_does_not_change_selection() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    let kick = source_root.path().join("kick.wav");
+    let snare = source_root.path().join("snare.wav");
+    let hat = source_root.path().join("hat.wav");
+    for file in [&kick, &snare, &hat] {
+        fs::write(file, []).expect("write sample");
+    }
+    state.library.folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+    state.library.folder_browser.select_file_with_modifiers(
+        snare.display().to_string(),
+        PointerModifiers {
+            command: true,
+            ..PointerModifiers::default()
+        },
+    );
+    for file in [&kick, &snare, &hat] {
+        assert!(
+            state
+                .library
+                .folder_browser
+                .set_file_rating_state(file, Rating::KEEP_3, true,)
+        );
+    }
+
+    state.open_sample_context_menu(hat.display().to_string(), Point::new(40.0, 120.0));
+    let mut context = radiant::prelude::UiUpdateContext::default();
+    state.apply_message(GuiMessage::UnlockContextSample, &mut context);
+    run_command_for_tests(&mut state, context.into_command());
+
+    assert_sample_rating(&state, &hat, Rating::KEEP_3, false);
+    assert_loaded_sample_rating(&state, &kick, Rating::KEEP_3, true);
+    assert_loaded_sample_rating(&state, &snare, Rating::KEEP_3, true);
+    assert_eq!(
+        state.library.folder_browser.selected_file_paths(),
+        vec![kick, snare]
+    );
+    assert!(state.ui.status.sample.contains("Unlocked hat.wav"));
+}
+
+#[test]
 fn third_negative_rating_does_not_auto_trash_selected_file() {
     let mut state = gui_state_for_span_tests();
     let source_root = tempfile::tempdir().expect("source root");


### PR DESCRIPTION
## Goal
Unlock every locked Keep sample in the current explicit multi-selection when the context-menu target is one of the selected samples.

## Scope and non-goals
- Scope: context-menu unlock target construction, optimistic rating state, persistence scheduling, harvest touch scheduling, and undo/redo coverage.
- Non-goals: change selection reconciliation, rating semantics, or behavior for right-clicking an unselected sample.

## Definition of Done
- Right-clicking a selected sample in an explicit multi-selection unlocks all selected locked Keep samples.
- Right-clicking an unselected sample unlocks only that context target and preserves the existing selection.
- Keep rating remains `KEEP_3`; only the lock bit is cleared.
- Persistence and one grouped undo/redo transaction cover the full selected set.
- Focused regression coverage passes.

## Validation
- `rustfmt --edition 2024 --check src/native_app/sample_library/sample_ratings.rs src/native_app/tests/file_operations.rs` — passed.
- `cargo test -p wavecrate context_menu_unlock -- --nocapture` — passed (3 tests).
- `cargo test -p wavecrate native_app::tests::file_operations -- --nocapture` — 43 passed, 11 unrelated pre-existing navigation/trash timing assertions failed.

## Known limitations
The broader `file_operations` module has unrelated failures in this worktree; the focused unlock lane is green.

User approval is required before merge.
