### PR TITLE
Fence stale waveform completions by selection identity

### DIFF
--- a/src/app/controller/library/background_jobs/polling/audio.rs
+++ b/src/app/controller/library/background_jobs/polling/audio.rs
@@ -56,7 +56,9 @@ impl AppController {
                 let Some(pending) = self.runtime.jobs.pending_audio() else {
                     return;
                 };
-                if !pending_audio_matches(&pending, request_id, &source_id, &relative_path) {
+                if !pending_audio_matches(&pending, request_id, &source_id, &relative_path)
+                    || !self.audio_target_matches_current(&source_id, &relative_path)
+                {
                     return;
                 }
                 self.runtime.jobs.set_pending_audio(None);

--- a/src/app/controller/library/background_jobs/polling/tests/audio/primary.rs
+++ b/src/app/controller/library/background_jobs/polling/tests/audio/primary.rs
@@ -6,7 +6,7 @@ use crate::app::controller::state::audio::PendingAudio;
 use crate::app::controller::test_support::{
     prepare_with_source_and_wav_entries, sample_entry, write_test_wav,
 };
-use crate::sample_sources::Rating;
+use crate::sample_sources::{Rating, SourceId};
 use std::path::Path;
 
 #[test]
@@ -16,6 +16,7 @@ fn audio_primary_message_ignores_stale_completion_then_applies_matching_result()
         prepare_with_source_and_wav_entries(vec![sample_entry("match.wav", Rating::NEUTRAL)]);
     let relative_path = Path::new("match.wav");
     write_test_wav(&source.root.join(relative_path), &[0.0, 0.25, -0.25, 0.5]);
+    controller.sample_view.wav.selected_wav = Some(relative_path.to_path_buf());
     controller.ui.waveform.loading = Some(relative_path.to_path_buf());
     controller
         .runtime
@@ -68,4 +69,44 @@ fn audio_primary_message_ignores_stale_completion_then_applies_matching_result()
         .expect("matching primary completion should stage the handoff");
     assert_eq!(staged.source_id, source.id);
     assert_eq!(staged.relative_path, relative_path);
+}
+
+#[test]
+/// A primary completion for the old selection must not stage audio after focus moves.
+fn audio_primary_message_ignores_completion_for_old_selection() {
+    let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
+        sample_entry("old.wav", Rating::NEUTRAL),
+        sample_entry("new.wav", Rating::NEUTRAL),
+    ]);
+    let old_path = Path::new("old.wav");
+    let new_path = Path::new("new.wav");
+    write_test_wav(&source.root.join(old_path), &[0.0, 0.25, -0.25, 0.5]);
+    controller.selection_state.ctx.selected_source = Some(source.id.clone());
+    controller.sample_view.wav.selected_wav = Some(old_path.to_path_buf());
+    controller
+        .runtime
+        .jobs
+        .set_pending_audio(Some(PendingAudio {
+            request_id: 17,
+            source_id: source.id.clone(),
+            root: source.root.clone(),
+            relative_path: old_path.to_path_buf(),
+            intent: AudioLoadIntent::Selection,
+        }));
+
+    controller.selection_state.ctx.selected_source = Some(SourceId::from_string("new-source"));
+    controller.sample_view.wav.selected_wav = Some(new_path.to_path_buf());
+    controller.apply_background_job_message_for_tests(JobMessage::AudioLoaded(
+        AudioLoadResult::Primary {
+            request_id: 17,
+            source_id: source.id.clone(),
+            relative_path: old_path.to_path_buf(),
+            result: Ok(decode_audio_outcome(&controller, &source, old_path)),
+        },
+    ));
+
+    assert!(controller.runtime.jobs.pending_audio().is_some());
+    assert!(controller.runtime.jobs.staged_audio_handoff().is_none());
+    assert!(controller.sample_view.wav.loaded_wav.is_none());
+    assert!(controller.sample_view.wav.loaded_audio.is_none());
 }

--- a/src/app/controller/library/background_jobs/polling/tests/audio/similarity_refresh.rs
+++ b/src/app/controller/library/background_jobs/polling/tests/audio/similarity_refresh.rs
@@ -17,6 +17,7 @@ fn audio_visual_message_queues_one_follow_loaded_similarity_refresh() {
     let relative_path = Path::new("match.wav");
     write_test_wav(&source.root.join(relative_path), &[0.0, 0.25, -0.25, 0.5]);
     controller.selection_state.ctx.selected_source = Some(source.id.clone());
+    controller.sample_view.wav.selected_wav = Some(relative_path.to_path_buf());
     controller.ui.browser.search.sort = crate::app::state::SampleBrowserSort::Similarity;
     controller.ui.browser.search.similarity_sort_follow_loaded = true;
     controller.ui.waveform.loading = Some(relative_path.to_path_buf());

--- a/src/app/controller/library/background_jobs/polling/tests/audio/visuals.rs
+++ b/src/app/controller/library/background_jobs/polling/tests/audio/visuals.rs
@@ -9,7 +9,7 @@ use crate::app::controller::test_support::{
 use crate::app::controller::{AudioLoadIntent, PendingPlayback};
 use crate::app::state::WaveformView;
 use crate::app_core::ui_projection::project_waveform_model;
-use crate::sample_sources::Rating;
+use crate::sample_sources::{Rating, SourceId};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -20,6 +20,7 @@ fn audio_visual_message_commits_staged_handoff_before_playback() {
         prepare_with_source_and_wav_entries(vec![sample_entry("match.wav", Rating::NEUTRAL)]);
     let relative_path = Path::new("match.wav");
     write_test_wav(&source.root.join(relative_path), &[0.0, 0.25, -0.25, 0.5]);
+    controller.sample_view.wav.selected_wav = Some(relative_path.to_path_buf());
     controller.ui.waveform.loading = Some(relative_path.to_path_buf());
     controller
         .runtime
@@ -91,6 +92,7 @@ fn audio_visual_message_rerenders_stale_view_before_projecting_waveform_image() 
         prepare_with_source_and_wav_entries(vec![sample_entry("match.wav", Rating::NEUTRAL)]);
     let relative_path = Path::new("match.wav");
     write_test_wav(&source.root.join(relative_path), &[0.0, 0.25, -0.25, 0.5]);
+    controller.sample_view.wav.selected_wav = Some(relative_path.to_path_buf());
     controller.ui.waveform.loading = Some(relative_path.to_path_buf());
     controller.ui.waveform.view = WaveformView {
         start: 0.25,
@@ -164,4 +166,123 @@ fn audio_visual_message_rerenders_stale_view_before_projecting_waveform_image() 
         projected.waveform_image.is_some(),
         "visual should be rerendered for the current stale view before projection"
     );
+}
+
+#[test]
+/// A visual completion for the old selection must not publish or finalize its staged handoff.
+fn audio_visual_message_ignores_completion_for_old_selection() {
+    let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
+        sample_entry("old.wav", Rating::NEUTRAL),
+        sample_entry("new.wav", Rating::NEUTRAL),
+    ]);
+    let old_path = Path::new("old.wav");
+    let new_path = Path::new("new.wav");
+    write_test_wav(&source.root.join(old_path), &[0.0, 0.25, -0.25, 0.5]);
+    controller.selection_state.ctx.selected_source = Some(source.id.clone());
+    controller.sample_view.wav.selected_wav = Some(old_path.to_path_buf());
+
+    let outcome = decode_audio_outcome(&controller, &source, old_path);
+    let cache_token = outcome.decoded.cache_token;
+    controller.handle_audio_loaded(
+        PendingAudio {
+            request_id: 17,
+            source_id: source.id.clone(),
+            root: source.root.clone(),
+            relative_path: old_path.to_path_buf(),
+            intent: AudioLoadIntent::Selection,
+        },
+        outcome,
+    );
+    controller.selection_state.ctx.selected_source = Some(SourceId::from_string("new-source"));
+    controller.sample_view.wav.selected_wav = Some(new_path.to_path_buf());
+
+    controller.handle_audio_visual_loaded(AudioVisualResult {
+        request_id: 17,
+        source_id: source.id.clone(),
+        relative_path: old_path.to_path_buf(),
+        metadata: controller
+            .current_file_metadata(&source, old_path)
+            .expect("metadata"),
+        cache_token,
+        transients: Arc::from(vec![0.2, 0.7]),
+        image: None,
+        projected_image: None,
+        render_meta: None,
+        stretched: false,
+    });
+    controller.finalize_staged_audio_handoff(cache_token);
+
+    let staged = controller
+        .runtime
+        .jobs
+        .staged_audio_handoff()
+        .expect("stale visual must leave the old handoff untouched");
+    assert_eq!(staged.relative_path, old_path);
+    assert!(controller.sample_view.wav.loaded_wav.is_none());
+    assert!(controller.sample_view.wav.loaded_audio.is_none());
+    assert!(controller.sample_view.waveform.decoded.is_none());
+    assert!(controller.ui.waveform.image.is_none());
+    assert!(controller.ui.waveform.transients.is_empty());
+}
+
+#[test]
+/// Explicit compare-anchor playback may load a target that is not browser-selected.
+fn compare_anchor_visual_completion_preserves_explicit_playback_target() {
+    let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
+        sample_entry("anchor.wav", Rating::NEUTRAL),
+        sample_entry("current.wav", Rating::NEUTRAL),
+    ]);
+    let anchor_path = Path::new("anchor.wav");
+    let current_path = Path::new("current.wav");
+    write_test_wav(&source.root.join(anchor_path), &[0.0, 0.25, -0.25, 0.5]);
+    controller.selection_state.ctx.selected_source = Some(source.id.clone());
+    controller.sample_view.wav.selected_wav = Some(current_path.to_path_buf());
+    controller
+        .runtime
+        .jobs
+        .set_pending_playback(Some(PendingPlayback {
+            source_id: source.id.clone(),
+            relative_path: anchor_path.to_path_buf(),
+            looped: false,
+            start_override: None,
+            force_loaded_audio: true,
+        }));
+
+    let outcome = decode_audio_outcome(&controller, &source, anchor_path);
+    let cache_token = outcome.decoded.cache_token;
+    controller.handle_audio_loaded(
+        PendingAudio {
+            request_id: 17,
+            source_id: source.id.clone(),
+            root: source.root.clone(),
+            relative_path: anchor_path.to_path_buf(),
+            intent: AudioLoadIntent::Selection,
+        },
+        outcome,
+    );
+    controller.handle_audio_visual_loaded(AudioVisualResult {
+        request_id: 17,
+        source_id: source.id.clone(),
+        relative_path: anchor_path.to_path_buf(),
+        metadata: controller
+            .current_file_metadata(&source, anchor_path)
+            .expect("metadata"),
+        cache_token,
+        transients: Arc::from(vec![0.2, 0.7]),
+        image: None,
+        projected_image: None,
+        render_meta: None,
+        stretched: false,
+    });
+
+    assert_eq!(
+        controller.sample_view.wav.loaded_wav.as_deref(),
+        Some(anchor_path)
+    );
+    assert_eq!(controller.ui.loaded_wav.as_deref(), Some(anchor_path));
+    assert_eq!(
+        controller.sample_view.wav.selected_wav.as_deref(),
+        Some(current_path)
+    );
+    assert!(controller.runtime.jobs.pending_playback().is_none());
 }

--- a/src/app/controller/library/wavs/audio_loading/completion.rs
+++ b/src/app/controller/library/wavs/audio_loading/completion.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use crate::app::controller::playback::telemetry::log_audio_start_stage;
+use std::path::Path;
 
 mod cache;
 mod error;
@@ -8,6 +9,24 @@ mod transients;
 mod visual;
 
 impl AppController {
+    pub(crate) fn audio_target_matches_current(
+        &self,
+        source_id: &crate::sample_sources::SourceId,
+        relative_path: &Path,
+    ) -> bool {
+        self.runtime
+            .jobs
+            .pending_playback()
+            .as_ref()
+            .is_some_and(|pending| {
+                pending.force_loaded_audio
+                    && pending.source_id == *source_id
+                    && pending.relative_path == relative_path
+            })
+            || (self.selection_state.ctx.selected_source.as_ref() == Some(source_id)
+                && self.sample_view.wav.selected_wav.as_deref() == Some(relative_path))
+    }
+
     pub(crate) fn handle_audio_loaded(&mut self, pending: PendingAudio, outcome: AudioLoadOutcome) {
         log_audio_start_stage(
             "handle_audio_loaded",

--- a/src/app/controller/library/wavs/audio_loading/completion/handoff.rs
+++ b/src/app/controller/library/wavs/audio_loading/completion/handoff.rs
@@ -56,6 +56,9 @@ impl AppController {
         let Some(staged) = self.runtime.jobs.staged_audio_handoff() else {
             return;
         };
+        if !self.audio_target_matches_current(&staged.source_id, &staged.relative_path) {
+            return;
+        }
         if staged.decoded.cache_token != cache_token {
             return;
         }

--- a/src/app/controller/library/wavs/audio_loading/completion/visual.rs
+++ b/src/app/controller/library/wavs/audio_loading/completion/visual.rs
@@ -46,6 +46,9 @@ impl AppController {
         &self,
         result: &AudioVisualResult,
     ) -> Option<ValidatedVisualHandoff> {
+        if !self.audio_target_matches_current(&result.source_id, &result.relative_path) {
+            return None;
+        }
         let staged = self.runtime.jobs.staged_audio_handoff()?;
         if staged.request_id != result.request_id
             || staged.source_id != result.source_id

--- a/src/app/controller/tests/waveform_nav_render/async_loading.rs
+++ b/src/app/controller/tests/waveform_nav_render/async_loading.rs
@@ -112,6 +112,7 @@ fn loading_flag_clears_after_audio_load() {
     controller.library.sources.push(source.clone());
     controller.selection_state.ctx.selected_source = Some(source.id.clone());
     let rel = PathBuf::from("load.wav");
+    controller.sample_view.wav.selected_wav = Some(rel.clone());
     write_test_wav(&source.root.join(&rel), &[0.0, 0.5, -0.5]);
     controller.set_wav_entries_for_tests(vec![sample_entry(
         "load.wav",


### PR DESCRIPTION
## Goal

Prevent an obsolete asynchronous waveform/audio result from replacing the waveform for the currently selected sample during rapid navigation, including extraction-adjacent deferred-selection windows.

## Scope and non-goals

This change adds current source/path identity fencing at primary audio completion, visual completion, and staged-handoff publication. It preserves latest-only cancellation, explicit compare-anchor playback, browser focus, and the existing responsive retained-image loading policy.

No source-processing, extraction, database, audio decoding, or worker scheduling behavior was changed. Broader lifecycle or cache architecture changes are out of scope.

## Definition of Done

- Primary, visual, and staged-handoff completions cannot publish a browser-owned result after selection identity changes.
- Explicit force-loaded compare-anchor playback still accepts its exact target without changing browser selection.
- Stale-result and rapid-selection regression coverage passes.
- UI-thread state remains guarded by the existing controller completion path.
- No obsolete waveform flash is introduced by the completion fence.
- User approval is required before merge.

## Validation

- `cargo test -p wavecrate --lib 'app::controller::library::background_jobs::polling::tests::audio' -- --test-threads=1`: 9 passed.
- `cargo test -p wavecrate --lib waveform_nav_render::async_loading -- --test-threads=1`: 5 passed.
- `cargo test -p wavecrate --lib compare_anchor -- --test-threads=1`: 12 passed.
- `git diff --check`: passed before commit.
- Independent Terra review of the complete diff: APPROVE, no findings.
- `cargo test -p wavecrate --lib`: parallel lane reported 4028 passed, 100 unrelated load-sensitive failures, and 27 ignored. A reproduced isolated failure reports source-manifest readiness revision drift (expected revision 2, found 4); the changed controller/audio lanes pass serially.

## Known limitations

Real-app rapid-navigation and extraction-adjacent runtime acceptance remain user-owned. The controller-level fences and regression fixtures cover the reviewed stale-result contract.

## Merge

This PR is ready for review. Explicit user approval is required before merge.