### PR TITLE
Refresh Finder-created folders incrementally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6127,6 +6127,8 @@ dependencies = [
  "base64",
  "bincode",
  "blake3",
+ "cap-fs-ext",
+ "cap-std",
  "chacha20poly1305",
  "criterion",
  "crossbeam-queue",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,8 @@ zip = { version = "2.2.1", default-features = false, features = ["deflate"] }
 keyring = "3.6.2"
 chacha20poly1305 = "0.10.1"
 base64 = "0.22.1"
+cap-fs-ext = "4.0.2"
+cap-std = "4.0.2"
 ed25519-dalek = "2.2.0"
 wavecrate-analysis = { path = "crates/wavecrate-analysis" }
 wavecrate-library = { path = "crates/wavecrate-library" }

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -450,6 +450,17 @@ pub(in crate::native_app) struct SourceFilesystemSyncSuccess {
     pub(in crate::native_app) committed_delta:
         wavecrate::sample_sources::scanner::CommittedSourceDelta,
     pub(in crate::native_app) browser_projection_delta: Option<BrowserProjectionDelta>,
+    pub(in crate::native_app) prepared_folder_projections: Vec<PreparedFolderProjection>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct PreparedFolderProjection {
+    pub(in crate::native_app) relative_path: PathBuf,
+    pub(in crate::native_app) snapshot_revision: u64,
+    /// `Some` is a worker-prepared no-follow subtree snapshot; `None` marks a
+    /// folder that was removed before the targeted sync completed.
+    pub(in crate::native_app) folder:
+        Option<crate::native_app::sample_library::folder_browser::FolderEntry>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -20,8 +20,9 @@ pub(in crate::native_app) use loading::{
 };
 pub(in crate::native_app) use message::{
     AudioOutputPersistResult, BrowserProjectionDelta, BrowserScrollSurface, GuiMessage,
-    MetadataMessage, SettingsMessage, SimilaritySettingsPersistResult, SourceFilesystemSyncResult,
-    SourceFilesystemSyncSuccess, TrashMoveTarget, VolumeSettingsPersistResult,
+    MetadataMessage, PreparedFolderProjection, SettingsMessage, SimilaritySettingsPersistResult,
+    SourceFilesystemSyncResult, SourceFilesystemSyncSuccess, TrashMoveTarget,
+    VolumeSettingsPersistResult,
 };
 pub(in crate::native_app) use progress::{
     FileMoveProgress, NormalizationFailure, NormalizationHarvestDerivation, NormalizationProgress,

--- a/src/native_app/sample_library/folder_browser.rs
+++ b/src/native_app/sample_library/folder_browser.rs
@@ -34,7 +34,7 @@ mod path_helpers;
 use path_helpers::{folder_label, path_id, path_id_matches, rewrite_path_id};
 
 mod folder_entry;
-use folder_entry::FolderEntry;
+pub(in crate::native_app) use folder_entry::FolderEntry;
 
 mod drag_drop;
 use drag_drop::{BrowserDragDropState, FolderBrowserDropTarget};
@@ -80,6 +80,7 @@ mod scanning;
 #[cfg(test)]
 use scanning::load_source_snapshot;
 use scanning::{file_entry, placeholder_folder};
+pub(in crate::native_app) use scanning::load_folder_at_path_with_browser_metadata;
 
 mod curation;
 mod harvest_filter;

--- a/src/native_app/sample_library/folder_browser/scanning.rs
+++ b/src/native_app/sample_library/folder_browser/scanning.rs
@@ -17,6 +17,7 @@ pub(in crate::native_app) use progress::INDEX_PROGRESS_REPORT_INTERVAL;
 #[cfg(test)]
 pub(in crate::native_app) use progress::scan_source_with_progress;
 pub(in crate::native_app) use progress::scan_source_with_progress_cancellable;
+pub(in crate::native_app) use traversal::load_folder_at_path_with_browser_metadata;
 pub(in crate::native_app) use traversal::refresh_folder_tree_only;
 pub(super) use traversal::{load_folder_at_path, load_source_snapshot, placeholder_folder};
 pub(in crate::native_app) use verification::verify_direct_folder;

--- a/src/native_app/sample_library/folder_browser/scanning/entry.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/entry.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
+use cap_std::fs::Dir;
 use wavecrate_library::sample_sources::{
     SourceDatabase, SourceEntryFileType, SourceEntryKind, SourceEntryProbeError,
     SourceTraversalPolicy, classify_source_entry_with_policy,
@@ -121,6 +122,65 @@ pub(super) fn read_sorted_entries(
     Some(entries)
 }
 
+pub(super) fn read_sorted_entries_nofollow(
+    directory: &Dir,
+    path: &Path,
+    source_root: &Path,
+    policy: SourceTraversalPolicy,
+    cancel: &AtomicBool,
+) -> Option<Vec<BrowserEntry>> {
+    if cancel.load(Ordering::Acquire) {
+        return None;
+    }
+    let relative_path = path.strip_prefix(source_root).unwrap_or(path);
+    if classify_source_entry_with_policy(relative_path, SourceEntryFileType::Directory, policy)
+        .visible_kind()
+        != Some(BrowserEntryKind::Directory)
+    {
+        return None;
+    }
+    let mut entries = Vec::new();
+    for entry in directory.read_dir(".").ok()? {
+        if cancel.load(Ordering::Acquire) {
+            return None;
+        }
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                tracing::warn!(directory = %path.display(), %error, "Failed to read browser directory entry");
+                continue;
+            }
+        };
+        let entry_path = path.join(entry.file_name());
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) => {
+                tracing::warn!(path = %entry_path.display(), %error, "Failed to read browser entry type without following links");
+                continue;
+            }
+        };
+        let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
+        if let Some(kind) = classify_source_entry_with_policy(
+            relative_path,
+            source_entry_cap_file_type(&file_type),
+            policy,
+        )
+        .visible_kind()
+        {
+            entries.push(BrowserEntry {
+                path: entry_path,
+                kind,
+            });
+        }
+    }
+    entries.sort_by(|a, b| {
+        file_label(&a.path)
+            .to_ascii_lowercase()
+            .cmp(&file_label(&b.path).to_ascii_lowercase())
+    });
+    Some(entries)
+}
+
 pub(super) fn source_traversal_policy(root: &Path, database_root: &Path) -> SourceTraversalPolicy {
     SourceDatabase::open_for_ui_read_with_database_root(root, database_root)
         .and_then(|db| db.source_traversal_policy())
@@ -128,6 +188,14 @@ pub(super) fn source_traversal_policy(root: &Path, database_root: &Path) -> Sour
 }
 
 fn source_entry_file_type(file_type: &FileType) -> SourceEntryFileType {
+    SourceEntryFileType::from_no_followed_type(
+        file_type.is_dir(),
+        file_type.is_file(),
+        file_type.is_symlink(),
+    )
+}
+
+fn source_entry_cap_file_type(file_type: &cap_std::fs::FileType) -> SourceEntryFileType {
     SourceEntryFileType::from_no_followed_type(
         file_type.is_dir(),
         file_type.is_file(),

--- a/src/native_app/sample_library/folder_browser/scanning/entry.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/entry.rs
@@ -1,6 +1,7 @@
 use std::{
     fs::{self, FileType},
     path::{Path, PathBuf},
+    sync::atomic::{AtomicBool, Ordering},
 };
 use wavecrate_library::sample_sources::{
     SourceDatabase, SourceEntryFileType, SourceEntryKind, SourceEntryProbeError,
@@ -47,7 +48,11 @@ pub(super) fn read_sorted_entries(
     path: &Path,
     source_root: &Path,
     policy: SourceTraversalPolicy,
+    cancel: Option<&AtomicBool>,
 ) -> Option<Vec<BrowserEntry>> {
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+        return None;
+    }
     let relative_path = path.strip_prefix(source_root).unwrap_or(path);
     if classify_source_entry_with_policy(relative_path, SourceEntryFileType::Directory, policy)
         .visible_kind()
@@ -66,45 +71,48 @@ pub(super) fn read_sorted_entries(
             return None;
         }
     };
-    let mut entries = read_dir
-        .filter_map(|entry| match entry {
-            Ok(entry) => Some(entry),
+    let mut entries = Vec::new();
+    for entry in read_dir {
+        if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+            return None;
+        }
+        let entry = match entry {
+            Ok(entry) => entry,
             Err(error) => {
                 tracing::warn!(
                     directory = %path.display(),
                     %error,
                     "Failed to read browser directory entry"
                 );
-                None
+                continue;
             }
-        })
-        .filter_map(|entry| {
-            let entry_path = entry.path();
-            match entry.file_type() {
-                Ok(file_type) => {
-                    let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
-                    classify_source_entry_with_policy(
-                        relative_path,
-                        source_entry_file_type(&file_type),
-                        policy,
-                    )
-                    .visible_kind()
-                    .map(|kind| BrowserEntry {
+        };
+        let entry_path = entry.path();
+        match entry.file_type() {
+            Ok(file_type) => {
+                let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
+                if let Some(kind) = classify_source_entry_with_policy(
+                    relative_path,
+                    source_entry_file_type(&file_type),
+                    policy,
+                )
+                .visible_kind()
+                {
+                    entries.push(BrowserEntry {
                         path: entry_path,
                         kind,
-                    })
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        path = %entry_path.display(),
-                        %error,
-                        "Failed to read browser entry type without following links"
-                    );
-                    None
+                    });
                 }
             }
-        })
-        .collect::<Vec<_>>();
+            Err(error) => {
+                tracing::warn!(
+                    path = %entry_path.display(),
+                    %error,
+                    "Failed to read browser entry type without following links"
+                );
+            }
+        }
+    }
     entries.sort_by(|a, b| {
         file_label(&a.path)
             .to_ascii_lowercase()

--- a/src/native_app/sample_library/folder_browser/scanning/traversal.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/traversal.rs
@@ -3,6 +3,8 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
+use cap_fs_ext::{DirExt, ambient_authority};
+use cap_std::fs::Dir;
 
 use wavecrate_library::sample_sources::BrowserFileMetadata;
 
@@ -15,6 +17,7 @@ use super::{
     },
     entry::{
         BrowserEntryKind, classify_path_without_following, read_sorted_entries,
+        read_sorted_entries_nofollow,
         source_traversal_policy,
     },
     file_entry_metadata::{file_entry, file_entry_with_snapshot_metadata},
@@ -111,7 +114,21 @@ pub(in crate::native_app) fn load_folder_at_path_with_browser_metadata(
     policy: wavecrate::sample_sources::SourceTraversalPolicy,
     cancel: &AtomicBool,
 ) -> Option<FolderEntry> {
-    load_folder_with_browser_metadata(path, source_root, metadata, policy, cancel)
+    let mut directory = Dir::open_ambient_dir(source_root, ambient_authority()).ok()?;
+    for component in path.strip_prefix(source_root).ok()?.components() {
+        let std::path::Component::Normal(component) = component else {
+            return None;
+        };
+        directory = directory.open_dir_nofollow(component).ok()?;
+    }
+    load_folder_with_browser_metadata(
+        &directory,
+        path,
+        source_root,
+        metadata,
+        policy,
+        cancel,
+    )
 }
 
 pub(super) fn load_folder(
@@ -140,6 +157,7 @@ pub(super) fn load_folder(
 }
 
 fn load_folder_with_browser_metadata(
+    directory: &Dir,
     path: &Path,
     source_root: &Path,
     metadata: &HashMap<PathBuf, BrowserFileMetadata>,
@@ -149,7 +167,7 @@ fn load_folder_with_browser_metadata(
     if cancel.load(Ordering::Acquire) {
         return None;
     }
-    let entries = read_sorted_entries(path, source_root, policy, Some(cancel))?;
+    let entries = read_sorted_entries_nofollow(directory, path, source_root, policy, cancel)?;
     let mut children = Vec::new();
     for entry in entries
         .iter()
@@ -158,7 +176,14 @@ fn load_folder_with_browser_metadata(
         if cancel.load(Ordering::Acquire) {
             return None;
         }
+        let Some(name) = entry.path.file_name() else {
+            return None;
+        };
+        let Ok(child_directory) = directory.open_dir_nofollow(name) else {
+            continue;
+        };
         let Some(child) = load_folder_with_browser_metadata(
+            &child_directory,
             &entry.path,
             source_root,
             metadata,

--- a/src/native_app/sample_library/folder_browser/scanning/traversal.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/traversal.rs
@@ -1,9 +1,9 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
+    sync::atomic::{AtomicBool, Ordering},
 };
 
-use wavecrate::sample_sources::BrowserMetadataSnapshot;
 use wavecrate_library::sample_sources::BrowserFileMetadata;
 
 use super::{
@@ -107,16 +107,11 @@ pub(in crate::native_app::sample_library::folder_browser) fn load_folder_at_path
 pub(in crate::native_app) fn load_folder_at_path_with_browser_metadata(
     path: &Path,
     source_root: &Path,
-    snapshot: &BrowserMetadataSnapshot,
+    metadata: &HashMap<PathBuf, BrowserFileMetadata>,
     policy: wavecrate::sample_sources::SourceTraversalPolicy,
+    cancel: &AtomicBool,
 ) -> Option<FolderEntry> {
-    let metadata = snapshot
-        .files
-        .iter()
-        .filter(|entry| !entry.missing)
-        .map(|entry| (entry.relative_path.clone(), entry.clone()))
-        .collect::<HashMap<_, _>>();
-    load_folder_with_browser_metadata(path, source_root, &metadata, policy)
+    load_folder_with_browser_metadata(path, source_root, metadata, policy, cancel)
 }
 
 pub(super) fn load_folder(
@@ -125,7 +120,7 @@ pub(super) fn load_folder(
     ratings: &SourceMetadataMap,
     policy: wavecrate_library::sample_sources::SourceTraversalPolicy,
 ) -> Option<FolderEntry> {
-    let entries = read_sorted_entries(path, source_root, policy)?;
+    let entries = read_sorted_entries(path, source_root, policy, None)?;
     let children = entries
         .iter()
         .filter(|entry| entry.kind == BrowserEntryKind::Directory)
@@ -149,38 +144,64 @@ fn load_folder_with_browser_metadata(
     source_root: &Path,
     metadata: &HashMap<PathBuf, BrowserFileMetadata>,
     policy: wavecrate::sample_sources::SourceTraversalPolicy,
+    cancel: &AtomicBool,
 ) -> Option<FolderEntry> {
-    let entries = read_sorted_entries(path, source_root, policy)?;
-    let children = entries
+    if cancel.load(Ordering::Acquire) {
+        return None;
+    }
+    let entries = read_sorted_entries(path, source_root, policy, Some(cancel))?;
+    let mut children = Vec::new();
+    for entry in entries
         .iter()
         .filter(|entry| entry.kind == BrowserEntryKind::Directory)
-        .filter_map(|entry| {
-            load_folder_with_browser_metadata(&entry.path, source_root, metadata, policy)
-        })
-        .collect::<Vec<_>>();
-    let files = entries
+    {
+        if cancel.load(Ordering::Acquire) {
+            return None;
+        }
+        let Some(child) = load_folder_with_browser_metadata(
+            &entry.path,
+            source_root,
+            metadata,
+            policy,
+            cancel,
+        ) else {
+            if cancel.load(Ordering::Acquire) {
+                return None;
+            }
+            continue;
+        };
+        children.push(child);
+    }
+    let mut files = Vec::new();
+    for entry in entries
         .iter()
         .filter(|entry| entry.kind == BrowserEntryKind::File)
-        .map(|entry| {
-            entry
-                .path
-                .strip_prefix(source_root)
-                .ok()
-                .and_then(|relative| metadata.get(relative))
-                .map(|metadata| {
-                    file_entry_with_snapshot_metadata(
-                        &entry.path,
-                        metadata.file_size,
-                        metadata.rating,
-                        metadata.locked,
-                        metadata.collections.clone(),
-                        metadata.last_played_at,
-                        metadata.last_curated_at,
-                    )
-                })
-                .unwrap_or_else(|| file_entry(&entry.path))
-        })
-        .collect::<Vec<_>>();
+    {
+        if cancel.load(Ordering::Acquire) {
+            return None;
+        }
+        let file = entry
+            .path
+            .strip_prefix(source_root)
+            .ok()
+            .and_then(|relative| metadata.get(relative))
+            .map(|metadata| {
+                file_entry_with_snapshot_metadata(
+                    &entry.path,
+                    metadata.file_size,
+                    metadata.rating,
+                    metadata.locked,
+                    metadata.collections.clone(),
+                    metadata.last_played_at,
+                    metadata.last_curated_at,
+                )
+            })
+            .unwrap_or_else(|| file_entry(&entry.path));
+        files.push(file);
+    }
+    if cancel.load(Ordering::Acquire) {
+        return None;
+    }
     Some(FolderEntry {
         id: path_id(path),
         name: folder_label(path),
@@ -195,7 +216,7 @@ fn load_folder_tree_only(
     policy: wavecrate_library::sample_sources::SourceTraversalPolicy,
     folder_count: &mut usize,
 ) -> Option<FolderEntry> {
-    let entries = read_sorted_entries(path, source_root, policy)?;
+    let entries = read_sorted_entries(path, source_root, policy, None)?;
     *folder_count += 1;
     let children = entries
         .iter()

--- a/src/native_app/sample_library/folder_browser/scanning/traversal.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/traversal.rs
@@ -1,4 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use wavecrate::sample_sources::BrowserMetadataSnapshot;
+use wavecrate_library::sample_sources::BrowserFileMetadata;
 
 use super::{
     super::{
@@ -11,6 +17,7 @@ use super::{
         BrowserEntryKind, classify_path_without_following, read_sorted_entries,
         source_traversal_policy,
     },
+    file_entry_metadata::{file_entry, file_entry_with_snapshot_metadata},
     metadata::{SourceMetadataMap, rated_file_entry, source_rating_map, source_rating_snapshot},
 };
 
@@ -94,6 +101,24 @@ pub(in crate::native_app::sample_library::folder_browser) fn load_folder_at_path
     load_folder(path, source_root, &ratings, policy)
 }
 
+/// Build a no-follow folder subtree from a worker-owned committed metadata
+/// snapshot. The UI completion path receives the resulting value and never
+/// reopens the filesystem or source database.
+pub(in crate::native_app) fn load_folder_at_path_with_browser_metadata(
+    path: &Path,
+    source_root: &Path,
+    snapshot: &BrowserMetadataSnapshot,
+    policy: wavecrate::sample_sources::SourceTraversalPolicy,
+) -> Option<FolderEntry> {
+    let metadata = snapshot
+        .files
+        .iter()
+        .filter(|entry| !entry.missing)
+        .map(|entry| (entry.relative_path.clone(), entry.clone()))
+        .collect::<HashMap<_, _>>();
+    load_folder_with_browser_metadata(path, source_root, &metadata, policy)
+}
+
 pub(super) fn load_folder(
     path: &Path,
     source_root: &Path,
@@ -110,6 +135,51 @@ pub(super) fn load_folder(
         .iter()
         .filter(|entry| entry.kind == BrowserEntryKind::File)
         .map(|entry| rated_file_entry(&entry.path, source_root, ratings))
+        .collect::<Vec<_>>();
+    Some(FolderEntry {
+        id: path_id(path),
+        name: folder_label(path),
+        children,
+        files,
+    })
+}
+
+fn load_folder_with_browser_metadata(
+    path: &Path,
+    source_root: &Path,
+    metadata: &HashMap<PathBuf, BrowserFileMetadata>,
+    policy: wavecrate::sample_sources::SourceTraversalPolicy,
+) -> Option<FolderEntry> {
+    let entries = read_sorted_entries(path, source_root, policy)?;
+    let children = entries
+        .iter()
+        .filter(|entry| entry.kind == BrowserEntryKind::Directory)
+        .filter_map(|entry| {
+            load_folder_with_browser_metadata(&entry.path, source_root, metadata, policy)
+        })
+        .collect::<Vec<_>>();
+    let files = entries
+        .iter()
+        .filter(|entry| entry.kind == BrowserEntryKind::File)
+        .map(|entry| {
+            entry
+                .path
+                .strip_prefix(source_root)
+                .ok()
+                .and_then(|relative| metadata.get(relative))
+                .map(|metadata| {
+                    file_entry_with_snapshot_metadata(
+                        &entry.path,
+                        metadata.file_size,
+                        metadata.rating,
+                        metadata.locked,
+                        metadata.collections.clone(),
+                        metadata.last_played_at,
+                        metadata.last_curated_at,
+                    )
+                })
+                .unwrap_or_else(|| file_entry(&entry.path))
+        })
         .collect::<Vec<_>>();
     Some(FolderEntry {
         id: path_id(path),

--- a/src/native_app/sample_library/folder_browser/scanning/verification.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/verification.rs
@@ -60,7 +60,7 @@ fn read_direct_folder_snapshot(
     {
         return DirectFolderSnapshot::Missing;
     }
-    let Some(entries) = read_sorted_entries(path, source_root, policy) else {
+    let Some(entries) = read_sorted_entries(path, source_root, policy, None) else {
         return DirectFolderSnapshot::Unavailable;
     };
     let child_paths = entries

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -60,24 +60,29 @@ impl FolderBrowserState {
         let Some(target_revision) = target_revision else {
             return false;
         };
-        if let Some(delta) = &delta {
-            if delta.manifest_revision <= current_revision {
-                return true;
-            }
-            let folder_snapshot_covers_delta =
-                folder_projections_cover_delta(&source_root, delta, &folder_projections);
-            let revision_is_contiguous =
-                delta.manifest_revision == current_revision.saturating_add(1);
-            if (!revision_is_contiguous && !folder_snapshot_covers_delta)
-                || delta.snapshot_revision != delta.manifest_revision
-            {
-                tracing::info!(
-                    source_id,
-                    current_revision,
-                    incoming_revision = delta.manifest_revision,
-                    "Browser projection revision gap requires a full snapshot refresh"
-                );
+        let apply_manifest_delta = if let Some(delta) = &delta {
+            if delta.manifest_revision < current_revision {
                 return false;
+            }
+            if delta.manifest_revision == current_revision {
+                false
+            } else {
+                let folder_snapshot_covers_delta =
+                    folder_projections_cover_delta(&source_root, delta, &folder_projections);
+                let revision_is_contiguous =
+                    delta.manifest_revision == current_revision.saturating_add(1);
+                if (!revision_is_contiguous && !folder_snapshot_covers_delta)
+                    || delta.snapshot_revision != delta.manifest_revision
+                {
+                    tracing::info!(
+                        source_id,
+                        current_revision,
+                        incoming_revision = delta.manifest_revision,
+                        "Browser projection revision gap requires a full snapshot refresh"
+                    );
+                    return false;
+                }
+                true
             }
         } else if target_revision != current_revision {
             tracing::info!(
@@ -87,7 +92,9 @@ impl FolderBrowserState {
                 "Folder projection snapshot is not at the current committed revision"
             );
             return false;
-        }
+        } else {
+            false
+        };
         if folder_projections
             .iter()
             .any(|projection| projection.snapshot_revision != target_revision)
@@ -131,7 +138,7 @@ impl FolderBrowserState {
                     }
                 }
             }
-            if let Some(delta) = &delta {
+            if apply_manifest_delta && let Some(delta) = &delta {
                 let removed = delta
                     .removed_file_ids
                     .iter()
@@ -155,7 +162,7 @@ impl FolderBrowserState {
             }
             changed
         };
-        if delta.is_some() {
+        if apply_manifest_delta {
             self.source.sources[source_index].projection_revision = Some(target_revision);
         }
         if changed {

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -22,6 +22,7 @@ impl FolderBrowserState {
             .and_then(|source| source.projection_revision)
     }
 
+    #[cfg(test)]
     pub(in crate::native_app) fn apply_committed_projection_delta(
         &mut self,
         source_id: &str,

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -11,7 +11,7 @@ use super::super::{
     },
     scanning::{merge_scan_discovery, placeholder_folder},
 };
-use crate::native_app::app::BrowserProjectionDelta;
+use crate::native_app::app::{BrowserProjectionDelta, PreparedFolderProjection};
 
 impl FolderBrowserState {
     pub(in crate::native_app) fn source_projection_revision(&self, source_id: &str) -> Option<u64> {
@@ -27,6 +27,15 @@ impl FolderBrowserState {
         source_id: &str,
         delta: BrowserProjectionDelta,
     ) -> bool {
+        self.apply_committed_projection(source_id, Some(delta), Vec::new())
+    }
+
+    pub(in crate::native_app) fn apply_committed_projection(
+        &mut self,
+        source_id: &str,
+        delta: Option<BrowserProjectionDelta>,
+        folder_projections: Vec<PreparedFolderProjection>,
+    ) -> bool {
         let Some(source_index) = self
             .source
             .sources
@@ -38,16 +47,50 @@ impl FolderBrowserState {
         let Some(current_revision) = self.source.sources[source_index].projection_revision else {
             return false;
         };
-        if delta.manifest_revision <= current_revision {
-            return true;
-        }
-        if delta.manifest_revision != current_revision.saturating_add(1) {
+        let source_root = self.source.sources[source_index].root.clone();
+        let target_revision = delta
+            .as_ref()
+            .map(|delta| delta.manifest_revision)
+            .or_else(|| {
+                folder_projections
+                    .first()
+                    .map(|projection| projection.snapshot_revision)
+            });
+        let Some(target_revision) = target_revision else {
+            return false;
+        };
+        if let Some(delta) = &delta {
+            if delta.manifest_revision <= current_revision {
+                return true;
+            }
+            let folder_snapshot_covers_delta =
+                folder_projections_cover_delta(&source_root, delta, &folder_projections);
+            let revision_is_contiguous =
+                delta.manifest_revision == current_revision.saturating_add(1);
+            if (!revision_is_contiguous && !folder_snapshot_covers_delta)
+                || delta.snapshot_revision != delta.manifest_revision
+            {
+                tracing::info!(
+                    source_id,
+                    current_revision,
+                    incoming_revision = delta.manifest_revision,
+                    "Browser projection revision gap requires a full snapshot refresh"
+                );
+                return false;
+            }
+        } else if target_revision != current_revision {
             tracing::info!(
                 source_id,
                 current_revision,
-                incoming_revision = delta.manifest_revision,
-                "Browser projection revision gap requires a full snapshot refresh"
+                snapshot_revision = target_revision,
+                "Folder projection snapshot is not at the current committed revision"
             );
+            return false;
+        }
+        if folder_projections
+            .iter()
+            .any(|projection| projection.snapshot_revision != target_revision)
+        {
             return false;
         }
         let selected = self.source.selected_source == source_id && self.source.selected_tree_loaded;
@@ -60,29 +103,60 @@ impl FolderBrowserState {
             let Some(root) = root else {
                 return false;
             };
-            let removed = delta
-                .removed_file_ids
-                .iter()
-                .cloned()
-                .collect::<HashSet<_>>();
-            let mut changed = root.remove_files_by_ids(&removed);
-            for folder in &delta.folders {
-                if root.ensure_folder_path(folder).is_none() {
-                    return false;
+            let mut changed = false;
+            for projection in &folder_projections {
+                let folder_path = PathBuf::from(&root.id).join(&projection.relative_path);
+                let folder_id = path_id(&folder_path);
+                match &projection.folder {
+                    Some(folder) => {
+                        if root.id == folder_id {
+                            changed |= *root != *folder;
+                            *root = folder.clone();
+                        } else {
+                            let Some(parent) = folder_path.parent() else {
+                                return false;
+                            };
+                            let Some(parent_folder) = root.find_mut(&path_id(parent)) else {
+                                return false;
+                            };
+                            changed |= super::super::scanning::upsert_folder(
+                                &mut parent_folder.children,
+                                folder.clone(),
+                            );
+                        }
+                    }
+                    None => {
+                        changed |= root.take_child_by_id(&folder_id).is_some();
+                    }
                 }
             }
-            for file in delta.upserted_files {
-                let Some(parent) = PathBuf::from(&file.id).parent().map(PathBuf::from) else {
-                    return false;
-                };
-                let Some(folder) = root.ensure_folder_path(&parent) else {
-                    return false;
-                };
-                changed |= folder.upsert_projected_file(file);
+            if let Some(delta) = &delta {
+                let removed = delta
+                    .removed_file_ids
+                    .iter()
+                    .cloned()
+                    .collect::<HashSet<_>>();
+                changed |= root.remove_files_by_ids(&removed);
+                for folder in &delta.folders {
+                    if root.ensure_folder_path(folder).is_none() {
+                        return false;
+                    }
+                }
+                for file in &delta.upserted_files {
+                    let Some(parent) = PathBuf::from(&file.id).parent().map(PathBuf::from) else {
+                        return false;
+                    };
+                    let Some(folder) = root.ensure_folder_path(&parent) else {
+                        return false;
+                    };
+                    changed |= folder.upsert_projected_file(file.clone());
+                }
             }
             changed
         };
-        self.source.sources[source_index].projection_revision = Some(delta.snapshot_revision);
+        if delta.is_some() {
+            self.source.sources[source_index].projection_revision = Some(target_revision);
+        }
         if changed {
             if selected {
                 self.retain_tree_state_after_selected_source_refresh();
@@ -584,6 +658,31 @@ impl FolderBrowserState {
         }
         changed
     }
+}
+
+fn folder_projections_cover_delta(
+    source_root: &std::path::Path,
+    delta: &BrowserProjectionDelta,
+    folder_projections: &[PreparedFolderProjection],
+) -> bool {
+    if folder_projections.is_empty() {
+        return false;
+    }
+    let covered = |path: &std::path::Path| {
+        folder_projections.iter().any(|projection| {
+            let projection_path = source_root.join(&projection.relative_path);
+            path == projection_path || path.starts_with(&projection_path)
+        })
+    };
+    delta
+        .upserted_files
+        .iter()
+        .all(|file| covered(std::path::Path::new(&file.id)))
+        && delta
+            .removed_file_ids
+            .iter()
+            .all(|file_id| covered(std::path::Path::new(file_id)))
+        && delta.folders.iter().all(|folder| covered(folder))
 }
 
 fn retained_source_entry(root: &std::path::Path) -> Option<SourceEntry> {

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::native_app::app::BrowserProjectionDelta;
+use crate::native_app::app::{BrowserProjectionDelta, PreparedFolderProjection};
 use crate::native_app::sample_library::folder_browser::model::file_entry_with_snapshot_metadata;
 use crate::native_app::sample_library::folder_browser::scan_types::{
     FolderScanDiscovery, FolderScanItem, MetadataHydrationStatus,
@@ -287,6 +287,65 @@ fn committed_projection_delta_applies_only_at_the_next_revision() {
         },
     ));
     assert!(browser.tree.folders[0].find_file(&path_id(&new)).is_some());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn equal_revision_applies_structural_projection_but_stale_revision_remains_fenced() {
+    let root = temp_source_root("wavecrate-gui-equal-revision-structural-projection");
+    let empty = root.join("empty");
+    fs::create_dir_all(&empty).expect("create empty folder");
+    let mut browser = FolderBrowserState::load_default();
+    let request = browser
+        .begin_add_source_path(root.clone(), 52)
+        .expect("initial scan");
+    let source_id = request.source_id.clone();
+    assert!(browser.apply_scan_finished(scan_source_with_progress(request, |_| {}, |_| {})));
+    let revision = browser
+        .source
+        .sources
+        .iter()
+        .find(|source| source.id == source_id)
+        .and_then(|source| source.projection_revision)
+        .expect("projection revision");
+    assert!(revision > 0);
+
+    assert!(browser.apply_committed_projection(
+        &source_id,
+        Some(BrowserProjectionDelta {
+            manifest_revision: revision,
+            snapshot_revision: revision,
+            folders: Vec::new(),
+            removed_file_ids: Vec::new(),
+            upserted_files: Vec::new(),
+        }),
+        vec![PreparedFolderProjection {
+            relative_path: std::path::PathBuf::from("empty"),
+            snapshot_revision: revision,
+            folder: None,
+        }],
+    ));
+    assert!(browser.find_folder(&path_id(&empty)).is_none());
+    assert_eq!(
+        browser
+            .source
+            .sources
+            .iter()
+            .find(|source| source.id == source_id)
+            .and_then(|source| source.projection_revision),
+        Some(revision)
+    );
+
+    assert!(!browser.apply_committed_projection_delta(
+        &source_id,
+        BrowserProjectionDelta {
+            manifest_revision: revision.saturating_sub(1),
+            snapshot_revision: revision.saturating_sub(1),
+            folders: Vec::new(),
+            removed_file_ids: Vec::new(),
+            upserted_files: Vec::new(),
+        },
+    ));
     let _ = fs::remove_dir_all(root);
 }
 

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning_symlinks.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning_symlinks.rs
@@ -1,6 +1,8 @@
 use super::super::FolderEntry;
 use super::*;
+use crate::native_app::sample_library::folder_browser::load_folder_at_path_with_browser_metadata;
 use std::os::unix::fs as unix_fs;
+use std::{collections::HashMap, sync::atomic::AtomicBool};
 
 struct SymlinkFixture {
     root: PathBuf,
@@ -99,6 +101,20 @@ fn source_scanning_initial_load_and_tree_refresh_skip_symlink_entries() {
         .find_folder(&path_id(&fixture.root))
         .expect("refreshed source root should remain available");
     fixture.assert_safe_tree(refreshed);
+}
+
+#[test]
+fn worker_projection_opens_directory_targets_without_following_links() {
+    let fixture = SymlinkFixture::new("wavecrate-browser-worker-symlink");
+    let folder = load_folder_at_path_with_browser_metadata(
+        &fixture.root,
+        &fixture.root,
+        &HashMap::new(),
+        wavecrate::sample_sources::SourceTraversalPolicy::default(),
+        &AtomicBool::new(false),
+    )
+    .expect("source root should project");
+    fixture.assert_safe_tree(&folder);
 }
 
 #[test]

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -147,14 +147,12 @@ impl NativeAppState {
                 let renames_reconciled = success.renames_reconciled;
                 let incomplete_error = success.incomplete_error;
                 let delta = success.committed_delta;
-                let browser_delta_applied = success
-                    .browser_projection_delta
-                    .map(|projection| {
-                        self.library
-                            .folder_browser
-                            .apply_committed_projection_delta(&source_id, projection)
-                    })
-                    .unwrap_or(false);
+                let browser_projection_applied =
+                    self.library.folder_browser.apply_committed_projection(
+                        &source_id,
+                        success.browser_projection_delta,
+                        success.prepared_folder_projections,
+                    );
                 self.reapply_desired_rating_overlay();
                 tracing::info!(
                     source_id = %source_id,
@@ -208,7 +206,7 @@ impl NativeAppState {
                         Instant::now(),
                         context,
                     );
-                } else if !browser_delta_applied {
+                } else if !browser_projection_applied {
                     self.queue_filesystem_source_refresh(
                         source_id,
                         SourceRefreshCause::ProjectionRevisionGap {

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
     thread,
@@ -317,11 +317,26 @@ fn prepare_folder_projections(
     let policy = db
         .source_traversal_policy()
         .map_err(|error| format!("read source traversal policy: {error}"))?;
-    let mut target_candidates = paths
+    let committed_manifest_paths = delta
+        .created
         .iter()
-        .filter(|path| path.is_relative())
-        .cloned()
-        .collect::<Vec<_>>();
+        .map(|entry| entry.relative_path.clone())
+        .chain(delta.changed.iter().map(|entry| entry.relative_path.clone()))
+        .chain(delta.deleted.iter().map(|entry| entry.relative_path.clone()))
+        .chain(delta.moved.iter().flat_map(|moved| {
+            [
+                moved.old_relative_path.clone(),
+                moved.new_relative_path.clone(),
+            ]
+        }))
+        .collect::<HashSet<_>>();
+    let mut target_candidates = Vec::new();
+    for path in paths.iter().filter(|path| path.is_relative()) {
+        target_candidates.push(path.clone());
+        if !committed_manifest_paths.contains(path) {
+            append_directory_ancestors(&mut target_candidates, path);
+        }
+    }
     for entry in &delta.deleted {
         append_directory_ancestors(&mut target_candidates, &entry.relative_path);
     }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -339,6 +339,7 @@ fn prepare_folder_projections(
                 {
                     Some(relative_path.clone())
                 }
+                Ok(_) => Some(relative_path.clone()),
                 _ => None,
             }
         })
@@ -372,7 +373,8 @@ fn prepare_folder_projections(
                 )
             }
             Err(SourceEntryProbeError::Missing) => None,
-            _ => continue,
+            Ok(_) => None,
+            Err(_) => continue,
         };
         projections.push(PreparedFolderProjection {
             relative_path,

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
     thread,
     time::Duration,
@@ -317,11 +317,22 @@ fn prepare_folder_projections(
     let policy = db
         .source_traversal_policy()
         .map_err(|error| format!("read source traversal policy: {error}"))?;
-    let mut targets = paths
+    let mut target_candidates = paths
         .iter()
         .filter(|path| path.is_relative())
+        .cloned()
+        .collect::<Vec<_>>();
+    for entry in &delta.deleted {
+        append_directory_ancestors(&mut target_candidates, &entry.relative_path);
+    }
+    for moved in &delta.moved {
+        append_directory_ancestors(&mut target_candidates, &moved.old_relative_path);
+        append_directory_ancestors(&mut target_candidates, &moved.new_relative_path);
+    }
+    let mut targets = target_candidates
+        .into_iter()
         .filter_map(|relative_path| {
-            match classify_path_without_following_with_policy(&root.join(relative_path), policy) {
+            match classify_path_without_following_with_policy(&root.join(&relative_path), policy) {
                 Ok(classification)
                     if classification.visible_kind() == Some(SourceEntryKind::Directory) =>
                 {
@@ -383,6 +394,17 @@ fn prepare_folder_projections(
         });
     }
     Ok(projections)
+}
+
+fn append_directory_ancestors(targets: &mut Vec<PathBuf>, relative_path: &Path) {
+    let mut ancestor = relative_path.parent();
+    while let Some(path) = ancestor {
+        if path.as_os_str().is_empty() {
+            break;
+        }
+        targets.push(path.to_path_buf());
+        ancestor = path.parent();
+    }
 }
 
 fn wait_for_retry(cancel: &AtomicBool, delay: Duration) -> bool {

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     path::PathBuf,
     sync::atomic::{AtomicBool, Ordering},
     thread,
@@ -7,7 +8,8 @@ use std::{
 
 use wavecrate::sample_sources::{BrowserMetadataSnapshot, SourceDatabase};
 use wavecrate_library::sample_sources::{
-    SourceEntryKind, SourceEntryProbeError, classify_path_without_following_with_policy,
+    BrowserFileMetadata, SourceEntryKind, SourceEntryProbeError,
+    classify_path_without_following_with_policy,
 };
 use wavecrate_scan::sample_sources::scanner::{
     self, ScanWritePhase, ScanWriter, UncoordinatedScanWriter,
@@ -179,6 +181,7 @@ fn sync_source_database_paths_once(
                     &db,
                     &paths,
                     &completed.committed_delta,
+                    cancel,
                 ) {
                     Ok(preparation) => preparation,
                     Err(error) => {
@@ -208,6 +211,7 @@ fn build_browser_projection_preparation(
     db: &SourceDatabase,
     paths: &[PathBuf],
     delta: &scanner::CommittedSourceDelta,
+    cancel: &AtomicBool,
 ) -> Result<(Option<BrowserProjectionDelta>, Vec<PreparedFolderProjection>), String> {
     let snapshot = db
         .browser_metadata_snapshot()
@@ -222,7 +226,14 @@ fn build_browser_projection_preparation(
     }
     let browser_projection_delta = (delta.revision > 0)
         .then(|| build_browser_projection_delta(root, &snapshot, delta));
-    let prepared_folder_projections = prepare_folder_projections(root, db, paths, &snapshot, delta)?;
+    let metadata = snapshot
+        .files
+        .iter()
+        .filter(|entry| !entry.missing)
+        .map(|entry| (entry.relative_path.clone(), entry.clone()))
+        .collect::<HashMap<PathBuf, BrowserFileMetadata>>();
+    let prepared_folder_projections =
+        prepare_folder_projections(root, db, paths, &metadata, &snapshot, delta, cancel)?;
     Ok((browser_projection_delta, prepared_folder_projections))
 }
 
@@ -298,8 +309,10 @@ fn prepare_folder_projections(
     root: &std::path::Path,
     db: &SourceDatabase,
     paths: &[PathBuf],
+    metadata: &HashMap<PathBuf, BrowserFileMetadata>,
     snapshot: &BrowserMetadataSnapshot,
     delta: &scanner::CommittedSourceDelta,
+    cancel: &AtomicBool,
 ) -> Result<Vec<PreparedFolderProjection>, String> {
     let policy = db
         .source_traversal_policy()
@@ -346,10 +359,16 @@ fn prepare_folder_projections(
             Ok(classification)
                 if classification.visible_kind() == Some(SourceEntryKind::Directory) => {
                 Some(
-                    load_folder_at_path_with_browser_metadata(&absolute_path, root, snapshot, policy)
-                        .ok_or_else(|| {
-                            format!("read folder projection: {}", absolute_path.display())
-                        })?,
+                    load_folder_at_path_with_browser_metadata(
+                        &absolute_path,
+                        root,
+                        metadata,
+                        policy,
+                        cancel,
+                    )
+                    .ok_or_else(|| {
+                        format!("read folder projection: {}", absolute_path.display())
+                    })?,
                 )
             }
             Err(SourceEntryProbeError::Missing) => None,

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -6,14 +6,21 @@ use std::{
 };
 
 use wavecrate::sample_sources::{BrowserMetadataSnapshot, SourceDatabase};
-use wavecrate_library::sample_sources::is_supported_audio;
+use wavecrate_library::sample_sources::{
+    SourceEntryKind, SourceEntryProbeError, classify_path_without_following_with_policy,
+};
 use wavecrate_scan::sample_sources::scanner::{
     self, ScanWritePhase, ScanWriter, UncoordinatedScanWriter,
 };
 
 use crate::native_app::{
-    app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
-    sample_library::folder_browser::model::file_entry_with_snapshot_metadata,
+    app::{
+        BrowserProjectionDelta, PreparedFolderProjection, SourceFilesystemSyncResult,
+        SourceFilesystemSyncSuccess,
+    },
+    sample_library::folder_browser::{
+        load_folder_at_path_with_browser_metadata, model::file_entry_with_snapshot_metadata,
+    },
 };
 
 const MAX_SYNC_ATTEMPTS: usize = 3;
@@ -118,7 +125,6 @@ fn sync_source_database_paths_once(
     cancel: &AtomicBool,
     writer: &impl ScanWriter,
 ) -> Result<SourceFilesystemSyncSuccess, String> {
-    let browser_delta_eligible = paths.iter().all(|path| is_supported_audio(path));
     let _writer = writer.lock(ScanWritePhase::Open);
     if cancel.load(Ordering::Acquire) {
         return Err(String::from(
@@ -165,49 +171,66 @@ fn sync_source_database_paths_once(
                     }
                 }
             };
-            let browser_projection_delta = if browser_delta_eligible
-                && incomplete_error.is_none()
-                && completed.committed_delta.revision > 0
+            let (browser_projection_delta, prepared_folder_projections) = if incomplete_error
+                .is_none()
             {
-                match build_browser_projection_delta(root, &db, &completed.committed_delta) {
-                    Ok(projection) => projection,
+                match build_browser_projection_preparation(
+                    root,
+                    &db,
+                    &paths,
+                    &completed.committed_delta,
+                ) {
+                    Ok(preparation) => preparation,
                     Err(error) => {
                         tracing::warn!(
                             source_id,
                             error,
                             "Falling back to a full browser projection after delta hydration failed"
                         );
-                        None
+                        (None, Vec::new())
                     }
                 }
             } else {
-                None
+                (None, Vec::new())
             };
             Ok(SourceFilesystemSyncSuccess {
                 renames_reconciled: completed.renames_reconciled,
                 incomplete_error,
                 committed_delta: completed.committed_delta,
                 browser_projection_delta,
+                prepared_folder_projections,
             })
         })
 }
 
-fn build_browser_projection_delta(
+fn build_browser_projection_preparation(
     root: &std::path::Path,
     db: &SourceDatabase,
+    paths: &[PathBuf],
     delta: &scanner::CommittedSourceDelta,
-) -> Result<Option<BrowserProjectionDelta>, String> {
-    let BrowserMetadataSnapshot { revision, files } = db
+) -> Result<(Option<BrowserProjectionDelta>, Vec<PreparedFolderProjection>), String> {
+    let snapshot = db
         .browser_metadata_snapshot()
         .map_err(|error| format!("read committed browser projection delta: {error}"))?;
-    if revision != delta.revision {
+    if delta.revision > 0 && snapshot.revision != delta.revision {
         tracing::info!(
             committed_revision = delta.revision,
-            snapshot_revision = revision,
-            "Browser delta snapshot was not the exact committed revision"
+            snapshot_revision = snapshot.revision,
+            "Browser projection snapshot was not the exact committed revision"
         );
-        return Ok(None);
+        return Ok((None, Vec::new()));
     }
+    let browser_projection_delta = (delta.revision > 0)
+        .then(|| build_browser_projection_delta(root, &snapshot, delta));
+    let prepared_folder_projections = prepare_folder_projections(root, db, paths, &snapshot, delta)?;
+    Ok((browser_projection_delta, prepared_folder_projections))
+}
+
+fn build_browser_projection_delta(
+    root: &std::path::Path,
+    snapshot: &BrowserMetadataSnapshot,
+    delta: &scanner::CommittedSourceDelta,
+) -> BrowserProjectionDelta {
     let upsert_paths = delta
         .created
         .iter()
@@ -226,7 +249,10 @@ fn build_browser_projection_delta(
         )
         .collect::<std::collections::HashSet<_>>();
     let mut folders = std::collections::BTreeSet::new();
-    let upserted_files = files
+    let upserted_files = snapshot
+        .files
+        .iter()
+        .cloned()
         .into_iter()
         .filter(|entry| !entry.missing && upsert_paths.contains(entry.relative_path.as_path()))
         .map(|entry| {
@@ -259,13 +285,83 @@ fn build_browser_projection_delta(
                 .to_string()
         }))
         .collect();
-    Ok(Some(BrowserProjectionDelta {
+    BrowserProjectionDelta {
         manifest_revision: delta.revision,
-        snapshot_revision: revision,
+        snapshot_revision: snapshot.revision,
         folders: folders.into_iter().collect(),
         removed_file_ids,
         upserted_files,
-    }))
+    }
+}
+
+fn prepare_folder_projections(
+    root: &std::path::Path,
+    db: &SourceDatabase,
+    paths: &[PathBuf],
+    snapshot: &BrowserMetadataSnapshot,
+    delta: &scanner::CommittedSourceDelta,
+) -> Result<Vec<PreparedFolderProjection>, String> {
+    let policy = db
+        .source_traversal_policy()
+        .map_err(|error| format!("read source traversal policy: {error}"))?;
+    let mut targets = paths
+        .iter()
+        .filter(|path| path.is_relative())
+        .filter_map(|relative_path| {
+            match classify_path_without_following_with_policy(&root.join(relative_path), policy) {
+                Ok(classification)
+                    if classification.visible_kind() == Some(SourceEntryKind::Directory) =>
+                {
+                    Some(relative_path.clone())
+                }
+                Err(SourceEntryProbeError::Missing)
+                    if snapshot
+                        .files
+                        .iter()
+                        .all(|entry| entry.relative_path != *relative_path)
+                        && delta
+                            .deleted
+                            .iter()
+                            .all(|entry| entry.relative_path != *relative_path) =>
+                {
+                    Some(relative_path.clone())
+                }
+                _ => None,
+            }
+        })
+        .collect::<Vec<_>>();
+    targets.sort();
+    targets.dedup();
+    let target_set = targets.clone();
+    targets.retain(|path| {
+        !target_set.iter().any(|ancestor| {
+            ancestor != path && path.starts_with(ancestor) && ancestor < path
+        })
+    });
+
+    let mut projections = Vec::new();
+    for relative_path in targets {
+        let absolute_path = root.join(&relative_path);
+        let folder = match classify_path_without_following_with_policy(&absolute_path, policy) {
+            Ok(classification)
+                if classification.visible_kind() == Some(SourceEntryKind::Directory) => {
+                Some(
+                    load_folder_at_path_with_browser_metadata(&absolute_path, root, snapshot, policy)
+                        .ok_or_else(|| {
+                            format!("read folder projection: {}", absolute_path.display())
+                        })?,
+                )
+            }
+            Err(SourceEntryProbeError::Missing) => None,
+            _ => continue,
+        };
+        projections.push(PreparedFolderProjection {
+            relative_path,
+            snapshot_revision: snapshot.revision,
+            folder,
+        });
+    }
+    Ok(projections)
 }
 
 fn wait_for_retry(cancel: &AtomicBool, delay: Duration) -> bool {
@@ -292,9 +388,12 @@ mod tests {
 
     #[test]
     fn filesystem_sync_panic_returns_a_terminal_result() {
-        let result = recover_source_filesystem_sync(String::from("source"), 17, 2, || {
-            panic!("simulated targeted sync panic")
-        });
+        let result = recover_source_filesystem_sync(
+            String::from("source"),
+            17,
+            2,
+            || panic!("simulated targeted sync panic"),
+        );
 
         assert_eq!(result.source_id, "source");
         assert_eq!(result.lifecycle_generation, 17);

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -456,3 +456,62 @@ fn source_filesystem_change_patches_new_folder_after_targeted_commit() {
         .iter()
         .any(|entry| entry.relative_path == Path::new("created-folder/nested/new.wav")));
 }
+
+#[cfg(unix)]
+#[test]
+fn source_filesystem_change_removes_folder_replaced_by_symlink() {
+    use std::os::unix::fs as unix_fs;
+
+    let source_root = tempfile::tempdir().expect("source root");
+    let replaced = source_root.path().join("replaced");
+    fs::create_dir_all(&replaced).expect("create replaced folder");
+    write_test_wav_i16(&replaced.join("old.wav"), &[0, 512, -512]);
+    let outside = tempfile::tempdir().expect("outside root");
+    write_test_wav_i16(&outside.path().join("outside.wav"), &[0, 1024, -1024]);
+
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 100)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let result = crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+        request,
+        |_| {},
+        |_| {},
+    );
+    state.finish_folder_scan(result, &mut ui::UiUpdateContext::default());
+    assert!(state
+        .library
+        .folder_browser
+        .folder_path(&replaced.to_string_lossy())
+        .is_some());
+
+    fs::remove_dir_all(&replaced).expect("remove replaced folder");
+    unix_fs::symlink(outside.path(), &replaced).expect("replace folder with symlink");
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
+            source_id,
+            paths: vec![PathBuf::from("replaced")],
+            overflowed: false,
+            source_root_available: true,
+            journal_checkpoint_event_id: None,
+        },
+        &mut context,
+    );
+    let sync_finished = crate::native_app::tests::run_worker_message_for_tests(
+        context.into_command(),
+        "gui-source-db-sync",
+    )
+    .expect("targeted source sync command");
+    state.apply_message(sync_finished, &mut ui::UiUpdateContext::default());
+
+    assert!(state
+        .library
+        .folder_browser
+        .folder_path(&replaced.to_string_lossy())
+        .is_none());
+    assert!(state.library.folder_progress().is_none());
+}

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -457,6 +457,354 @@ fn source_filesystem_change_patches_new_folder_after_targeted_commit() {
         .any(|entry| entry.relative_path == Path::new("created-folder/nested/new.wav")));
 }
 
+#[test]
+fn source_filesystem_change_renames_nested_folder_from_coalesced_descendant_events() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let old_folder = source_root.path().join("old-folder");
+    let old_nested = old_folder.join("nested");
+    fs::create_dir_all(&old_nested).expect("create old nested folder");
+    write_test_wav_i16(&old_nested.join("kick.wav"), &[0, 512, -512]);
+
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 100)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let result = crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+        request,
+        |_| {},
+        |_| {},
+    );
+    state.finish_folder_scan(result, &mut ui::UiUpdateContext::default());
+
+    let new_folder = source_root.path().join("new-folder");
+    fs::rename(&old_folder, &new_folder).expect("rename folder");
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
+            source_id: source_id.clone(),
+            paths: vec![
+                PathBuf::from("old-folder/nested/kick.wav"),
+                PathBuf::from("new-folder/nested/kick.wav"),
+            ],
+            overflowed: false,
+            source_root_available: true,
+            journal_checkpoint_event_id: None,
+        },
+        &mut context,
+    );
+    let sync_finished = crate::native_app::tests::run_worker_message_for_tests(
+        context.into_command(),
+        "gui-source-db-sync",
+    )
+    .expect("targeted source sync command");
+    state.apply_message(sync_finished, &mut ui::UiUpdateContext::default());
+
+    assert!(state.library.folder_progress().is_none());
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&old_folder.to_string_lossy())
+            .is_none()
+    );
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&new_folder.to_string_lossy())
+            .is_some()
+    );
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&new_folder.join("nested").to_string_lossy())
+            .is_some()
+    );
+    let db = wavecrate::sample_sources::SourceDatabase::open_for_test_fixture_source_write(
+        source_root.path(),
+    )
+    .expect("db");
+    let rows = db.list_files().expect("synced rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].relative_path,
+        Path::new("new-folder/nested/kick.wav")
+    );
+}
+
+#[test]
+fn source_filesystem_change_reparents_nested_folder_between_existing_parents() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let old_parent = source_root.path().join("old-parent");
+    let old_folder = old_parent.join("old-folder");
+    let old_nested = old_folder.join("nested");
+    let new_parent = source_root.path().join("new-parent");
+    fs::create_dir_all(&old_nested).expect("create old nested folder");
+    fs::create_dir_all(&new_parent).expect("create new parent folder");
+    write_test_wav_i16(&old_nested.join("kick.wav"), &[0, 512, -512]);
+
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 100)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let result = crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+        request,
+        |_| {},
+        |_| {},
+    );
+    state.finish_folder_scan(result, &mut ui::UiUpdateContext::default());
+
+    let new_folder = new_parent.join("new-folder");
+    fs::rename(&old_folder, &new_folder).expect("reparent and rename folder");
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
+            source_id: source_id.clone(),
+            paths: vec![
+                PathBuf::from("old-parent/old-folder/nested/kick.wav"),
+                PathBuf::from("new-parent/new-folder/nested/kick.wav"),
+            ],
+            overflowed: false,
+            source_root_available: true,
+            journal_checkpoint_event_id: None,
+        },
+        &mut context,
+    );
+    let sync_finished = crate::native_app::tests::run_worker_message_for_tests(
+        context.into_command(),
+        "gui-source-db-sync",
+    )
+    .expect("targeted source sync command");
+    state.apply_message(sync_finished, &mut ui::UiUpdateContext::default());
+
+    assert!(state.library.folder_progress().is_none());
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&old_parent.to_string_lossy())
+            .is_some()
+    );
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&old_folder.to_string_lossy())
+            .is_none()
+    );
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&new_parent.to_string_lossy())
+            .is_some()
+    );
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&new_folder.to_string_lossy())
+            .is_some()
+    );
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&new_folder.join("nested").to_string_lossy())
+            .is_some()
+    );
+    let db = wavecrate::sample_sources::SourceDatabase::open_for_test_fixture_source_write(
+        source_root.path(),
+    )
+    .expect("db");
+    let rows = db.list_files().expect("synced rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].relative_path,
+        Path::new("new-parent/new-folder/nested/kick.wav")
+    );
+}
+
+#[test]
+fn source_filesystem_change_removes_nested_folder_from_descendant_event() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let removed_folder = source_root.path().join("removed-folder");
+    let removed_nested = removed_folder.join("nested");
+    fs::create_dir_all(&removed_nested).expect("create removed nested folder");
+    write_test_wav_i16(&removed_nested.join("kick.wav"), &[0, 512, -512]);
+    write_test_wav_i16(&source_root.path().join("keep.wav"), &[0, 1024, -1024]);
+
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 100)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let result = crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+        request,
+        |_| {},
+        |_| {},
+    );
+    state.finish_folder_scan(result, &mut ui::UiUpdateContext::default());
+
+    fs::remove_dir_all(&removed_folder).expect("remove nested folder");
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
+            source_id,
+            paths: vec![PathBuf::from("removed-folder/nested/kick.wav")],
+            overflowed: false,
+            source_root_available: true,
+            journal_checkpoint_event_id: None,
+        },
+        &mut context,
+    );
+    let sync_finished = crate::native_app::tests::run_worker_message_for_tests(
+        context.into_command(),
+        "gui-source-db-sync",
+    )
+    .expect("targeted source sync command");
+    state.apply_message(sync_finished, &mut ui::UiUpdateContext::default());
+
+    assert!(state.library.folder_progress().is_none());
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&removed_folder.to_string_lossy())
+            .is_none()
+    );
+    let db = wavecrate::sample_sources::SourceDatabase::open_for_test_fixture_source_write(
+        source_root.path(),
+    )
+    .expect("db");
+    let rows = db.list_files().expect("synced rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].relative_path, Path::new("keep.wav"));
+    assert!(state
+        .library
+        .folder_browser
+        .selected_audio_files()
+        .iter()
+        .any(|file| file.name == "keep.wav"));
+}
+
+#[test]
+fn source_filesystem_change_removes_empty_folder_without_manifest_file_delta() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let empty_folder = source_root.path().join("empty-folder");
+    fs::create_dir_all(&empty_folder).expect("create empty folder");
+
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 100)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let result = crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+        request,
+        |_| {},
+        |_| {},
+    );
+    state.finish_folder_scan(result, &mut ui::UiUpdateContext::default());
+    let manifest_revision = state
+        .library
+        .folder_browser
+        .source_projection_revision(&source_id)
+        .expect("initial manifest revision");
+    assert!(manifest_revision > 0);
+    assert!(state
+        .library
+        .folder_browser
+        .folder_path(&empty_folder.to_string_lossy())
+        .is_some());
+    let db = wavecrate::sample_sources::SourceDatabase::open_for_test_fixture_source_write(
+        source_root.path(),
+    )
+    .expect("db");
+    let rows_before = db.list_files().expect("initial rows");
+
+    fs::remove_dir(&empty_folder).expect("remove empty folder");
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
+            source_id: source_id.clone(),
+            paths: vec![PathBuf::from("empty-folder")],
+            overflowed: false,
+            source_root_available: true,
+            journal_checkpoint_event_id: None,
+        },
+        &mut context,
+    );
+    let sync_finished = crate::native_app::tests::run_worker_message_for_tests(
+        context.into_command(),
+        "gui-source-db-sync",
+    )
+    .expect("targeted source sync command");
+    let committed_delta = match &sync_finished {
+        crate::native_app::test_support::state::GuiMessage::SourceFilesystemSyncFinished(result) => {
+            result
+                .result
+                .as_ref()
+                .expect("targeted source sync result")
+                .committed_delta
+                .clone()
+        }
+        message => panic!("expected source sync completion, got {message:?}"),
+    };
+    assert!(committed_delta.is_empty());
+    state.apply_message(sync_finished, &mut ui::UiUpdateContext::default());
+
+    assert!(state.library.folder_progress().is_none());
+    assert!(state
+        .library
+        .folder_browser
+        .folder_path(&empty_folder.to_string_lossy())
+        .is_none());
+    assert_eq!(
+        state
+            .library
+            .folder_browser
+            .source_projection_revision(&source_id),
+        Some(manifest_revision + 1)
+    );
+    let rows_after = db.list_files().expect("synced rows");
+    assert_eq!(rows_after.len(), rows_before.len());
+    assert_eq!(
+        rows_after
+            .iter()
+            .map(|row| row.relative_path.clone())
+            .collect::<Vec<_>>(),
+        rows_before
+            .iter()
+            .map(|row| row.relative_path.clone())
+            .collect::<Vec<_>>()
+    );
+
+    assert!(!state
+        .library
+        .folder_browser
+        .apply_committed_projection_delta(
+            &source_id,
+            crate::native_app::app::BrowserProjectionDelta {
+                manifest_revision: manifest_revision.saturating_sub(1),
+                snapshot_revision: manifest_revision.saturating_sub(1),
+                folders: Vec::new(),
+                removed_file_ids: Vec::new(),
+                upserted_files: Vec::new(),
+            },
+        ));
+}
+
 #[cfg(unix)]
 #[test]
 fn source_filesystem_change_removes_folder_replaced_by_symlink() {

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::native_app::app::SourceSelectionRequest;
+use std::path::Path;
 
 #[test]
 fn context_source_refresh_queues_scan_without_clearing_loaded_tree() {
@@ -384,4 +385,74 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
         vec!["keep.wav"],
         "the browser projection should refresh only from committed background state"
     );
+}
+
+#[test]
+fn source_filesystem_change_patches_new_folder_after_targeted_commit() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let existing = source_root.path().join("existing");
+    fs::create_dir_all(&existing).expect("create existing folder");
+    write_test_wav_i16(&existing.join("keep.wav"), &[0, 512, -512]);
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 100)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let result = crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+        request,
+        |_| {},
+        |_| {},
+    );
+    state.finish_folder_scan(result, &mut ui::UiUpdateContext::default());
+
+    let created = source_root.path().join("created-folder");
+    let nested = created.join("nested");
+    fs::create_dir_all(&nested).expect("create nested folder");
+    write_test_wav_i16(&nested.join("new.wav"), &[0, 1024, -1024]);
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
+            source_id: source_id.clone(),
+            paths: vec![PathBuf::from("created-folder")],
+            overflowed: false,
+            source_root_available: true,
+            journal_checkpoint_event_id: None,
+        },
+        &mut context,
+    );
+
+    let sync_finished = crate::native_app::tests::run_worker_message_for_tests(
+        context.into_command(),
+        "gui-source-db-sync",
+    )
+    .expect("targeted source sync command");
+    state.apply_message(sync_finished, &mut ui::UiUpdateContext::default());
+    assert!(
+        state
+            .library
+            .folder_progress()
+            .is_none(),
+        "a committed directory watcher event should not queue a source-wide folder scan"
+    );
+    assert!(state
+        .library
+        .folder_browser
+        .folder_path(&created.to_string_lossy())
+        .is_some());
+    assert!(state
+        .library
+        .folder_browser
+        .folder_path(&nested.to_string_lossy())
+        .is_some());
+    let db = wavecrate::sample_sources::SourceDatabase::open_for_test_fixture_source_write(
+        source_root.path(),
+    )
+    .expect("db");
+    assert!(db
+        .list_files()
+        .expect("synced rows")
+        .iter()
+        .any(|entry| entry.relative_path == Path::new("created-folder/nested/new.wav")));
 }

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -698,6 +698,67 @@ fn source_filesystem_change_removes_nested_folder_from_descendant_event() {
 }
 
 #[test]
+fn source_filesystem_change_removes_unsupported_only_nested_folder_from_descendant_event() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let removed_folder = source_root.path().join("removed-folder");
+    let removed_nested = removed_folder.join("nested");
+    fs::create_dir_all(&removed_nested).expect("create removed nested folder");
+    fs::write(removed_nested.join("notes.txt"), b"not an indexed sample")
+        .expect("write unsupported file");
+
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 100)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let result = crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+        request,
+        |_| {},
+        |_| {},
+    );
+    state.finish_folder_scan(result, &mut ui::UiUpdateContext::default());
+    assert!(state
+        .library
+        .folder_browser
+        .folder_path(&removed_folder.to_string_lossy())
+        .is_some());
+    let db = wavecrate::sample_sources::SourceDatabase::open_for_test_fixture_source_write(
+        source_root.path(),
+    )
+    .expect("db");
+    assert!(db.list_files().expect("initial rows").is_empty());
+
+    fs::remove_dir_all(&removed_folder).expect("remove nested folder");
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
+            source_id,
+            paths: vec![PathBuf::from("removed-folder/nested/notes.txt")],
+            overflowed: false,
+            source_root_available: true,
+            journal_checkpoint_event_id: None,
+        },
+        &mut context,
+    );
+    let sync_finished = crate::native_app::tests::run_worker_message_for_tests(
+        context.into_command(),
+        "gui-source-db-sync",
+    )
+    .expect("targeted source sync command");
+    state.apply_message(sync_finished, &mut ui::UiUpdateContext::default());
+
+    assert!(state.library.folder_progress().is_none());
+    assert!(state
+        .library
+        .folder_browser
+        .folder_path(&removed_folder.to_string_lossy())
+        .is_none());
+    assert!(db.list_files().expect("synced rows").is_empty());
+}
+
+#[test]
 fn source_filesystem_change_removes_empty_folder_without_manifest_file_delta() {
     let source_root = tempfile::tempdir().expect("source root");
     let empty_folder = source_root.path().join("empty-folder");


### PR DESCRIPTION
## Goal

Reflect Finder-created, duplicated, renamed, reparented, and removed folder changes in an already-added Wavecrate source promptly without a manual rescan or a heavy source-wide browser refresh.

## Scope

- Keep watcher debounce/coalescing, readiness, lifecycle fencing, no-follow traversal, bounded background processing, and overflow/full-refresh fallbacks intact.
- After a committed targeted source sync, prepare affected folder subtrees and committed browser metadata on the worker, then apply the prepared projection in memory on the UI thread.
- Derive missing directory ancestors from committed deleted/moved entries and unrepresented raw watcher paths so descendant-only Finder events retire stale folder nodes and cross-parent renames reparent correctly.
- Allow an exact structural folder projection at the current manifest revision while fencing older revisions.
- Non-goals: watcher backend redesign, source-processing policy changes, merge.

## Definition of Done

- Nested newly created/duplicated folders appear through targeted sync without a source-wide folder scan.
- External folder rename/reparent and deletion remove stale nodes and show the current tree placement, including nested content and descendant/coalesced event paths.
- Empty/non-audio-only folder deletion is reflected without a source-wide scan.
- UI completion performs no filesystem or SQLite reads.
- Cancellation, coalesced targets, metadata snapshots, no-follow traversal, revision gaps, incomplete work, stale lifecycle completions, symlink replacement, and watcher overflow retain safe behavior.

## Validation

- cargo check --locked --lib — passed.
- cargo test --locked --lib source_filesystem_change_ -- --nocapture — 10 passed.
- cargo test --locked --lib native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::tests:: -- --nocapture — 6 passed.
- cargo test --locked --lib native_app::sample_library::source_watcher:: -- --nocapture — 34 passed.
- cargo test --locked --lib native_app::sample_library::folder_browser::tests::source_scanning -- --nocapture — 23 passed.
- cargo test --locked -p wavecrate-scan --lib targeted_sync — 25 passed.
- git diff --check — passed.
- cargo fmt --all -- --check remains red on unrelated pre-existing workspace formatting; no formatter changes were applied.

## Known limitations

The current Finder/native-app run confirmed creation/duplication. A fresh real-app acceptance pass for external rename, cross-parent move, and deletion is still recommended; the successful targeted path should converge after the existing 400 ms watcher debounce without source-wide folder progress. Ambiguous/overflow/revision-gap events retain conservative full-refresh fallback.

User approval is required before merge.
