### PR TITLE
Bound Playmark extraction reconciliation to committed projections

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -56,9 +56,9 @@ pub use pending_renames::{PendingRenameDiagnostics, PendingRenameEntry, PendingR
 pub use rename_metadata::RenameMetadataSnapshot;
 pub use types::{
     BrowserFileMetadata, BrowserMetadataCursor, BrowserMetadataPage, BrowserMetadataSnapshot,
-    Rating, SampleCollection, SampleSoundType, SourceIndexClassification, SourceIndexDiagnostic,
-    SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage,
-    WavEntry,
+    ExistingFileMetadataUpdate, Rating, SampleCollection, SampleSoundType,
+    SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot,
+    SourceManifestEntry, SourceTag, SourceTagUsage, WavEntry,
 };
 pub use util::normalize_relative_path;
 pub use write::{

--- a/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
@@ -227,6 +227,148 @@ impl SourceDatabase {
         browser_metadata_snapshot_with_observer(self, || {})
     }
 
+    /// Fetch browser metadata for exact source-relative paths at one committed revision.
+    ///
+    /// The query is bounded by `paths` and fails closed when another writer advances the source
+    /// revision before the read begins. It is the committed-mutation counterpart to the full
+    /// browser snapshot and must not be replaced with a source-wide materialization.
+    pub fn browser_metadata_for_paths_at_revision(
+        &self,
+        expected_revision: u64,
+        paths: &[std::path::PathBuf],
+    ) -> Result<BrowserMetadataSnapshot, SourceDbError> {
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(map_sql_error)?;
+        let revision = transaction
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'revision'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+            .transpose()?
+            .unwrap_or_default();
+        if revision != expected_revision {
+            return Err(SourceDbError::Unexpected);
+        }
+        if paths.is_empty() {
+            return Ok(BrowserMetadataSnapshot {
+                revision,
+                files: Vec::new(),
+            });
+        }
+
+        let wav_columns = super::super::schema::table_columns(&transaction, "wav_files")?;
+        let collection_columns =
+            super::super::schema::table_columns(&transaction, "wav_file_collections")?;
+        let memberships_available =
+            collection_columns.contains("path") && collection_columns.contains("collection");
+        let supported_filter = if wav_columns.contains("extension") {
+            crate::sample_sources::supported_audio_where_clause()
+        } else {
+            String::from(
+                "lower(path) GLOB '*.wav' AND path NOT GLOB '._*' AND path NOT GLOB '*/._*'",
+            )
+        };
+        let legacy_collection =
+            optional_browser_column(&wav_columns, "collection", "NULL AS collection");
+        let placeholders = (1..=paths.len())
+            .map(|index| format!("?{index}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT path, {}, {}, {}, {}, {legacy_collection}, {}, {}, {}
+             FROM wav_files
+             WHERE {supported_filter} AND path IN ({placeholders})
+             ORDER BY path ASC",
+            optional_browser_column(&wav_columns, "tag", "0 AS tag"),
+            optional_browser_column(&wav_columns, "locked", "0 AS locked"),
+            optional_browser_column(&wav_columns, "last_played_at", "NULL AS last_played_at"),
+            optional_browser_column(&wav_columns, "last_curated_at", "NULL AS last_curated_at"),
+            optional_browser_column(&wav_columns, "file_size", "0 AS file_size"),
+            optional_browser_column(&wav_columns, "modified_ns", "0 AS modified_ns"),
+            optional_browser_column(&wav_columns, "missing", "0 AS missing"),
+        );
+        let raw_paths = paths
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        let mut statement = transaction.prepare(&sql).map_err(map_sql_error)?;
+        let rows = statement
+            .query_map(rusqlite::params_from_iter(raw_paths.iter()), |row| {
+                let Some(relative_path) = decode_relative_path(
+                    row.get(0)?,
+                    "Skipping browser metadata row with invalid relative path",
+                )?
+                else {
+                    return Ok(None);
+                };
+                let legacy_collection = if memberships_available {
+                    Vec::new()
+                } else {
+                    row.get::<_, Option<i64>>(5)?
+                        .and_then(SampleCollection::from_i64)
+                        .into_iter()
+                        .collect()
+                };
+                Ok(Some((
+                    row.get::<_, String>(0)?,
+                    BrowserFileMetadata {
+                        relative_path,
+                        file_size: u64::try_from(row.get::<_, i64>(6)?).unwrap_or_default(),
+                        modified_ns: row.get(7)?,
+                        missing: row.get::<_, i64>(8)? != 0,
+                        rating: Rating::from_i64(row.get(1)?),
+                        locked: row.get::<_, i64>(2)? != 0,
+                        collections: legacy_collection,
+                        last_played_at: row.get(3)?,
+                        last_curated_at: row.get(4)?,
+                    },
+                )))
+            })
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        drop(statement);
+
+        let mut files = rows.into_iter().map(|(_, file)| file).collect::<Vec<_>>();
+        if memberships_available && !files.is_empty() {
+            let placeholders = (1..=raw_paths.len())
+                .map(|index| format!("?{index}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "SELECT path, collection FROM wav_file_collections WHERE path IN ({placeholders}) ORDER BY path ASC, collection ASC"
+            );
+            let mut statement = transaction.prepare(&sql).map_err(map_sql_error)?;
+            let memberships = statement
+                .query_map(rusqlite::params_from_iter(raw_paths.iter()), |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                })
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?;
+            let mut by_path = HashMap::<String, Vec<SampleCollection>>::new();
+            for (path, collection) in memberships {
+                if let Some(collection) = SampleCollection::from_i64(collection) {
+                    by_path.entry(path).or_default().push(collection);
+                }
+            }
+            for file in &mut files {
+                let raw_path = file.relative_path.to_string_lossy().into_owned();
+                file.collections = by_path.remove(&raw_path).unwrap_or_default();
+            }
+        }
+        Ok(BrowserMetadataSnapshot { revision, files })
+    }
+
     /// Fetch one bounded browser metadata page at an exact source revision.
     ///
     /// `after_cursor` is an exclusive raw-SQL keyset cursor. A revision mismatch fails closed so pages

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -112,6 +112,33 @@ fn browser_metadata_page_advances_past_invalid_raw_path_rows() {
 }
 
 #[test]
+fn browser_metadata_for_paths_is_exact_and_revision_fenced() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+    db.upsert_file(Path::new("one.wav"), 10, 5).unwrap();
+    db.upsert_file(Path::new("two.wav"), 20, 6).unwrap();
+    db.set_tag(Path::new("one.wav"), Rating::KEEP_1).unwrap();
+    let revision = db.get_revision().unwrap();
+
+    let snapshot = db
+        .browser_metadata_for_paths_at_revision(
+            revision,
+            &[PathBuf::from("one.wav"), PathBuf::from("not-indexed.wav")],
+        )
+        .unwrap();
+    assert_eq!(snapshot.revision, revision);
+    assert_eq!(snapshot.files.len(), 1);
+    assert_eq!(snapshot.files[0].relative_path, PathBuf::from("one.wav"));
+    assert_eq!(snapshot.files[0].rating, Rating::KEEP_1);
+
+    db.set_tag(Path::new("two.wav"), Rating::new(2)).unwrap();
+    assert!(
+        db.browser_metadata_for_paths_at_revision(revision, &[PathBuf::from("one.wav")])
+            .is_err()
+    );
+}
+
+#[test]
 fn browser_metadata_snapshot_has_constant_statement_count_for_large_sources() {
     let dir = tempdir().unwrap();
     let mut db = SourceDatabase::open_for_source_write(dir.path()).unwrap();

--- a/crates/wavecrate-library/src/sample_sources/db/types.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/types.rs
@@ -323,6 +323,15 @@ pub struct BrowserMetadataPage {
     pub next_cursor: Option<BrowserMetadataCursor>,
 }
 
+/// Whether an existing live source row accepted a metadata-only update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExistingFileMetadataUpdate {
+    /// The live row was updated without changing path or identity revisions.
+    Updated,
+    /// No live row exists yet; the caller must order the update after authoritative creation.
+    Missing,
+}
+
 /// Authoritative identity facts for one live source-manifest row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceManifestEntry {

--- a/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
@@ -6,7 +6,9 @@ use std::{
 use rusqlite::{OptionalExtension, params};
 
 use super::super::util::map_sql_error;
-use super::super::{Rating, SampleSoundType, SourceDbError, SourceWriteBatch};
+use super::super::{
+    ExistingFileMetadataUpdate, Rating, SampleSoundType, SourceDbError, SourceWriteBatch,
+};
 use super::command::{SourceContentHashWrite, SourceFileWrite, SourceTagWrite};
 use super::mutation::{
     update_flag_statement, update_path_i64_statement, update_path_null_statement,
@@ -31,6 +33,31 @@ const CLEAR_LAST_CURATED_AT_SQL: &str =
     "UPDATE wav_files SET last_curated_at = NULL WHERE path = ?1";
 
 impl<'conn> SourceWriteBatch<'conn> {
+    /// Update filesystem facts for an existing live row without inserting or dirtying path or
+    /// identity revisions.
+    pub fn update_existing_file_metadata(
+        &mut self,
+        relative_path: &Path,
+        file_size: u64,
+        modified_ns: i64,
+    ) -> Result<ExistingFileMetadataUpdate, SourceDbError> {
+        let updated = self.tx.execute(
+            "UPDATE wav_files
+                 SET file_size = ?1, modified_ns = ?2, missing = 0
+                 WHERE path = ?3 AND missing = 0",
+            rusqlite::params![
+                file_size as i64,
+                modified_ns,
+                relative_path.to_string_lossy()
+            ],
+        )?;
+        Ok(if updated == 0 {
+            ExistingFileMetadataUpdate::Missing
+        } else {
+            ExistingFileMetadataUpdate::Updated
+        })
+    }
+
     pub(super) fn apply_file_write(
         &mut self,
         write: SourceFileWrite<'_>,

--- a/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
@@ -33,6 +33,32 @@ const CLEAR_LAST_CURATED_AT_SQL: &str =
     "UPDATE wav_files SET last_curated_at = NULL WHERE path = ?1";
 
 impl<'conn> SourceWriteBatch<'conn> {
+    /// Check that an existing live row is present without changing scanner-owned facts.
+    ///
+    /// Auxiliary metadata writers use this guard in their own transaction so a stale file
+    /// observation cannot overwrite the manifest's size, mtime, or missing state while an
+    /// external scanner update is racing with the write.
+    pub fn ensure_existing_live_file(
+        &self,
+        relative_path: &Path,
+    ) -> Result<ExistingFileMetadataUpdate, SourceDbError> {
+        let exists = self
+            .tx
+            .query_row(
+                "SELECT 1 FROM wav_files WHERE path = ?1 AND missing = 0 LIMIT 1",
+                [relative_path.to_string_lossy().as_ref()],
+                |_| Ok(()),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .is_some();
+        Ok(if exists {
+            ExistingFileMetadataUpdate::Updated
+        } else {
+            ExistingFileMetadataUpdate::Missing
+        })
+    }
+
     /// Update filesystem facts for an existing live row without inserting or dirtying path or
     /// identity revisions.
     pub fn update_existing_file_metadata(

--- a/crates/wavecrate-library/src/sample_sources/db/write/tests/revision.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/tests/revision.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use tempfile::tempdir;
 
-use super::super::super::{Rating, SampleSoundType, SourceDatabase};
+use super::super::super::{ExistingFileMetadataUpdate, Rating, SampleSoundType, SourceDatabase};
 use super::helpers::{revision_value, wav_paths_revision_value};
 
 #[test]
@@ -134,4 +134,36 @@ fn metadata_wrapper_uses_batch_revision_policy_without_wav_path_churn() {
     );
     assert_eq!(revision_value(&db), 1);
     assert_eq!(wav_paths_revision_value(&db), 0);
+}
+
+#[test]
+fn existing_file_metadata_update_is_revision_neutral_and_defers_missing_rows() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+    let path = Path::new("one.wav");
+    db.upsert_file(path, 10, 5).unwrap();
+    let revision = revision_value(&db);
+
+    let mut batch = db.write_batch().unwrap();
+    assert_eq!(
+        batch.update_existing_file_metadata(path, 20, 7).unwrap(),
+        ExistingFileMetadataUpdate::Updated
+    );
+    batch.commit_auxiliary_state().unwrap();
+
+    assert_eq!(revision_value(&db), revision);
+    let entry = db.entry_for_path(path).unwrap().unwrap();
+    assert_eq!(entry.file_size, 20);
+    assert_eq!(entry.modified_ns, 7);
+
+    let missing = Path::new("missing.wav");
+    let mut batch = db.write_batch().unwrap();
+    assert_eq!(
+        batch.update_existing_file_metadata(missing, 30, 9).unwrap(),
+        ExistingFileMetadataUpdate::Missing
+    );
+    batch.commit_auxiliary_state().unwrap();
+
+    assert_eq!(revision_value(&db), revision);
+    assert!(db.entry_for_path(missing).unwrap().is_none());
 }

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -18,11 +18,11 @@ pub use audio_support::{
 pub use db::normalize_relative_path;
 pub use db::{
     BrowserFileMetadata, BrowserMetadataCursor, BrowserMetadataPage, BrowserMetadataSnapshot,
-    DB_FILE_NAME, ManifestCommitResult, Rating, SampleCollection, SourceCollectionWrite,
-    SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole, SourceDbError,
-    SourceFileWrite, SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry,
-    SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage, SourceTagWrite,
-    SourceWriteCommand, WavEntry,
+    DB_FILE_NAME, ExistingFileMetadataUpdate, ManifestCommitResult, Rating, SampleCollection,
+    SourceCollectionWrite, SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
+    SourceDbError, SourceFileWrite, SourceIndexClassification, SourceIndexDiagnostic,
+    SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage,
+    SourceTagWrite, SourceWriteCommand, WavEntry,
 };
 pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::sample_sources::db::ExistingFileMetadataUpdate;
 use crate::sample_sources::{Rating, SourceDatabase};
 use std::path::Path;
 use std::time::Duration;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/hard_rescan.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/hard_rescan.rs
@@ -21,6 +21,42 @@ fn hard_rescan_prunes_missing_rows() {
 }
 
 #[test]
+fn auxiliary_metadata_write_does_not_hide_external_content_change() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("one.wav");
+    std::fs::write(&file_path, b"before").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let before = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+
+    // An external edit races with a revision-neutral auxiliary write. The latter must only guard
+    // live-row existence; scanner-owned size/mtime/hash facts remain untouched for reconciliation.
+    std::fs::write(&file_path, b"after with different content").unwrap();
+    let aux =
+        SourceDatabase::open_for_user_metadata_write_with_database_root(dir.path(), dir.path())
+            .unwrap();
+    let mut batch = aux.write_batch().unwrap();
+    assert!(matches!(
+        batch
+            .ensure_existing_live_file(Path::new("one.wav"))
+            .unwrap(),
+        ExistingFileMetadataUpdate::Updated
+    ));
+    batch.set_tag(Path::new("one.wav"), Rating::KEEP_1).unwrap();
+    batch.commit_auxiliary_state().unwrap();
+
+    let after_aux = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+    assert_eq!(after_aux.file_size, before.file_size);
+    assert_eq!(after_aux.modified_ns, before.modified_ns);
+    let stats = hard_rescan(&db).unwrap();
+    assert_eq!(stats.committed_delta.changed.len(), 1);
+    assert_eq!(
+        stats.committed_delta.changed[0].relative_path,
+        Path::new("one.wav")
+    );
+}
+
+#[test]
 fn hard_rescan_prunes_missing_files_with_tags() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("one.wav");

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -450,6 +450,8 @@ pub(in crate::native_app) struct SourceFilesystemSyncSuccess {
     pub(in crate::native_app) committed_delta:
         wavecrate::sample_sources::scanner::CommittedSourceDelta,
     pub(in crate::native_app) browser_projection_delta: Option<BrowserProjectionDelta>,
+    pub(in crate::native_app) projection_handoff_ticket:
+        Option<crate::native_app::source_processing::ProjectionHandoffTicket>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/native_app/audio/playback_history/worker.rs
+++ b/src/native_app/audio/playback_history/worker.rs
@@ -1,11 +1,9 @@
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::{cell::RefCell, collections::HashMap, path::PathBuf};
+
+#[cfg(test)]
+use std::path::Path;
 
 use wavecrate::sample_sources::{ExistingFileMetadataUpdate, SourceDatabase};
-use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 use crate::native_app::audio::playback_history::LastPlayedPersistResult;
 
@@ -38,11 +36,18 @@ pub(super) fn persist_last_played(request: LastPlayedPersistRequest) -> LastPlay
 }
 
 fn persist_last_played_inner(request: &LastPlayedPersistRequest) -> Result<(), String> {
-    let (file_size, modified_ns) =
-        file_metadata(&request.source_root.join(&request.relative_path))?;
-    with_playback_history_source_db(request, |db| {
-        persist_last_played_with_db(db, request, file_size, modified_ns)
-    })
+    with_playback_history_source_db(request, |db| persist_last_played_with_db(db, request))
+}
+
+#[cfg(test)]
+fn file_metadata(path: &Path) -> Result<(u64, i64), String> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
+    let modified_ns = metadata
+        .modified()
+        .map(wavecrate_library::timestamps::system_time_to_unix_nanos)
+        .map_err(|err| format!("Missing modified time for {}: {err}", path.display()))?;
+    Ok((metadata.len(), modified_ns))
 }
 
 fn with_playback_history_source_db<T>(
@@ -73,13 +78,11 @@ fn with_playback_history_source_db<T>(
 fn persist_last_played_with_db(
     db: &SourceDatabase,
     request: &LastPlayedPersistRequest,
-    file_size: u64,
-    modified_ns: i64,
 ) -> Result<(), String> {
     let mut batch = db.write_batch().map_err(|err| err.to_string())?;
     if matches!(
         batch
-            .update_existing_file_metadata(&request.relative_path, file_size, modified_ns)
+            .ensure_existing_live_file(&request.relative_path)
             .map_err(|err| err.to_string())?,
         ExistingFileMetadataUpdate::Missing
     ) {
@@ -94,17 +97,6 @@ fn persist_last_played_with_db(
     batch
         .commit_auxiliary_state()
         .map_err(|err| err.to_string())
-}
-
-fn file_metadata(path: &Path) -> Result<(u64, i64), String> {
-    let metadata = std::fs::metadata(path)
-        .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
-    let modified_ns = system_time_to_unix_nanos(
-        metadata
-            .modified()
-            .map_err(|err| format!("Missing modified time for {}: {err}", path.display()))?,
-    );
-    Ok((metadata.len(), modified_ns))
 }
 
 #[cfg(test)]

--- a/src/native_app/audio/playback_history/worker.rs
+++ b/src/native_app/audio/playback_history/worker.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use wavecrate::sample_sources::SourceDatabase;
+use wavecrate::sample_sources::{ExistingFileMetadataUpdate, SourceDatabase};
 use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 use crate::native_app::audio::playback_history::LastPlayedPersistResult;
@@ -77,13 +77,23 @@ fn persist_last_played_with_db(
     modified_ns: i64,
 ) -> Result<(), String> {
     let mut batch = db.write_batch().map_err(|err| err.to_string())?;
-    batch
-        .upsert_file(&request.relative_path, file_size, modified_ns)
-        .map_err(|err| err.to_string())?;
+    if matches!(
+        batch
+            .update_existing_file_metadata(&request.relative_path, file_size, modified_ns)
+            .map_err(|err| err.to_string())?,
+        ExistingFileMetadataUpdate::Missing
+    ) {
+        return Err(format!(
+            "playback persistence deferred until source row exists: {}",
+            request.relative_path.display()
+        ));
+    }
     batch
         .set_last_played_at(&request.relative_path, request.played_at)
         .map_err(|err| err.to_string())?;
-    batch.commit().map_err(|err| err.to_string())
+    batch
+        .commit_auxiliary_state()
+        .map_err(|err| err.to_string())
 }
 
 fn file_metadata(path: &Path) -> Result<(u64, i64), String> {

--- a/src/native_app/metadata/assignment.rs
+++ b/src/native_app/metadata/assignment.rs
@@ -22,6 +22,32 @@ struct MetadataTagTarget {
 }
 
 impl NativeAppState {
+    /// Apply extracted-file metadata to the immediate UI projection without attempting durable
+    /// writes. The authoritative file-mutation completion schedules those writes after its source
+    /// row exists.
+    pub(in crate::native_app) fn project_extracted_file_metadata(
+        &mut self,
+        absolute_path: &Path,
+        playback_type: ExtractedFilePlaybackType,
+    ) -> Result<(), String> {
+        let (source_root, source_database_root, relative_path) =
+            self.extracted_file_metadata_target(absolute_path)?;
+        self.library.folder_browser.set_file_rating_state(
+            absolute_path,
+            EXTRACTED_FILE_RATING,
+            EXTRACTED_FILE_LOCKED,
+        );
+        self.assign_extracted_file_playback_type(
+            absolute_path,
+            source_root,
+            source_database_root,
+            relative_path,
+            playback_type,
+            None,
+        );
+        Ok(())
+    }
+
     pub(in crate::native_app) fn add_metadata_tags(
         &mut self,
         tags: Vec<String>,
@@ -43,15 +69,8 @@ impl NativeAppState {
         playback_type: ExtractedFilePlaybackType,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Result<(), String> {
-        let Some((source_root, source_database_root, relative_path)) = self
-            .library
-            .folder_browser
-            .source_database_relative_file_path(absolute_path)
-        else {
-            return Err(String::from(
-                "extracted file is not inside a configured source",
-            ));
-        };
+        let (source_root, source_database_root, relative_path) =
+            self.extracted_file_metadata_target(absolute_path)?;
         self.library.folder_browser.set_file_rating_state(
             absolute_path,
             EXTRACTED_FILE_RATING,
@@ -86,10 +105,30 @@ impl NativeAppState {
             source_database_root,
             relative_path,
             playback_type,
-            context,
+            Some(context),
         );
 
         Ok(())
+    }
+
+    fn extracted_file_metadata_target(
+        &self,
+        absolute_path: &Path,
+    ) -> Result<(PathBuf, PathBuf, PathBuf), String> {
+        let Some((source_root, source_database_root, relative_path)) = self
+            .library
+            .folder_browser
+            .source_database_relative_file_path(absolute_path)
+        else {
+            return Err(String::from(
+                "extracted file is not inside a configured source",
+            ));
+        };
+        self.library
+            .folder_browser
+            .source_id_for_file_path(absolute_path)
+            .ok_or_else(|| String::from("extracted file source is unavailable"))?;
+        Ok((source_root, source_database_root, relative_path))
     }
 
     fn assign_extracted_file_playback_type(
@@ -99,7 +138,7 @@ impl NativeAppState {
         source_database_root: PathBuf,
         relative_path: PathBuf,
         playback_type: ExtractedFilePlaybackType,
-        context: &mut ui::UiUpdateContext<GuiMessage>,
+        mut context: Option<&mut ui::UiUpdateContext<GuiMessage>>,
     ) {
         let tag = playback_type.tag().to_string();
         let file_id = absolute_path.to_string_lossy().to_string();
@@ -114,9 +153,10 @@ impl NativeAppState {
             replace_other_playback_type_tags(&mut file_tags, tag.as_str(), &mut added);
         if !file_tags.iter().any(|existing| existing == &tag) {
             file_tags.push(tag.clone());
-            push_unique(&mut added, tag);
+            push_unique(&mut added, tag.clone());
         }
-        if added.is_empty() && removed_conflicting.is_empty() {
+        let persist = context.is_some();
+        if !persist && added.is_empty() && removed_conflicting.is_empty() {
             return;
         }
 
@@ -142,17 +182,21 @@ impl NativeAppState {
                 assigned: false,
             });
         }
-        if !added.is_empty() {
+        if persist {
+            let mut durable_added = added.clone();
+            push_unique(&mut durable_added, tag.clone());
             requests.push(MetadataTagPersistRequest {
                 absolute_path: absolute_path.to_path_buf(),
                 source_root,
                 source_database_root,
                 relative_path,
-                tags: added,
+                tags: durable_added,
                 assigned: true,
             });
         }
-        enqueue_metadata_tag_persist_requests(requests, context);
+        if let Some(context) = context.take() {
+            enqueue_metadata_tag_persist_requests(requests, context);
+        }
     }
 
     #[cfg(test)]

--- a/src/native_app/metadata/persistence.rs
+++ b/src/native_app/metadata/persistence.rs
@@ -5,7 +5,9 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
 };
-use wavecrate::sample_sources::{SourceDatabase, SourceDbError, db::SourceWriteBatch};
+use wavecrate::sample_sources::{
+    ExistingFileMetadataUpdate, SourceDatabase, SourceDbError, db::SourceWriteBatch,
+};
 use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 pub(super) fn persist_metadata_tag_assignment(
@@ -72,9 +74,17 @@ fn persist_metadata_tag_assignment_inner(
     )
     .map_err(|err| err.to_string())?;
     let mut batch = db.write_batch().map_err(|err| err.to_string())?;
-    batch
-        .upsert_file(&request.relative_path, file_size, modified_ns)
-        .map_err(|err| err.to_string())?;
+    if matches!(
+        batch
+            .update_existing_file_metadata(&request.relative_path, file_size, modified_ns)
+            .map_err(|err| err.to_string())?,
+        ExistingFileMetadataUpdate::Missing
+    ) {
+        return Err(format!(
+            "metadata tag persistence deferred until source row exists: {}",
+            request.relative_path.display()
+        ));
+    }
     for tag in &request.tags {
         if request.assigned {
             remove_conflicting_persisted_playback_tags(&mut batch, &request.relative_path, tag)
@@ -89,7 +99,9 @@ fn persist_metadata_tag_assignment_inner(
         }
         .map_err(|err| err.to_string())?;
     }
-    batch.commit().map_err(|err| err.to_string())
+    batch
+        .commit_auxiliary_state()
+        .map_err(|err| err.to_string())
 }
 
 fn remove_conflicting_persisted_playback_tags(
@@ -221,7 +233,9 @@ fn repair_persisted_metadata_tag_conflicts(
             .replace_tags_for_path(&repair.relative_path, &repair.tags)
             .map_err(|err| err.to_string())?;
     }
-    batch.commit().map_err(|err| err.to_string())
+    batch
+        .commit_auxiliary_state()
+        .map_err(|err| err.to_string())
 }
 
 fn file_metadata(path: &Path) -> Result<(u64, i64), String> {

--- a/src/native_app/metadata/persistence.rs
+++ b/src/native_app/metadata/persistence.rs
@@ -8,7 +8,6 @@ use std::{
 use wavecrate::sample_sources::{
     ExistingFileMetadataUpdate, SourceDatabase, SourceDbError, db::SourceWriteBatch,
 };
-use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 pub(super) fn persist_metadata_tag_assignment(
     request: MetadataTagPersistRequest,
@@ -67,7 +66,6 @@ fn unique_request_tags(requests: &[MetadataTagPersistRequest]) -> Vec<String> {
 fn persist_metadata_tag_assignment_inner(
     request: &MetadataTagPersistRequest,
 ) -> Result<(), String> {
-    let (file_size, modified_ns) = file_metadata(&request.absolute_path)?;
     let db = SourceDatabase::open_for_user_metadata_write_with_database_root(
         &request.source_root,
         &request.source_database_root,
@@ -76,13 +74,14 @@ fn persist_metadata_tag_assignment_inner(
     let mut batch = db.write_batch().map_err(|err| err.to_string())?;
     if matches!(
         batch
-            .update_existing_file_metadata(&request.relative_path, file_size, modified_ns)
+            .ensure_existing_live_file(&request.relative_path)
             .map_err(|err| err.to_string())?,
         ExistingFileMetadataUpdate::Missing
     ) {
         return Err(format!(
-            "metadata tag persistence deferred until source row exists: {}",
-            request.relative_path.display()
+            "metadata tag persistence deferred until source row exists: {} ({})",
+            request.relative_path.display(),
+            request.absolute_path.display()
         ));
     }
     for tag in &request.tags {
@@ -238,12 +237,88 @@ fn repair_persisted_metadata_tag_conflicts(
         .map_err(|err| err.to_string())
 }
 
-fn file_metadata(path: &Path) -> Result<(u64, i64), String> {
-    let metadata = std::fs::metadata(path)
-        .map_err(|err| format!("Sample metadata unavailable for {}: {err}", path.display()))?;
-    let modified_ns = metadata
-        .modified()
-        .map(system_time_to_unix_nanos)
-        .unwrap_or_default();
-    Ok((metadata.len(), modified_ns))
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native_app::sample_library::sample_ratings::{
+        RatingPersistRequest, persist_rating_requests,
+    };
+    use wavecrate::sample_sources::{Rating, SourceDatabase};
+
+    #[test]
+    fn extracted_metadata_retry_after_authoritative_row_persists_rating_and_playback_tag() {
+        let root = tempfile::tempdir().expect("source root");
+        let relative_path = PathBuf::from("extracted.wav");
+        let absolute_path = root.path().join(&relative_path);
+        std::fs::write(&absolute_path, b"extracted").expect("extracted file");
+
+        let rating_request = RatingPersistRequest {
+            source_id: String::from("source"),
+            lifecycle_generation: None,
+            root: root.path().to_path_buf(),
+            database_root: root.path().to_path_buf(),
+            relative_path: relative_path.clone(),
+            absolute_path: absolute_path.clone(),
+            rating: Rating::KEEP_1,
+            locked: false,
+        };
+        assert!(
+            persist_rating_requests(std::slice::from_ref(&rating_request), |_| true)[0]
+                .as_ref()
+                .expect("missing-row result")
+                .is_err()
+        );
+        assert!(
+            persist_metadata_tag_additions_for_tests(
+                absolute_path.clone(),
+                root.path().to_path_buf(),
+                relative_path.clone(),
+                vec![String::from("loop")],
+            )
+            .is_err()
+        );
+
+        let database = SourceDatabase::open_for_user_metadata_write_with_database_root(
+            root.path(),
+            root.path(),
+        )
+        .expect("source database");
+        let metadata = std::fs::metadata(&absolute_path).expect("file metadata");
+        let mut batch = database.write_batch().expect("write batch");
+        batch
+            .upsert_file(
+                &relative_path,
+                metadata.len(),
+                metadata
+                    .modified()
+                    .expect("modified")
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("epoch")
+                    .as_nanos() as i64,
+            )
+            .expect("authoritative row");
+        batch.commit().expect("commit source row");
+
+        assert!(
+            persist_metadata_tag_additions_for_tests(
+                absolute_path.clone(),
+                root.path().to_path_buf(),
+                relative_path.clone(),
+                vec![String::from("loop")],
+            )
+            .is_ok()
+        );
+        assert_eq!(
+            persist_rating_requests(std::slice::from_ref(&rating_request), |_| true)[0],
+            Some(Ok(()))
+        );
+        assert_eq!(
+            database.tag_for_path(&relative_path).expect("rating"),
+            Some(Rating::KEEP_1)
+        );
+        assert_eq!(
+            database.tag_labels_for_path(&relative_path).expect("tags"),
+            vec![String::from("loop")]
+        );
+    }
 }

--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -134,9 +134,16 @@ pub(in crate::native_app) struct FileMutationPostCommit {
     pub(in crate::native_app) playback_type: ExtractedFilePlaybackType,
     pub(in crate::native_app) focus_derivative: bool,
     pub(in crate::native_app) started_at: Instant,
+    pub(in crate::native_app) presentation: FileMutationPostCommitPresentation,
 }
 
 impl Eq for FileMutationPostCommit {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum FileMutationPostCommitPresentation {
+    Extracted,
+    Drag,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum ExpectedMutationPathState {

--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -9,8 +9,9 @@ use std::{collections::BTreeSet, path::PathBuf, time::Instant};
 
 use radiant::prelude as ui;
 use wavecrate::sample_sources::{readiness::ReadinessStage, scanner::CommittedSourceDelta};
+use wavecrate::selection::SelectionRange;
 
-use crate::native_app::app::{GuiMessage, NativeAppState};
+use crate::native_app::app::{ExtractedFilePlaybackType, GuiMessage, NativeAppState};
 use crate::native_app::sample_library::folder_browser::BrowserListingRevealReason;
 use crate::native_app::sample_library::folder_browser::commands::{
     FileMoveConflictCompletion, FolderMoveRequest, FolderMoveSuccess, RenameCommitCompletion,
@@ -38,6 +39,15 @@ pub(in crate::native_app) const COMMITTED_MUTATION_PREP_INTENTS: SourcePrepInten
         readiness: ReadinessIntent::InvalidateAndRequestConvergence,
         priority: SourcePriorityIntent::PromoteIfSelected,
         metadata_refresh: MetadataRefreshIntent::Force,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+pub(in crate::native_app) const COMMITTED_PLAYMARK_PREP_INTENTS: SourcePrepIntents =
+    SourcePrepIntents {
+        readiness: ReadinessIntent::InvalidateAndRequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::IfNotLoaded,
         refresh_waveform_cache_projection_if_selected: true,
         cache_warm: CacheWarmIntent::Preserve,
         feedback: SourceFeedbackIntent::Preserve,
@@ -114,6 +124,19 @@ pub(in crate::native_app) enum FileMutationSemantics {
     PathOnlyMove,
     Delete,
 }
+
+/// Extraction follow-up inputs captured before asynchronous reconciliation changes selection or
+/// playback state. The follow-up is admitted only after the created source row is authoritative.
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::native_app) struct FileMutationPostCommit {
+    pub(in crate::native_app) source_path: PathBuf,
+    pub(in crate::native_app) selection: SelectionRange,
+    pub(in crate::native_app) playback_type: ExtractedFilePlaybackType,
+    pub(in crate::native_app) focus_derivative: bool,
+    pub(in crate::native_app) started_at: Instant,
+}
+
+impl Eq for FileMutationPostCommit {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum ExpectedMutationPathState {
@@ -221,6 +244,7 @@ pub(in crate::native_app) struct FileMutationChange {
     expected_before_state: Option<ExpectedMutationPathState>,
     expected_after_state: Option<ExpectedMutationPathState>,
     projection: Option<FileMutationProjection>,
+    post_commit: Option<FileMutationPostCommit>,
 }
 
 impl FileMutationChange {
@@ -234,6 +258,7 @@ impl FileMutationChange {
             expected_before_state: None,
             expected_after_state: None,
             projection: None,
+            post_commit: None,
         }
     }
 
@@ -247,6 +272,7 @@ impl FileMutationChange {
             expected_before_state: None,
             expected_after_state: None,
             projection: None,
+            post_commit: None,
         }
     }
 
@@ -260,6 +286,7 @@ impl FileMutationChange {
             expected_before_state: None,
             expected_after_state: None,
             projection: None,
+            post_commit: None,
         }
     }
 
@@ -273,6 +300,7 @@ impl FileMutationChange {
             expected_before_state: None,
             expected_after_state: None,
             projection: None,
+            post_commit: None,
         }
     }
 
@@ -289,6 +317,14 @@ impl FileMutationChange {
         projection: FileMutationProjection,
     ) -> Self {
         self.projection = Some(projection);
+        self
+    }
+
+    pub(in crate::native_app) fn with_post_commit(
+        mut self,
+        post_commit: FileMutationPostCommit,
+    ) -> Self {
+        self.post_commit = Some(post_commit);
         self
     }
 
@@ -316,6 +352,8 @@ pub(in crate::native_app) struct CommittedFileMutation {
     pub(in crate::native_app) committed_delta: CommittedSourceDelta,
     pub(in crate::native_app) affected_relative_paths: Vec<PathBuf>,
     pub(in crate::native_app) watcher_echoes: Vec<CommittedWatcherEcho>,
+    pub(in crate::native_app) browser_projection_delta:
+        Option<crate::native_app::app::BrowserProjectionDelta>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -531,19 +569,69 @@ impl NativeAppState {
                 .entry(event.source_id.clone())
                 .or_default();
             let current_commit = (event.committed_source_revision, event.operation_id);
-            if mutation_completion_is_stale_or_duplicate(*last_commit, current_commit) {
+            let accepted_commit = *last_commit;
+            if mutation_completion_is_stale_or_duplicate(accepted_commit, current_commit) {
                 tracing::debug!(
                     source_id = %event.source_id,
                     operation_id = event.operation_id,
                     revision = event.committed_source_revision,
-                    accepted_revision = last_commit.0,
-                    accepted_operation_id = last_commit.1,
+                    accepted_revision = accepted_commit.0,
+                    accepted_operation_id = accepted_commit.1,
                     "Ignoring stale committed file-mutation completion"
                 );
                 continue;
             }
-            *last_commit = (*last_commit).max(current_commit);
-
+            let extraction_post_commit = event
+                .changes
+                .iter()
+                .find_map(|change| change.post_commit.clone());
+            let extraction_path = event
+                .changes
+                .iter()
+                .find_map(|change| change.after_path.clone());
+            let browser_projection_applied =
+                event
+                    .browser_projection_delta
+                    .clone()
+                    .is_some_and(|projection| {
+                        self.library
+                            .folder_browser
+                            .apply_committed_projection_delta(&event.source_id, projection)
+                    });
+            if event.operation == FileMutationOperation::Extract && !browser_projection_applied {
+                // This is the conservative recovery path: the exact committed projection could
+                // not be applied at the expected revision, so do not acknowledge the watcher or
+                // publish readiness. Affected-path refresh keeps the durable metadata completion
+                // visible while the queued source refresh repairs the missing projection.
+                self.library
+                    .folder_browser
+                    .refresh_filesystem_paths(&event.source_id, &event.affected_relative_paths);
+                if let (Some(post_commit), Some(path)) =
+                    (extraction_post_commit.as_ref(), extraction_path.as_deref())
+                {
+                    let metadata_error = self.finish_committed_playmark_extraction_metadata(
+                        path,
+                        post_commit,
+                        context,
+                    );
+                    self.reapply_desired_rating_overlay();
+                    self.finish_committed_playmark_extraction_visuals(
+                        path,
+                        post_commit,
+                        metadata_error.as_deref(),
+                    );
+                }
+                self.queue_full_source_reconciliation_after_committed_mutation(
+                    event.source_id.clone(),
+                    event.committed_source_revision,
+                    event.lifecycle_generation,
+                    context,
+                );
+                continue;
+            }
+            self.transactions
+                .latest_committed_mutation
+                .insert(event.source_id.clone(), accepted_commit.max(current_commit));
             for change in &event.changes {
                 let before = change.before_path.as_deref().and_then(|path| {
                     self.library
@@ -613,6 +701,19 @@ impl NativeAppState {
                     _ => {}
                 }
             }
+            let extraction_metadata_error =
+                match (&extraction_post_commit, extraction_path.as_deref()) {
+                    (Some(post_commit), Some(path))
+                        if event.operation == FileMutationOperation::Extract =>
+                    {
+                        self.finish_committed_playmark_extraction_metadata(
+                            path,
+                            post_commit,
+                            context,
+                        )
+                    }
+                    _ => None,
+                };
             self.reapply_desired_rating_overlay();
 
             let projections = event
@@ -620,9 +721,10 @@ impl NativeAppState {
                 .iter()
                 .filter_map(|change| change.projection.as_ref())
                 .collect::<Vec<_>>();
-            if !projections
-                .iter()
-                .any(|projection| projection.replaces_default_refresh())
+            if !browser_projection_applied
+                && !projections
+                    .iter()
+                    .any(|projection| projection.replaces_default_refresh())
             {
                 self.library
                     .folder_browser
@@ -630,6 +732,15 @@ impl NativeAppState {
             }
             for projection in projections {
                 self.apply_committed_file_mutation_projection(projection, context);
+            }
+            if let (Some(post_commit), Some(path)) =
+                (extraction_post_commit.as_ref(), extraction_path.as_deref())
+            {
+                self.finish_committed_playmark_extraction_visuals(
+                    path,
+                    post_commit,
+                    extraction_metadata_error.as_deref(),
+                );
             }
             if let Some(watcher) = self.library.source_watcher.as_ref() {
                 watcher.acknowledge_committed_paths(
@@ -657,7 +768,11 @@ impl NativeAppState {
             // reconciler. It deliberately happens after the source DB and browser projection.
             self.queue_source_prep(
                 event.source_id,
-                COMMITTED_MUTATION_PREP_INTENTS,
+                if extraction_post_commit.is_some() {
+                    COMMITTED_PLAYMARK_PREP_INTENTS
+                } else {
+                    COMMITTED_MUTATION_PREP_INTENTS
+                },
                 COMMITTED_MUTATION_PREP_REASON,
                 context,
             );

--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -20,6 +20,7 @@ use crate::native_app::sample_library::source_prep::{
     CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
     SourcePrepIntents, SourcePriorityIntent,
 };
+use crate::native_app::source_processing::ProjectionHandoffTicket;
 
 #[cfg(test)]
 mod tests;
@@ -29,9 +30,11 @@ mod worker;
 pub(in crate::native_app) use watcher_echo::{
     CommittedWatcherEcho, CommittedWatcherPathState, observed_watcher_path_state,
 };
+#[cfg(test)]
+use worker::reconcile_file_mutation_requests;
 use worker::{
     build_source_requests, capture_expected_filesystem_state, merge_file_mutation_failures,
-    mutation_completion_is_stale_or_duplicate, reconcile_file_mutation_requests,
+    mutation_completion_is_stale_or_duplicate, reconcile_file_mutation_requests_with_handoff,
 };
 
 pub(in crate::native_app) const COMMITTED_MUTATION_PREP_INTENTS: SourcePrepIntents =
@@ -361,6 +364,7 @@ pub(in crate::native_app) struct CommittedFileMutation {
     pub(in crate::native_app) watcher_echoes: Vec<CommittedWatcherEcho>,
     pub(in crate::native_app) browser_projection_delta:
         Option<crate::native_app::app::BrowserProjectionDelta>,
+    pub(in crate::native_app) projection_handoff_ticket: Option<ProjectionHandoffTicket>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -471,13 +475,14 @@ impl NativeAppState {
         work: FileMutationWork,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        let budget = self.background.source_processing.budget_handle();
         context
             .business()
             .background("gui-committed-file-mutation")
             .run(
                 move |_| {
                     merge_file_mutation_failures(
-                        reconcile_file_mutation_requests(work.requests),
+                        reconcile_file_mutation_requests_with_handoff(work.requests, budget),
                         work.failures,
                     )
                 },
@@ -605,7 +610,16 @@ impl NativeAppState {
                             .folder_browser
                             .apply_committed_projection_delta(&event.source_id, projection)
                     });
-            if event.operation == FileMutationOperation::Extract && !browser_projection_applied {
+            let projection_accepted = event
+                .projection_handoff_ticket
+                .as_ref()
+                .is_some_and(|ticket| browser_projection_applied && ticket.accept());
+            if !projection_accepted {
+                if let Some(ticket) = event.projection_handoff_ticket.as_ref()
+                    && !browser_projection_applied
+                {
+                    ticket.reject("committed_mutation_projection_rejected");
+                }
                 // This is the conservative recovery path: the exact committed projection could
                 // not be applied at the expected revision, so do not acknowledge the watcher or
                 // publish readiness. Affected-path refresh keeps the durable metadata completion
@@ -627,6 +641,13 @@ impl NativeAppState {
                         post_commit,
                         metadata_error.as_deref(),
                     );
+                }
+                for projection in event
+                    .changes
+                    .iter()
+                    .filter_map(|change| change.projection.as_ref())
+                {
+                    self.apply_committed_file_mutation_projection(projection, context);
                 }
                 self.queue_full_source_reconciliation_after_committed_mutation(
                     event.source_id.clone(),
@@ -764,12 +785,6 @@ impl NativeAppState {
                 changes = event.changes.len(),
                 invalidated_stages = ?event.invalidated_stages,
                 "Committed Wavecrate-owned file mutation"
-            );
-            self.background.source_processing.request_source_delta(
-                &event.source_id,
-                event.lifecycle_generation,
-                &event.committed_delta,
-                "committed_file_mutation_delta",
             );
             // This call refreshes metadata projections and wakes the source-owned readiness
             // reconciler. It deliberately happens after the source DB and browser projection.

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -419,6 +419,7 @@ fn stale_lifecycle_completion_has_no_committed_mutation_side_effects() {
         },
         affected_relative_paths: vec![PathBuf::from("stale.wav")],
         watcher_echoes,
+        browser_projection_delta: None,
     };
     let selected_before = state
         .library

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -420,6 +420,7 @@ fn stale_lifecycle_completion_has_no_committed_mutation_side_effects() {
         affected_relative_paths: vec![PathBuf::from("stale.wav")],
         watcher_echoes,
         browser_projection_delta: None,
+        projection_handoff_ticket: None,
     };
     let selected_before = state
         .library

--- a/src/native_app/sample_library/committed_file_mutations/worker.rs
+++ b/src/native_app/sample_library/committed_file_mutations/worker.rs
@@ -13,6 +13,7 @@ use super::{
     FileMutationOperation, FileMutationOutcome, FileMutationSemantics,
 };
 use crate::native_app::sample_library::folder_scan_actions::sync_source_database_paths;
+use crate::native_app::source_processing::{ExternalScanHandoff, SourceProcessingBudgetHandle};
 
 #[derive(Clone, Debug)]
 pub(super) struct SourceMutationRequest {
@@ -181,6 +182,7 @@ fn source_for_path(sources: &[SampleSource], path: &Path) -> Option<String> {
         .map(|(source, _)| source.id.as_str().to_string())
 }
 
+#[cfg(test)]
 pub(super) fn reconcile_file_mutation_requests(
     requests: Vec<SourceMutationRequest>,
 ) -> FileMutationOutcome {
@@ -191,6 +193,72 @@ pub(super) fn reconcile_file_mutation_requests(
     })
 }
 
+pub(super) fn reconcile_file_mutation_requests_with_handoff(
+    requests: Vec<SourceMutationRequest>,
+    budget: SourceProcessingBudgetHandle,
+) -> FileMutationOutcome {
+    let mut committed = Vec::new();
+    let mut failures = Vec::new();
+    for request in requests {
+        let source_id = request.source.id.as_str().to_string();
+        let Some(permit) =
+            budget.acquire_scan_for_generation(&source_id, request.lifecycle_generation)
+        else {
+            failures.push(FileMutationFailure {
+                source_id: Some(source_id),
+                operation_id: request.operation_id,
+                operation: request.operation,
+                error: String::from("source mutation reconciliation canceled"),
+            });
+            continue;
+        };
+        match request
+            .source
+            .database_root()
+            .map_err(|error| format!("resolve source metadata location: {error}"))
+            .and_then(|database_root| {
+                reconcile_source_mutation_with_cancel(
+                    request.clone(),
+                    database_root,
+                    &permit.cancel_token(),
+                )
+            }) {
+            Ok(mut event) => {
+                if event.browser_projection_delta.is_some() {
+                    let ticket =
+                        permit.release_after_projection_handoff(event.committed_delta.clone());
+                    event.projection_handoff_ticket = Some(ticket);
+                } else {
+                    permit.release_after_handoff(ExternalScanHandoff::FullReconciliation {
+                        reason: "committed_mutation_projection_unavailable",
+                    });
+                }
+                committed.push(event);
+            }
+            Err(error) => {
+                permit.release_after_handoff(ExternalScanHandoff::FullReconciliation {
+                    reason: "committed_mutation_reconciliation_failed",
+                });
+                failures.push(FileMutationFailure {
+                    source_id: Some(source_id),
+                    operation_id: request.operation_id,
+                    operation: request.operation,
+                    error,
+                });
+            }
+        }
+    }
+    if failures.is_empty() {
+        FileMutationOutcome::Committed(committed)
+    } else {
+        FileMutationOutcome::Failed {
+            committed,
+            failures,
+        }
+    }
+}
+
+#[cfg(test)]
 pub(super) fn reconcile_file_mutation_requests_with_database_roots(
     requests: Vec<SourceMutationRequest>,
     database_root_for: impl Fn(&SampleSource) -> Result<PathBuf, String>,
@@ -223,7 +291,16 @@ pub(super) fn reconcile_file_mutation_requests_with_database_roots(
     }
 }
 
+#[cfg(test)]
 pub(super) fn reconcile_source_mutation(
+    request: SourceMutationRequest,
+    database_root: PathBuf,
+    cancel: &AtomicBool,
+) -> Result<CommittedFileMutation, String> {
+    reconcile_source_mutation_with_cancel(request, database_root, &cancel)
+}
+
+fn reconcile_source_mutation_with_cancel(
     request: SourceMutationRequest,
     database_root: PathBuf,
     cancel: &AtomicBool,
@@ -315,6 +392,7 @@ pub(super) fn reconcile_source_mutation(
         affected_relative_paths: request.affected_relative_paths,
         watcher_echoes: request.watcher_echoes,
         browser_projection_delta: success.browser_projection_delta,
+        projection_handoff_ticket: None,
     })
 }
 

--- a/src/native_app/sample_library/committed_file_mutations/worker.rs
+++ b/src/native_app/sample_library/committed_file_mutations/worker.rs
@@ -233,11 +233,10 @@ pub(super) fn reconcile_source_mutation(
     let before_database =
         SourceDatabase::open_for_background_job_with_database_root(root, &database_root)
             .map_err(|error| format!("open source before mutation reconciliation: {error}"))?;
-    let before = manifest_by_path(
-        before_database
-            .list_manifest_entries()
-            .map_err(|error| format!("read source manifest before mutation: {error}"))?,
-    );
+    let (_, before_entries) = before_database
+        .manifest_snapshot_with_revision_under_paths(&request.affected_relative_paths)
+        .map_err(|error| format!("read affected source manifest before mutation: {error}"))?;
+    let before = manifest_by_path(before_entries);
     drop(before_database);
 
     let sync = sync_source_database_paths(
@@ -258,11 +257,10 @@ pub(super) fn reconcile_source_mutation(
     let after_database =
         SourceDatabase::open_for_background_job_with_database_root(root, &database_root)
             .map_err(|error| format!("open source after mutation reconciliation: {error}"))?;
-    let after = manifest_by_path(
-        after_database
-            .list_manifest_entries()
-            .map_err(|error| format!("read source manifest after mutation: {error}"))?,
-    );
+    let (_, after_entries) = after_database
+        .manifest_snapshot_with_revision_under_paths(&request.affected_relative_paths)
+        .map_err(|error| format!("read affected source manifest after mutation: {error}"))?;
+    let after = manifest_by_path(after_entries);
     let committed_source_revision = after_database
         .get_revision()
         .map_err(|error| format!("read committed source revision: {error}"))?
@@ -316,6 +314,7 @@ pub(super) fn reconcile_source_mutation(
         committed_delta: success.committed_delta,
         affected_relative_paths: request.affected_relative_paths,
         watcher_echoes: request.watcher_echoes,
+        browser_projection_delta: success.browser_projection_delta,
     })
 }
 

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -174,7 +174,18 @@ impl NativeAppState {
                 } else {
                     false
                 };
-                if incomplete_error.is_none() && !browser_delta_applied {
+                let projection_accepted = if incomplete_error.is_none() && browser_delta_applied {
+                    success
+                        .projection_handoff_ticket
+                        .as_ref()
+                        .is_some_and(|ticket| ticket.accept())
+                } else {
+                    if let Some(ticket) = success.projection_handoff_ticket.as_ref() {
+                        ticket.reject("projection_handoff_projection_rejected");
+                    }
+                    false
+                };
+                if incomplete_error.is_none() && !projection_accepted {
                     incomplete_error = Some(String::from(
                         "committed filesystem sync did not apply an exact browser projection",
                     ));
@@ -195,15 +206,7 @@ impl NativeAppState {
                     renames_reconciled,
                     "Committed filesystem source delta"
                 );
-                if !result.cancelled && incomplete_error.is_none() {
-                    self.background.source_processing.request_source_delta(
-                        &source_id,
-                        result.lifecycle_generation,
-                        &delta,
-                        "filesystem_sync_committed_delta",
-                    );
-                }
-                if !result.cancelled && !delta.is_empty() && incomplete_error.is_none() {
+                if !result.cancelled && !delta.is_empty() && projection_accepted {
                     self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
                     self.queue_source_prep(
                         source_id.clone(),
@@ -221,7 +224,7 @@ impl NativeAppState {
                         );
                 }
                 if !result.cancelled
-                    && incomplete_error.is_none()
+                    && projection_accepted
                     && let (Some(watcher), Some(event_id)) = (
                         self.library.source_watcher.as_ref(),
                         journal_checkpoint_event_id,
@@ -233,16 +236,6 @@ impl NativeAppState {
                     self.queue_filesystem_source_refresh(
                         source_id,
                         SourceRefreshCause::FilesystemSyncIncomplete,
-                        Some(result.lifecycle_generation),
-                        Instant::now(),
-                        context,
-                    );
-                } else if !browser_delta_applied {
-                    self.queue_filesystem_source_refresh(
-                        source_id,
-                        SourceRefreshCause::ProjectionRevisionGap {
-                            committed_revision: delta.revision,
-                        },
                         Some(result.lifecycle_generation),
                         Instant::now(),
                         context,
@@ -587,15 +580,27 @@ impl NativeAppState {
                     },
                 );
                 result.journal_checkpoint_event_id = journal_checkpoint_event_id;
-                let handoff = match &result.result {
-                    Ok(success) if !result.cancelled && success.incomplete_error.is_none() => {
-                        ExternalScanHandoff::CommittedDelta(success.committed_delta.clone())
+                let projection_ticket = match &mut result.result {
+                    Ok(success)
+                        if !result.cancelled
+                            && success.incomplete_error.is_none()
+                            && success.browser_projection_delta.is_some() =>
+                    {
+                        Some(
+                            permit
+                                .release_after_projection_handoff(success.committed_delta.clone()),
+                        )
                     }
-                    _ => ExternalScanHandoff::FullReconciliation {
-                        reason: "targeted_source_sync_incomplete",
-                    },
+                    _ => {
+                        permit.release_after_handoff(ExternalScanHandoff::FullReconciliation {
+                            reason: "targeted_source_sync_incomplete",
+                        });
+                        None
+                    }
                 };
-                permit.release_after_handoff(handoff);
+                if let Ok(success) = &mut result.result {
+                    success.projection_handoff_ticket = projection_ticket;
+                }
                 result
             },
             GuiMessage::SourceFilesystemSyncFinished,
@@ -754,6 +759,7 @@ mod tests {
                     ..CommittedSourceDelta::default()
                 },
                 browser_projection_delta: projection,
+                projection_handoff_ticket: None,
             }),
         }
     }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -29,6 +29,22 @@ pub(in crate::native_app) const FILESYSTEM_SYNC_PREP_INTENTS: SourcePrepIntents 
 pub(in crate::native_app) const FILESYSTEM_SYNC_PREP_REASON: &str = "filesystem_changed";
 
 impl NativeAppState {
+    pub(in crate::native_app) fn queue_full_source_reconciliation_after_committed_mutation(
+        &mut self,
+        source_id: String,
+        committed_revision: u64,
+        lifecycle_generation: u64,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        self.queue_filesystem_source_refresh(
+            source_id,
+            SourceRefreshCause::ProjectionRevisionGap { committed_revision },
+            Some(lifecycle_generation),
+            Instant::now(),
+            context,
+        );
+    }
+
     pub(in crate::native_app) fn refresh_source_after_filesystem_change(
         &mut self,
         source_id: String,

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -161,16 +161,29 @@ impl NativeAppState {
         match result.result {
             Ok(success) => {
                 let renames_reconciled = success.renames_reconciled;
-                let incomplete_error = success.incomplete_error;
+                let mut incomplete_error = success.incomplete_error;
                 let delta = success.committed_delta;
-                let browser_delta_applied = success
-                    .browser_projection_delta
-                    .map(|projection| {
-                        self.library
+                let browser_delta_applied = if incomplete_error.is_none() {
+                    match success.browser_projection_delta {
+                        Some(projection) => self
+                            .library
                             .folder_browser
-                            .apply_committed_projection_delta(&source_id, projection)
-                    })
-                    .unwrap_or(false);
+                            .apply_committed_projection_delta(&source_id, projection),
+                        None => false,
+                    }
+                } else {
+                    false
+                };
+                if incomplete_error.is_none() && !browser_delta_applied {
+                    incomplete_error = Some(String::from(
+                        "committed filesystem sync did not apply an exact browser projection",
+                    ));
+                    tracing::warn!(
+                        source_id = %source_id,
+                        revision = delta.revision,
+                        "Falling back to a full browser projection after committed projection completion failed"
+                    );
+                }
                 self.reapply_desired_rating_overlay();
                 tracing::info!(
                     source_id = %source_id,
@@ -636,7 +649,13 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{ManifestAuditFollowup, manifest_audit_followup};
+    use crate::native_app::{
+        app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
+        sample_library::folder_browser::{FolderBrowserState, scan::scan_source_with_progress},
+        test_support::state::NativeAppStateFixture,
+    };
     use wavecrate::sample_sources::scanner::{CommittedSourceDelta, ManifestIdentityDelta};
+    use wavecrate::sample_sources::{SampleSource, SourceId};
 
     #[test]
     fn content_generation_only_audit_reconciles_without_filesystem_rescan() {
@@ -674,5 +693,127 @@ mod tests {
             manifest_audit_followup(&delta),
             ManifestAuditFollowup::RefreshBrowserThenReconcile
         );
+    }
+
+    fn completion_test_state() -> (
+        tempfile::TempDir,
+        crate::native_app::app::NativeAppState,
+        String,
+        u64,
+    ) {
+        let root = tempfile::tempdir().expect("source root");
+        std::fs::write(root.path().join("sample.wav"), [0_u8; 8]).expect("write sample");
+        let mut browser = FolderBrowserState::from_root(root.path().to_path_buf());
+        let request = browser
+            .begin_add_source_path(root.path().to_path_buf(), 1)
+            .expect("initial scan request");
+        let source_id = request.source_id.clone();
+        let result = scan_source_with_progress(request, |_| {}, |_| {});
+        assert!(browser.apply_scan_finished(result));
+        let source = SampleSource::new_with_id(
+            SourceId::from_string(source_id.clone()),
+            root.path().to_path_buf(),
+        );
+        let mut state = NativeAppStateFixture::default()
+            .with_folder_browser(browser)
+            .build();
+        let generation = state
+            .background
+            .source_processing
+            .register_source_for_scan(source)
+            .expect("register source");
+        state
+            .background
+            .source_lifecycle_generations
+            .insert(source_id.clone(), generation);
+        (root, state, source_id, generation)
+    }
+
+    fn incomplete_result(
+        source_id: String,
+        generation: u64,
+        projection: Option<BrowserProjectionDelta>,
+    ) -> SourceFilesystemSyncResult {
+        SourceFilesystemSyncResult {
+            source_id,
+            lifecycle_generation: generation,
+            changed_count: 1,
+            journal_checkpoint_event_id: Some(73),
+            cancelled: false,
+            result: Ok(SourceFilesystemSyncSuccess {
+                renames_reconciled: 0,
+                incomplete_error: None,
+                committed_delta: CommittedSourceDelta {
+                    revision: 2,
+                    created: vec![ManifestIdentityDelta {
+                        identity: String::from("new-identity"),
+                        relative_path: PathBuf::from("new.wav"),
+                        content_generation: String::from("generation"),
+                        source_metadata_changed: true,
+                    }],
+                    ..CommittedSourceDelta::default()
+                },
+                browser_projection_delta: projection,
+            }),
+        }
+    }
+
+    #[test]
+    fn incomplete_completion_without_projection_schedules_full_recovery_without_side_effects() {
+        let (_root, mut state, source_id, generation) = completion_test_state();
+        let mut context = radiant::prelude::UiUpdateContext::default();
+
+        state.finish_source_filesystem_sync(
+            incomplete_result(source_id.clone(), generation, None),
+            &mut context,
+        );
+
+        assert!(
+            !state
+                .background
+                .source_processing
+                .pending_source_delta_contains_identity_for_tests(&source_id, "new-identity")
+        );
+        assert!(
+            state
+                .background
+                .source_processing
+                .source_dirty_for_tests(&source_id)
+        );
+        assert!(state.library.folder_scan_active());
+        assert!(state.library.source_watcher.is_none());
+    }
+
+    #[test]
+    fn rejected_completion_projection_schedules_full_recovery_without_side_effects() {
+        let (_root, mut state, source_id, generation) = completion_test_state();
+        let mut context = radiant::prelude::UiUpdateContext::default();
+        let rejected = BrowserProjectionDelta {
+            manifest_revision: 4,
+            snapshot_revision: 4,
+            folders: Vec::new(),
+            removed_file_ids: Vec::new(),
+            upserted_files: Vec::new(),
+        };
+
+        state.finish_source_filesystem_sync(
+            incomplete_result(source_id.clone(), generation, Some(rejected)),
+            &mut context,
+        );
+
+        assert!(
+            !state
+                .background
+                .source_processing
+                .pending_source_delta_contains_identity_for_tests(&source_id, "new-identity")
+        );
+        assert!(
+            state
+                .background
+                .source_processing
+                .source_dirty_for_tests(&source_id)
+        );
+        assert!(state.library.folder_scan_active());
+        assert!(state.library.source_watcher.is_none());
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use wavecrate::sample_sources::{BrowserMetadataSnapshot, SourceDatabase};
+use wavecrate::sample_sources::SourceDatabase;
 use wavecrate_library::sample_sources::is_supported_audio;
 use wavecrate_scan::sample_sources::scanner::{
     self, ScanWritePhase, ScanWriter, UncoordinatedScanWriter,
@@ -165,10 +165,7 @@ fn sync_source_database_paths_once(
                     }
                 }
             };
-            let browser_projection_delta = if browser_delta_eligible
-                && incomplete_error.is_none()
-                && completed.committed_delta.revision > 0
-            {
+            let browser_projection_delta = if browser_delta_eligible && incomplete_error.is_none() {
                 match build_browser_projection_delta(root, &db, &completed.committed_delta) {
                     Ok(projection) => projection,
                     Err(error) => {
@@ -197,9 +194,28 @@ fn build_browser_projection_delta(
     db: &SourceDatabase,
     delta: &scanner::CommittedSourceDelta,
 ) -> Result<Option<BrowserProjectionDelta>, String> {
-    let BrowserMetadataSnapshot { revision, files } = db
-        .browser_metadata_snapshot()
+    let projection_paths = delta
+        .created
+        .iter()
+        .map(|entry| entry.relative_path.clone())
+        .chain(
+            delta
+                .changed
+                .iter()
+                .map(|entry| entry.relative_path.clone()),
+        )
+        .chain(
+            delta
+                .moved
+                .iter()
+                .map(|entry| entry.new_relative_path.clone()),
+        )
+        .collect::<Vec<_>>();
+    let snapshot = db
+        .browser_metadata_for_paths_at_revision(delta.revision, &projection_paths)
         .map_err(|error| format!("read committed browser projection delta: {error}"))?;
+    let revision = snapshot.revision;
+    let files = snapshot.files;
     if revision != delta.revision {
         tracing::info!(
             committed_revision = delta.revision,
@@ -208,27 +224,14 @@ fn build_browser_projection_delta(
         );
         return Ok(None);
     }
-    let upsert_paths = delta
-        .created
+    let upsert_paths = projection_paths
         .iter()
-        .map(|entry| entry.relative_path.as_path())
-        .chain(
-            delta
-                .changed
-                .iter()
-                .map(|entry| entry.relative_path.as_path()),
-        )
-        .chain(
-            delta
-                .moved
-                .iter()
-                .map(|entry| entry.new_relative_path.as_path()),
-        )
+        .cloned()
         .collect::<std::collections::HashSet<_>>();
     let mut folders = std::collections::BTreeSet::new();
     let upserted_files = files
         .into_iter()
-        .filter(|entry| !entry.missing && upsert_paths.contains(entry.relative_path.as_path()))
+        .filter(|entry| !entry.missing && upsert_paths.contains(&entry.relative_path))
         .map(|entry| {
             let absolute = root.join(&entry.relative_path);
             if let Some(parent) = absolute.parent() {
@@ -383,6 +386,41 @@ mod tests {
                 .is_none(),
             "ordinary deep hashing must remain queued for the supervisor"
         );
+    }
+
+    #[test]
+    fn filesystem_sync_publishes_exact_revision_for_an_empty_duplicate_sync() {
+        let root = tempfile::tempdir().expect("source root");
+        let unchanged = root.path().join("unchanged.wav");
+        std::fs::write(&unchanged, vec![3_u8; 128]).expect("unchanged wav");
+        let db =
+            SourceDatabase::open_for_test_fixture_source_write(root.path()).expect("source db");
+        scanner::hard_rescan(&db).expect("initial scan");
+
+        let result = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![PathBuf::from("unchanged.wav")],
+            1,
+            &AtomicBool::new(false),
+        );
+
+        let success = result.result.expect("sync result");
+        assert!(success.committed_delta.is_empty());
+        let projection = success
+            .browser_projection_delta
+            .expect("empty sync still carries the authoritative revision");
+        assert_eq!(
+            projection.manifest_revision,
+            success.committed_delta.revision
+        );
+        assert_eq!(
+            projection.snapshot_revision,
+            success.committed_delta.revision
+        );
+        assert!(projection.upserted_files.is_empty());
+        assert!(projection.removed_file_ids.is_empty());
     }
 
     #[cfg(unix)]

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -167,8 +167,23 @@ fn sync_source_database_paths_once(
             };
             let browser_projection_delta = if browser_delta_eligible && incomplete_error.is_none() {
                 match build_browser_projection_delta(root, &db, &completed.committed_delta) {
-                    Ok(projection) => projection,
+                    Ok(Some(projection)) => Some(projection),
+                    Ok(None) => {
+                        incomplete_error = Some(format!(
+                            "browser projection was not available at committed revision {}",
+                            completed.committed_delta.revision
+                        ));
+                        tracing::warn!(
+                            source_id,
+                            revision = completed.committed_delta.revision,
+                            "Falling back to a full browser projection after exact revision hydration failed"
+                        );
+                        None
+                    }
                     Err(error) => {
+                        incomplete_error = Some(format!(
+                            "browser projection hydration failed: {error}"
+                        ));
                         tracing::warn!(
                             source_id,
                             error,
@@ -286,12 +301,54 @@ fn wait_for_retry(cancel: &AtomicBool, delay: Duration) -> bool {
 mod tests {
     use std::{
         path::{Path, PathBuf},
-        sync::atomic::AtomicBool,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
     };
 
     use wavecrate::sample_sources::{Rating, SourceDatabase, scanner};
+    use wavecrate_scan::sample_sources::scanner::{ScanWritePhase, ScanWriter};
 
-    use super::{recover_source_filesystem_sync, sync_source_database_paths};
+    use super::{
+        recover_source_filesystem_sync, sync_source_database_paths,
+        sync_source_database_paths_with_writer,
+    };
+
+    #[derive(Clone)]
+    struct RevisionBumpingWriter {
+        database_root: PathBuf,
+        manifest_locks: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    struct RevisionBumpGuard {
+        database_root: PathBuf,
+        bump_revision: bool,
+    }
+
+    impl Drop for RevisionBumpGuard {
+        fn drop(&mut self) {
+            if !self.bump_revision {
+                return;
+            }
+            let db = SourceDatabase::open_for_test_fixture_source_write(&self.database_root)
+                .expect("open revision-bump database");
+            db.set_tag(Path::new("fresh.wav"), Rating::KEEP_1)
+                .expect("bump committed revision after scan");
+        }
+    }
+
+    impl ScanWriter for RevisionBumpingWriter {
+        type Guard = RevisionBumpGuard;
+
+        fn lock(&self, phase: ScanWritePhase) -> Self::Guard {
+            RevisionBumpGuard {
+                database_root: self.database_root.clone(),
+                bump_revision: phase == ScanWritePhase::Manifest
+                    && self.manifest_locks.fetch_add(1, Ordering::AcqRel) == 1,
+            }
+        }
+    }
 
     #[test]
     fn filesystem_sync_panic_returns_a_terminal_result() {
@@ -421,6 +478,39 @@ mod tests {
         );
         assert!(projection.upserted_files.is_empty());
         assert!(projection.removed_file_ids.is_empty());
+    }
+
+    #[test]
+    fn filesystem_sync_requires_full_recovery_when_projection_revision_changes() {
+        let root = tempfile::tempdir().expect("source root");
+        std::fs::write(root.path().join("fresh.wav"), vec![7_u8; 9 * 1024 * 1024])
+            .expect("large wav");
+        let writer = RevisionBumpingWriter {
+            database_root: root.path().to_path_buf(),
+            manifest_locks: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+
+        let result = sync_source_database_paths_with_writer(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![PathBuf::from("fresh.wav")],
+            1,
+            &AtomicBool::new(false),
+            &writer,
+        );
+
+        let success = result
+            .result
+            .expect("revision mismatch should retain the committed scan");
+        assert!(success.browser_projection_delta.is_none());
+        assert!(!success.committed_delta.is_empty());
+        assert!(
+            success
+                .incomplete_error
+                .as_deref()
+                .is_some_and(|error| error.contains("browser projection hydration failed"))
+        );
     }
 
     #[cfg(unix)]

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -200,6 +200,7 @@ fn sync_source_database_paths_once(
                 incomplete_error,
                 committed_delta: completed.committed_delta,
                 browser_projection_delta,
+                projection_handoff_ticket: None,
             })
         })
 }

--- a/src/native_app/sample_library/sample_collections/persistence.rs
+++ b/src/native_app/sample_library/sample_collections/persistence.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use wavecrate::sample_sources::{ExistingFileMetadataUpdate, SourceDatabase};
-use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 use crate::native_app::sample_library::folder_browser::view_contract::MissingCollectionFile;
 
@@ -32,10 +31,9 @@ pub(super) fn persist_collection_updates(
         .map_err(|err| err.to_string())?;
     let mut batch = db.write_batch().map_err(|err| err.to_string())?;
     for update in updates {
-        let (file_size, modified_ns) = file_metadata(&update.absolute_path)?;
         if matches!(
             batch
-                .update_existing_file_metadata(&update.relative_path, file_size, modified_ns)
+                .ensure_existing_live_file(&update.relative_path)
                 .map_err(|err| err.to_string())?,
             ExistingFileMetadataUpdate::Missing
         ) {
@@ -87,17 +85,6 @@ pub(super) fn persist_missing_collection_cleanup(
     batch
         .commit_auxiliary_state()
         .map_err(|err| err.to_string())
-}
-
-fn file_metadata(path: &Path) -> Result<(u64, i64), String> {
-    let metadata = std::fs::metadata(path)
-        .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
-    let modified_ns = system_time_to_unix_nanos(
-        metadata
-            .modified()
-            .map_err(|err| format!("Missing modified time for {}: {err}", path.display()))?,
-    );
-    Ok((metadata.len(), modified_ns))
 }
 
 #[cfg(test)]

--- a/src/native_app/sample_library/sample_collections/persistence.rs
+++ b/src/native_app/sample_library/sample_collections/persistence.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use wavecrate::sample_sources::SourceDatabase;
+use wavecrate::sample_sources::{ExistingFileMetadataUpdate, SourceDatabase};
 use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 use crate::native_app::sample_library::folder_browser::view_contract::MissingCollectionFile;
@@ -33,9 +33,17 @@ pub(super) fn persist_collection_updates(
     let mut batch = db.write_batch().map_err(|err| err.to_string())?;
     for update in updates {
         let (file_size, modified_ns) = file_metadata(&update.absolute_path)?;
-        batch
-            .upsert_file(&update.relative_path, file_size, modified_ns)
-            .map_err(|err| err.to_string())?;
+        if matches!(
+            batch
+                .update_existing_file_metadata(&update.relative_path, file_size, modified_ns)
+                .map_err(|err| err.to_string())?,
+            ExistingFileMetadataUpdate::Missing
+        ) {
+            return Err(format!(
+                "collection persistence deferred until source row exists: {}",
+                update.relative_path.display()
+            ));
+        }
         match update.operation {
             CollectionOperation::Add => batch
                 .add_collection(&update.relative_path, update.collection)
@@ -45,7 +53,9 @@ pub(super) fn persist_collection_updates(
                 .map_err(|err| err.to_string())?,
         }
     }
-    batch.commit().map_err(|err| err.to_string())
+    batch
+        .commit_auxiliary_state()
+        .map_err(|err| err.to_string())
 }
 
 pub(super) fn group_missing_collection_files_by_source(
@@ -74,7 +84,9 @@ pub(super) fn persist_missing_collection_cleanup(
             .remove_collection(&file.relative_path, file.collection)
             .map_err(|err| err.to_string())?;
     }
-    batch.commit().map_err(|err| err.to_string())
+    batch
+        .commit_auxiliary_state()
+        .map_err(|err| err.to_string())
 }
 
 fn file_metadata(path: &Path) -> Result<(u64, i64), String> {

--- a/src/native_app/sample_library/sample_ratings.rs
+++ b/src/native_app/sample_library/sample_ratings.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use radiant::prelude as ui;
-use wavecrate::sample_sources::{Rating, SourceDatabase};
+use wavecrate::sample_sources::{ExistingFileMetadataUpdate, Rating, SourceDatabase};
 use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
@@ -784,9 +784,21 @@ pub(in crate::native_app) fn persist_rating_requests(
             for index in &active {
                 let request = &requests[*index];
                 let (file_size, modified_ns) = file_metadata(&request.absolute_path)?;
-                batch
-                    .upsert_file(&request.relative_path, file_size, modified_ns)
-                    .map_err(|err| err.to_string())?;
+                if matches!(
+                    batch
+                        .update_existing_file_metadata(
+                            &request.relative_path,
+                            file_size,
+                            modified_ns,
+                        )
+                        .map_err(|err| err.to_string())?,
+                    ExistingFileMetadataUpdate::Missing
+                ) {
+                    return Err(format!(
+                        "rating persistence deferred until source row exists: {}",
+                        request.relative_path.display()
+                    ));
+                }
                 batch
                     .set_tag(&request.relative_path, request.rating)
                     .map_err(|err| err.to_string())?;
@@ -794,7 +806,9 @@ pub(in crate::native_app) fn persist_rating_requests(
                     .set_locked(&request.relative_path, request.locked)
                     .map_err(|err| err.to_string())?;
             }
-            batch.commit().map_err(|err| err.to_string())
+            batch
+                .commit_auxiliary_state()
+                .map_err(|err| err.to_string())
         })();
         for index in active {
             results[index] = Some(result.clone());

--- a/src/native_app/sample_library/sample_ratings.rs
+++ b/src/native_app/sample_library/sample_ratings.rs
@@ -6,7 +6,6 @@ use std::{
 
 use radiant::prelude as ui;
 use wavecrate::sample_sources::{ExistingFileMetadataUpdate, Rating, SourceDatabase};
-use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
 use crate::native_app::sample_library::file_actions::sample_path_label;
@@ -783,14 +782,9 @@ pub(in crate::native_app) fn persist_rating_requests(
             let mut batch = db.write_batch().map_err(|err| err.to_string())?;
             for index in &active {
                 let request = &requests[*index];
-                let (file_size, modified_ns) = file_metadata(&request.absolute_path)?;
                 if matches!(
                     batch
-                        .update_existing_file_metadata(
-                            &request.relative_path,
-                            file_size,
-                            modified_ns,
-                        )
+                        .ensure_existing_live_file(&request.relative_path)
                         .map_err(|err| err.to_string())?,
                     ExistingFileMetadataUpdate::Missing
                 ) {
@@ -834,17 +828,6 @@ impl RatingUpdate {
 
 fn direction_label(delta: i8) -> &'static str {
     if delta < 0 { "down" } else { "up" }
-}
-
-fn file_metadata(path: &Path) -> Result<(u64, i64), String> {
-    let metadata = std::fs::metadata(path)
-        .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
-    let modified_ns = system_time_to_unix_nanos(
-        metadata
-            .modified()
-            .map_err(|err| format!("Missing modified time for {}: {err}", path.display()))?,
-    );
-    Ok((metadata.len(), modified_ns))
 }
 
 #[cfg(test)]

--- a/src/native_app/sample_library/selected_file_actions.rs
+++ b/src/native_app/sample_library/selected_file_actions.rs
@@ -3,7 +3,8 @@ use crate::native_app::app::{
 };
 use crate::native_app::app::{emit_gui_action, sample_path_label};
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation, FileMutationPostCommit, FileMutationProjection,
+    FileMutationChange, FileMutationOperation, FileMutationPostCommit,
+    FileMutationPostCommitPresentation, FileMutationProjection,
 };
 use crate::native_app::sample_library::folder_browser::BrowserListingRevealReason;
 use crate::native_app::sample_library::sample_list::{
@@ -539,6 +540,7 @@ impl NativeAppState {
                         playback_type,
                         focus_derivative: effective_focus_derivative,
                         started_at,
+                        presentation: FileMutationPostCommitPresentation::Extracted,
                     });
                     self.queue_committed_file_mutation(
                         FileMutationOperation::Extract,
@@ -575,9 +577,12 @@ impl NativeAppState {
                         "same_source_derivative"
                     }),
                 );
-                let metadata_error = self
-                    .assign_extracted_file_metadata(&path, playback_type, context)
-                    .err();
+                let metadata_error = if drag_position.is_some() {
+                    self.project_extracted_file_metadata(&path, playback_type)
+                        .err()
+                } else {
+                    None
+                };
                 if let Some(request) = self.harvest_selection_derivation_request(
                     &completion.source_path,
                     &path,
@@ -659,15 +664,34 @@ impl NativeAppState {
                 }
                 self.queue_partially_committed_file_mutation(
                     FileMutationOperation::Extract,
-                    vec![if focus_derivative && drag_position.is_none() {
-                        FileMutationChange::created(path.clone()).with_projection(
-                            FileMutationProjection::FocusAndLoad {
-                                path,
-                                reason: BrowserListingRevealReason::LoadedFileFocus,
-                            },
-                        )
+                    vec![if drag_position.is_none() {
+                        let change = if focus_derivative {
+                            FileMutationChange::created(path.clone()).with_projection(
+                                FileMutationProjection::FocusAndLoad {
+                                    path,
+                                    reason: BrowserListingRevealReason::LoadedFileFocus,
+                                },
+                            )
+                        } else {
+                            FileMutationChange::created(path)
+                        };
+                        change.with_post_commit(FileMutationPostCommit {
+                            source_path: completion.source_path.clone(),
+                            selection: completion.selection,
+                            playback_type,
+                            focus_derivative,
+                            started_at,
+                            presentation: FileMutationPostCommitPresentation::Extracted,
+                        })
                     } else {
-                        FileMutationChange::created(path)
+                        FileMutationChange::created(path).with_post_commit(FileMutationPostCommit {
+                            source_path: completion.source_path.clone(),
+                            selection: completion.selection,
+                            playback_type,
+                            focus_derivative: false,
+                            started_at,
+                            presentation: FileMutationPostCommitPresentation::Drag,
+                        })
                     }],
                     metadata_error
                         .into_iter()
@@ -719,6 +743,15 @@ impl NativeAppState {
         post_commit: &FileMutationPostCommit,
         metadata_error: Option<&str>,
     ) {
+        if post_commit.presentation == FileMutationPostCommitPresentation::Drag {
+            if let Some(error) = metadata_error {
+                self.ui.status.sample = format!(
+                    "Dragging {}; extracted metadata incomplete: {error}",
+                    sample_path_label(path)
+                );
+            }
+            return;
+        }
         self.evict_waveform_cache_path(path);
         self.waveform
             .current

--- a/src/native_app/sample_library/selected_file_actions.rs
+++ b/src/native_app/sample_library/selected_file_actions.rs
@@ -3,7 +3,7 @@ use crate::native_app::app::{
 };
 use crate::native_app::app::{emit_gui_action, sample_path_label};
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation, FileMutationProjection,
+    FileMutationChange, FileMutationOperation, FileMutationPostCommit, FileMutationProjection,
 };
 use crate::native_app::sample_library::folder_browser::BrowserListingRevealReason;
 use crate::native_app::sample_library::sample_list::{
@@ -504,6 +504,49 @@ impl NativeAppState {
     ) {
         match completion.result {
             Ok(path) => {
+                if drag_position.is_none() {
+                    // The authoritative metadata and browser publication remain deferred, but a
+                    // reused output path must not keep stale decoded audio while that completes.
+                    self.evict_waveform_cache_path(&path);
+                    let source_duration_seconds = self.waveform.current.duration_seconds() as f64;
+                    if let Some(request) = self.harvest_selection_derivation_request(
+                        &completion.source_path,
+                        &path,
+                        completion.selection,
+                        source_duration_seconds,
+                        harvest_operation.clone(),
+                    ) {
+                        self.background
+                            .harvest_selection_derivation
+                            .enqueue(request);
+                        self.background
+                            .harvest_selection_derivation
+                            .schedule_if_idle(context);
+                    }
+                    let cross_source_derivative =
+                        self.extraction_derivative_crosses_sources(&completion.source_path, &path);
+                    let mut change = FileMutationChange::created(path.clone());
+                    let effective_focus_derivative = focus_derivative && cross_source_derivative;
+                    if effective_focus_derivative {
+                        change = change.with_projection(FileMutationProjection::FocusAndLoad {
+                            path: path.clone(),
+                            reason: BrowserListingRevealReason::LoadedFileFocus,
+                        });
+                    }
+                    change = change.with_post_commit(FileMutationPostCommit {
+                        source_path: completion.source_path,
+                        selection: completion.selection,
+                        playback_type,
+                        focus_derivative: effective_focus_derivative,
+                        started_at,
+                    });
+                    self.queue_committed_file_mutation(
+                        FileMutationOperation::Extract,
+                        vec![change],
+                        context,
+                    );
+                    return;
+                }
                 self.evict_waveform_cache_path(&path);
                 self.waveform
                     .current
@@ -542,7 +585,9 @@ impl NativeAppState {
                     self.waveform.current.duration_seconds() as f64,
                     harvest_operation,
                 ) {
-                    self.background.harvest_selection_derivation.enqueue(request);
+                    self.background
+                        .harvest_selection_derivation
+                        .enqueue(request);
                     self.background
                         .harvest_selection_derivation
                         .schedule_if_idle(context);
@@ -654,6 +699,66 @@ impl NativeAppState {
                 );
             }
         }
+    }
+
+    pub(in crate::native_app) fn finish_committed_playmark_extraction_metadata(
+        &mut self,
+        path: &Path,
+        post_commit: &FileMutationPostCommit,
+        context: &mut radiant::prelude::UiUpdateContext<GuiMessage>,
+    ) -> Option<String> {
+        let metadata_error = self
+            .assign_extracted_file_metadata(path, post_commit.playback_type, context)
+            .err();
+        metadata_error
+    }
+
+    pub(in crate::native_app) fn finish_committed_playmark_extraction_visuals(
+        &mut self,
+        path: &Path,
+        post_commit: &FileMutationPostCommit,
+        metadata_error: Option<&str>,
+    ) {
+        self.evict_waveform_cache_path(path);
+        self.waveform
+            .current
+            .mark_extracted_play_selection(&post_commit.source_path, post_commit.selection);
+        self.waveform.current.flash_play_selection();
+        let protected_origin = self
+            .library
+            .folder_browser
+            .path_is_in_protected_source(&post_commit.source_path);
+        self.flash_primary_source_acceptance_for_protected_extraction(
+            &post_commit.source_path,
+            path,
+        );
+        self.log_sample_identity_checkpoint(
+            "waveform.extract.finished_after_refresh",
+            "finish_committed_playmark_extraction",
+            Some(path),
+            Some(if protected_origin && post_commit.focus_derivative {
+                "protected_origin_cross_source_derivative"
+            } else if post_commit.focus_derivative {
+                "cross_source_derivative"
+            } else if protected_origin {
+                "protected_origin_derivative_left_unfocused"
+            } else {
+                "same_source_derivative_left_unfocused"
+            }),
+        );
+        let label = sample_path_label(path);
+        self.ui.status.sample = match metadata_error {
+            Some(error) => format!("Extracted {label}; extracted metadata incomplete: {error}"),
+            None => format!("Extracted {label}"),
+        };
+        emit_gui_action(
+            "waveform.extract_playmarked_range",
+            Some("waveform"),
+            Some(&label),
+            "success",
+            post_commit.started_at,
+            None,
+        );
     }
 
     pub(in crate::native_app) fn finish_selected_whole_files_harvest_extraction(

--- a/src/native_app/source_processing/mod.rs
+++ b/src/native_app/source_processing/mod.rs
@@ -11,8 +11,8 @@ pub(in crate::native_app) use events::{
     SourceProcessingLifecycle, SourceProcessingPresentation, SourceProcessingProgressEvent,
 };
 pub(in crate::native_app) use supervisor::{
-    ExternalScanHandoff, SourceAuditLifecycleCause, SourceProcessingSupervisor,
-    SourceScanAdmissionState,
+    ExternalScanHandoff, ProjectionHandoffTicket, SourceAuditLifecycleCause,
+    SourceProcessingBudgetHandle, SourceProcessingSupervisor, SourceScanAdmissionState,
 };
 pub(in crate::native_app) use worker::run_internal_source_analysis_from_args;
 #[cfg(not(test))]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -90,8 +90,11 @@ mod state;
 mod state_machine_observation;
 mod telemetry;
 
-pub(in crate::native_app) use admission::{ExternalScanHandoff, SourceScanAdmissionState};
-use admission::{SourceProcessingBudgetHandle, install_worker_app_root};
+use admission::install_worker_app_root;
+pub(in crate::native_app) use admission::{
+    ExternalScanHandoff, ProjectionHandoffTicket, SourceProcessingBudgetHandle,
+    SourceScanAdmissionState,
+};
 use cache_ownership::*;
 pub(in crate::native_app) use commands::SourceAuditLifecycleCause;
 use control::*;

--- a/src/native_app/source_processing/supervisor/admission.rs
+++ b/src/native_app/source_processing/supervisor/admission.rs
@@ -15,6 +15,163 @@ pub(in crate::native_app) enum ExternalScanHandoff {
     FullReconciliation { reason: &'static str },
 }
 
+/// Clone-safe one-shot handoff from a worker's committed source mutation to the GUI projection.
+///
+/// The worker installs the source-scoped fence before releasing its scarce scan permit. The GUI
+/// must resolve the ticket only after applying the exact hydrated projection. Dropping the last
+/// unresolved clone takes the conservative full-reconciliation path.
+#[derive(Clone)]
+pub(in crate::native_app) struct ProjectionHandoffTicket {
+    shared: Arc<Shared>,
+    state: Arc<super::Mutex<ProjectionTicketState>>,
+    source_id: String,
+    lifecycle_generation: u64,
+    delta: CommittedSourceDelta,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProjectionTicketState {
+    Pending,
+    Accepted,
+    Rejected,
+}
+
+impl std::fmt::Debug for ProjectionHandoffTicket {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ProjectionHandoffTicket")
+            .field("source_id", &self.source_id)
+            .field("lifecycle_generation", &self.lifecycle_generation)
+            .field("revision", &self.delta.revision)
+            .finish()
+    }
+}
+
+impl PartialEq for ProjectionHandoffTicket {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &other.state)
+    }
+}
+
+impl Eq for ProjectionHandoffTicket {}
+
+impl ProjectionHandoffTicket {
+    fn new(
+        shared: Arc<Shared>,
+        source_id: String,
+        lifecycle_generation: u64,
+        delta: CommittedSourceDelta,
+    ) -> Self {
+        Self {
+            shared,
+            state: Arc::new(super::Mutex::new(ProjectionTicketState::Pending)),
+            source_id,
+            lifecycle_generation,
+            delta,
+        }
+    }
+
+    /// Accept the handoff after the GUI has applied the exact projection.
+    ///
+    /// `false` means the ticket was stale, invalid, rejected by the supervisor, or resolved more
+    /// than once. Every false outcome is conservative: it requests complete source
+    /// reconciliation and never publishes a targeted readiness delta.
+    pub(in crate::native_app) fn accept(&self) -> bool {
+        if !self.claim_resolution(ProjectionTicketState::Accepted) {
+            self.request_full_reconciliation("projection_handoff_duplicate_resolution");
+            return false;
+        }
+        let mut control = self.shared.control();
+        let fence_matches = control
+            .pending_projection_fences
+            .get(&self.source_id)
+            .is_some_and(|fence| {
+                fence.lifecycle_generation == self.lifecycle_generation
+                    && fence.revision == self.delta.revision
+            });
+        let current = control.source_is_active(&self.source_id)
+            && control.source_lifecycle_generations.get(&self.source_id)
+                == Some(&self.lifecycle_generation);
+        if !current || !fence_matches {
+            drop(control);
+            self.request_full_reconciliation("projection_handoff_stale_or_invalid");
+            return false;
+        }
+        control.pending_projection_fences.remove(&self.source_id);
+        let accepted = self.delta.is_empty()
+            || matches!(
+                control.queue_source_delta(
+                    &self.source_id,
+                    self.lifecycle_generation,
+                    &self.delta,
+                    "projection_handoff_accepted",
+                ),
+                SourceDeltaQueueResult::Queued | SourceDeltaQueueResult::Ignored
+            );
+        if !accepted {
+            control.pending_readiness_deltas.remove(&self.source_id);
+            control.cancel_source_work(&self.source_id);
+            control.mark_source_dirty(&self.source_id, "projection_handoff_delta_rejected");
+        }
+        drop(control);
+        self.shared.wake.notify_one();
+        accepted
+    }
+
+    /// Reject the handoff after projection absence, hydration failure, cancellation, or an
+    /// unsuccessful exact-revision apply.
+    pub(in crate::native_app) fn reject(&self, reason: &'static str) {
+        if !self.claim_resolution(ProjectionTicketState::Rejected) {
+            self.request_full_reconciliation("projection_handoff_duplicate_rejection");
+            return;
+        }
+        self.request_full_reconciliation(reason);
+    }
+
+    fn claim_resolution(&self, resolution: ProjectionTicketState) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if *state != ProjectionTicketState::Pending {
+            return false;
+        }
+        *state = resolution;
+        true
+    }
+
+    fn request_full_reconciliation(&self, reason: &'static str) {
+        let mut control = self.shared.control();
+        control.pending_projection_fences.remove(&self.source_id);
+        control.pending_readiness_deltas.remove(&self.source_id);
+        if control.source_is_active(&self.source_id)
+            && control.source_lifecycle_generations.get(&self.source_id)
+                == Some(&self.lifecycle_generation)
+        {
+            control.cancel_source_work(&self.source_id);
+            control.mark_source_dirty(&self.source_id, reason);
+        }
+        drop(control);
+        self.shared.wake.notify_one();
+    }
+}
+
+impl Drop for ProjectionHandoffTicket {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.state) != 1 {
+            return;
+        }
+        let pending = *self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            == ProjectionTicketState::Pending;
+        if pending {
+            self.reject("projection_handoff_dropped_unresolved");
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(in crate::native_app) struct SourceProcessingBudgetHandle {
     pub(super) shared: Arc<Shared>,
@@ -245,6 +402,49 @@ impl SourceProcessingBudgetPermit {
 
     pub(in crate::native_app) fn scan_writer(&self) -> DatabaseWriterGate {
         self.shared.database_writer.clone()
+    }
+
+    /// Install the source-scoped projection fence and release the scarce worker capacity before
+    /// handing the exact committed delta to the GUI.
+    pub(in crate::native_app) fn release_after_projection_handoff(
+        mut self,
+        delta: CommittedSourceDelta,
+    ) -> ProjectionHandoffTicket {
+        let source_id = self
+            .permit
+            .as_ref()
+            .map(|permit| permit.source_id().to_string())
+            .unwrap_or_default();
+        let ticket = ProjectionHandoffTicket::new(
+            Arc::clone(&self.shared),
+            source_id.clone(),
+            self.lifecycle_generation,
+            delta,
+        );
+        let mut control = self.shared.control();
+        let current = control.source_is_active(&source_id)
+            && control.source_lifecycle_generations.get(&source_id)
+                == Some(&self.lifecycle_generation);
+        if current && !control.pending_projection_fences.contains_key(&source_id) {
+            control.pending_projection_fences.insert(
+                source_id,
+                super::PendingProjectionFence {
+                    lifecycle_generation: self.lifecycle_generation,
+                    revision: ticket.delta.revision,
+                },
+            );
+            self.handoff_registered = true;
+        } else {
+            drop(control);
+            ticket.reject("projection_handoff_fence_install_rejected");
+            self.handoff_registered = true;
+            drop(self);
+            return ticket;
+        }
+        drop(control);
+        self.shared.wake.notify_one();
+        drop(self);
+        ticket
     }
 
     /// Register the committed scan result before releasing the source-processing budget.

--- a/src/native_app/source_processing/supervisor/admission.rs
+++ b/src/native_app/source_processing/supervisor/admission.rs
@@ -97,7 +97,16 @@ impl ProjectionHandoffTicket {
             self.request_full_reconciliation("projection_handoff_stale_or_invalid");
             return false;
         }
-        control.pending_projection_fences.remove(&self.source_id);
+        let fence_matches = control
+            .pending_projection_fences
+            .get(&self.source_id)
+            .is_some_and(|fence| {
+                fence.lifecycle_generation == self.lifecycle_generation
+                    && fence.revision == self.delta.revision
+            });
+        if fence_matches {
+            control.pending_projection_fences.remove(&self.source_id);
+        }
         let accepted = self.delta.is_empty()
             || matches!(
                 control.queue_source_delta(
@@ -106,7 +115,7 @@ impl ProjectionHandoffTicket {
                     &self.delta,
                     "projection_handoff_accepted",
                 ),
-                SourceDeltaQueueResult::Queued | SourceDeltaQueueResult::Ignored
+                SourceDeltaQueueResult::Queued
             );
         if !accepted {
             control.pending_readiness_deltas.remove(&self.source_id);
@@ -142,8 +151,17 @@ impl ProjectionHandoffTicket {
 
     fn request_full_reconciliation(&self, reason: &'static str) {
         let mut control = self.shared.control();
-        control.pending_projection_fences.remove(&self.source_id);
-        control.pending_readiness_deltas.remove(&self.source_id);
+        let fence_matches = control
+            .pending_projection_fences
+            .get(&self.source_id)
+            .is_some_and(|fence| {
+                fence.lifecycle_generation == self.lifecycle_generation
+                    && fence.revision == self.delta.revision
+            });
+        if fence_matches {
+            control.pending_projection_fences.remove(&self.source_id);
+            control.pending_readiness_deltas.remove(&self.source_id);
+        }
         if control.source_is_active(&self.source_id)
             && control.source_lifecycle_generations.get(&self.source_id)
                 == Some(&self.lifecycle_generation)

--- a/src/native_app/source_processing/supervisor/control.rs
+++ b/src/native_app/source_processing/supervisor/control.rs
@@ -1,7 +1,7 @@
 use super::{
     AcceptedManifestRevision, Arc, AtomicBool, BTreeMap, BTreeSet, CommittedSourceDelta, Ordering,
-    PendingReadinessDelta, PendingReadinessDeltaMerge, PendingSourceRetirement, PriorityContext,
-    SampleSource, source_storage_identity_matches,
+    PendingProjectionFence, PendingReadinessDelta, PendingReadinessDeltaMerge,
+    PendingSourceRetirement, PriorityContext, SampleSource, source_storage_identity_matches,
 };
 
 pub(super) struct ControlState {
@@ -17,6 +17,7 @@ pub(super) struct ControlState {
     pub(super) lifecycle_audits_deferred_until_watcher_ready: bool,
     pub(super) deferred_lifecycle_audit_sources: BTreeSet<String>,
     pub(super) pending_readiness_deltas: BTreeMap<String, PendingReadinessDelta>,
+    pub(super) pending_projection_fences: BTreeMap<String, PendingProjectionFence>,
     pub(super) accepted_manifest_revisions: BTreeMap<String, AcceptedManifestRevision>,
     pub(super) awaiting_foreground_refresh_sources: BTreeSet<String>,
     pub(super) force_manifest_audit_sources: BTreeSet<String>,

--- a/src/native_app/source_processing/supervisor/coordinator.rs
+++ b/src/native_app/source_processing/supervisor/coordinator.rs
@@ -36,6 +36,7 @@ pub(super) fn run_coordinator(shared: Arc<Shared>) {
             force_manifest_audit_sources,
             force_reanalysis_sources,
             pending_readiness_deltas,
+            pending_projection_fences,
             source_work_cancels,
             source_lifecycle_generations,
             priority,
@@ -143,6 +144,19 @@ pub(super) fn run_coordinator(shared: Arc<Shared>) {
             let force_manifest_audit_sources = control.force_manifest_audit_sources.clone();
             let force_reanalysis_sources = control.force_reanalysis_sources.clone();
             let pending_readiness_deltas = control.pending_readiness_deltas.clone();
+            let pending_projection_fences = control.pending_projection_fences.clone();
+            let blocked_dirty_sources = dirty_sources
+                .iter()
+                .filter(|source_id| pending_projection_fences.contains_key(*source_id))
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            control
+                .dirty_sources
+                .extend(blocked_dirty_sources.iter().cloned());
+            let dirty_sources = dirty_sources
+                .difference(&blocked_dirty_sources)
+                .cloned()
+                .collect::<BTreeSet<_>>();
             (
                 control
                     .sources
@@ -156,6 +170,7 @@ pub(super) fn run_coordinator(shared: Arc<Shared>) {
                 force_manifest_audit_sources,
                 force_reanalysis_sources,
                 pending_readiness_deltas,
+                pending_projection_fences,
                 control.source_work_cancels.clone(),
                 control.source_lifecycle_generations.clone(),
                 control.priority.clone(),
@@ -210,12 +225,18 @@ pub(super) fn run_coordinator(shared: Arc<Shared>) {
         }
         let sources_to_discover = sources
             .iter()
-            .filter(|source| discovery_source_id.as_deref() == Some(source.id.as_str()))
+            .filter(|source| {
+                discovery_source_id.as_deref() == Some(source.id.as_str())
+                    && !pending_projection_fences.contains_key(source.id.as_str())
+            })
             .cloned()
             .collect::<Vec<_>>();
         candidates.retain(|candidate| {
             let source_id = candidate.source.id.as_str();
             if !configured_source_ids.contains(source_id) {
+                return false;
+            }
+            if pending_projection_fences.contains_key(source_id) {
                 return false;
             }
             if !dirty_sources.contains(source_id) {
@@ -231,6 +252,9 @@ pub(super) fn run_coordinator(shared: Arc<Shared>) {
         source_stats.retain(|source_id, _| configured_source_ids.contains(source_id));
         let sweep_started = Instant::now();
         for source in &sources_to_discover {
+            if pending_projection_fences.contains_key(source.id.as_str()) {
+                continue;
+            }
             if !discovery_is_safety_probe
                 && !pending_readiness_deltas.contains_key(source.id.as_str())
             {

--- a/src/native_app/source_processing/supervisor/lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/lifecycle.rs
@@ -154,6 +154,14 @@ impl SourceProcessingSupervisor {
             retained_source_ids.contains(source_id) && !changed_source_ids.contains(source_id)
         });
         control
+            .pending_projection_fences
+            .retain(|source_id, fence| {
+                retained_source_ids.contains(source_id)
+                    && !changed_source_ids.contains(source_id)
+                    && source_lifecycle_generations.get(source_id)
+                        == Some(&fence.lifecycle_generation)
+            });
+        control
             .accepted_manifest_revisions
             .retain(|source_id, fence| {
                 retained_source_ids.contains(source_id)

--- a/src/native_app/source_processing/supervisor/model.rs
+++ b/src/native_app/source_processing/supervisor/model.rs
@@ -12,6 +12,12 @@ pub(super) struct PendingSourceRetirement {
     pub(super) terminal_offline: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct PendingProjectionFence {
+    pub(super) lifecycle_generation: u64,
+    pub(super) revision: u64,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct PendingReadinessDelta {
     pub(super) scope_ids: BTreeSet<String>,

--- a/src/native_app/source_processing/supervisor/state.rs
+++ b/src/native_app/source_processing/supervisor/state.rs
@@ -147,6 +147,7 @@ impl Shared {
                 lifecycle_audits_deferred_until_watcher_ready,
                 deferred_lifecycle_audit_sources: BTreeSet::new(),
                 pending_readiness_deltas: BTreeMap::new(),
+                pending_projection_fences: BTreeMap::new(),
                 accepted_manifest_revisions: BTreeMap::new(),
                 awaiting_foreground_refresh_sources: BTreeSet::new(),
                 force_manifest_audit_sources: BTreeSet::new(),

--- a/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
@@ -230,6 +230,101 @@ fn targeted_scan_handoff_is_registered_before_delayed_gui_delivery() {
 }
 
 #[test]
+fn projection_handoff_rejection_keeps_delta_and_readiness_fenced_until_gui_resolution() {
+    let (_directory, source) = unhashed_source("projection-handoff-rejection");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    {
+        let mut control = supervisor.shared.control();
+        control.dirty_sources.clear();
+    }
+    let generation = supervisor.lifecycle_generations()[source.id.as_str()];
+    let permit = supervisor
+        .budget_handle()
+        .acquire_scan_for_generation(source.id.as_str(), generation)
+        .expect("admit targeted sync");
+    let ticket = permit.release_after_projection_handoff(CommittedSourceDelta {
+        revision: 11,
+        changed: vec![wavecrate::sample_sources::scanner::ManifestIdentityDelta {
+            identity: String::from("projection.wav"),
+            relative_path: PathBuf::from("projection.wav"),
+            content_generation: String::from("generation-11"),
+            source_metadata_changed: true,
+        }],
+        ..CommittedSourceDelta::default()
+    });
+
+    let control = supervisor.shared.control();
+    assert!(
+        control
+            .pending_projection_fences
+            .contains_key(source.id.as_str())
+    );
+    assert!(
+        !control
+            .pending_readiness_deltas
+            .contains_key(source.id.as_str())
+    );
+    drop(control);
+
+    ticket.reject("projection_handoff_test_rejection");
+    let control = supervisor.shared.control();
+    assert!(
+        !control
+            .pending_projection_fences
+            .contains_key(source.id.as_str())
+    );
+    assert!(
+        !control
+            .pending_readiness_deltas
+            .contains_key(source.id.as_str())
+    );
+    assert!(control.dirty_sources.contains(source.id.as_str()));
+    drop(control);
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
+fn accepted_empty_projection_handoff_is_a_checkpoint_only_noop() {
+    let (_directory, source) = unhashed_source("projection-handoff-empty");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    {
+        let mut control = supervisor.shared.control();
+        control.dirty_sources.clear();
+    }
+    let generation = supervisor.lifecycle_generations()[source.id.as_str()];
+    let permit = supervisor
+        .budget_handle()
+        .acquire_scan_for_generation(source.id.as_str(), generation)
+        .expect("admit targeted sync");
+    let ticket = permit.release_after_projection_handoff(CommittedSourceDelta {
+        revision: 11,
+        ..CommittedSourceDelta::default()
+    });
+
+    assert!(ticket.accept());
+    let control = supervisor.shared.control();
+    assert!(
+        !control
+            .pending_projection_fences
+            .contains_key(source.id.as_str())
+    );
+    assert!(
+        !control
+            .pending_readiness_deltas
+            .contains_key(source.id.as_str())
+    );
+    assert!(!control.dirty_sources.contains(source.id.as_str()));
+    drop(control);
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
 fn foreground_scan_handoff_uses_full_fallback_before_capacity_release() {
     let (_directory, source) = unhashed_source("foreground-scan-fallback");
     let mut supervisor = SourceProcessingSupervisor::dormant();

--- a/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
@@ -325,6 +325,91 @@ fn accepted_empty_projection_handoff_is_a_checkpoint_only_noop() {
 }
 
 #[test]
+fn ignored_projection_handoff_delta_requests_full_reconciliation() {
+    let (_directory, source) = unhashed_source("projection-handoff-ignored");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    let generation = supervisor.lifecycle_generations()[source.id.as_str()];
+    {
+        let mut control = supervisor.shared.control();
+        control.accept_reconciled_manifest_revision(source.id.as_str(), generation, 11);
+        control.dirty_sources.clear();
+    }
+    let permit = supervisor
+        .budget_handle()
+        .acquire_scan_for_generation(source.id.as_str(), generation)
+        .expect("admit targeted sync");
+    let ticket = permit.release_after_projection_handoff(readiness_delta(11, "ignored"));
+
+    assert!(
+        !ticket.accept(),
+        "an ignored non-empty delta needs recovery"
+    );
+    let control = supervisor.shared.control();
+    assert!(
+        !control
+            .pending_projection_fences
+            .contains_key(source.id.as_str())
+    );
+    assert!(
+        !control
+            .pending_readiness_deltas
+            .contains_key(source.id.as_str())
+    );
+    assert!(control.dirty_sources.contains(source.id.as_str()));
+    drop(control);
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
+fn duplicate_old_projection_ticket_cannot_clear_newer_same_source_fence() {
+    let (_directory, source) = unhashed_source("projection-handoff-duplicate");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    let generation = supervisor.lifecycle_generations()[source.id.as_str()];
+    {
+        let mut control = supervisor.shared.control();
+        control.dirty_sources.clear();
+    }
+
+    let first_permit = supervisor
+        .budget_handle()
+        .acquire_scan_for_generation(source.id.as_str(), generation)
+        .expect("admit first targeted sync");
+    let first_ticket = first_permit.release_after_projection_handoff(readiness_delta(1, "first"));
+    assert!(first_ticket.accept());
+
+    let second_permit = supervisor
+        .budget_handle()
+        .acquire_scan_for_generation(source.id.as_str(), generation)
+        .expect("admit second targeted sync");
+    let second_ticket =
+        second_permit.release_after_projection_handoff(readiness_delta(2, "second"));
+
+    assert!(
+        !first_ticket.accept(),
+        "duplicate old ticket must remain stale"
+    );
+    let control = supervisor.shared.control();
+    assert_eq!(
+        control
+            .pending_projection_fences
+            .get(source.id.as_str())
+            .map(|fence| (fence.lifecycle_generation, fence.revision)),
+        Some((generation, 2)),
+        "a stale duplicate must not clear the newer same-source fence"
+    );
+    drop(control);
+
+    second_ticket.reject("projection_handoff_duplicate_test_cleanup");
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
 fn foreground_scan_handoff_uses_full_fallback_before_capacity_release() {
     let (_directory, source) = unhashed_source("foreground-scan-fallback");
     let mut supervisor = SourceProcessingSupervisor::dormant();

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -99,13 +99,13 @@ pub(crate) use wavecrate_library::sample_sources::is_supported_audio;
 pub use wavecrate_library::sample_sources::normalize_relative_path;
 pub use wavecrate_library::sample_sources::readiness;
 pub use wavecrate_library::sample_sources::{
-    BrowserMetadataSnapshot, DB_FILE_NAME, HarvestDerivationOperation, HarvestDerivationRecord,
-    HarvestFileIdentity, HarvestFileKey, HarvestFileRecord, HarvestMetadataSnapshot,
-    HarvestSourceRange, HarvestState, LIBRARY_DB_FILE_NAME, LibraryError, LibraryState,
-    NewHarvestDerivation, Rating, SampleSource, SourceCollectionWrite, SourceContentHashWrite,
-    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite, SourceId,
-    SourceMetadataStorage, SourceRole, SourceTagWrite, SourceWriteCommand, WavEntry,
-    database_path_for, default_primary_import_folder, normalize_path,
+    BrowserMetadataSnapshot, DB_FILE_NAME, ExistingFileMetadataUpdate, HarvestDerivationOperation,
+    HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey, HarvestFileRecord,
+    HarvestMetadataSnapshot, HarvestSourceRange, HarvestState, LIBRARY_DB_FILE_NAME, LibraryError,
+    LibraryState, NewHarvestDerivation, Rating, SampleSource, SourceCollectionWrite,
+    SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole, SourceDbError,
+    SourceFileWrite, SourceId, SourceMetadataStorage, SourceRole, SourceTagWrite,
+    SourceWriteCommand, WavEntry, database_path_for, default_primary_import_folder, normalize_path,
 };
 pub use wavecrate_library::sample_sources::{HiddenDirectoryPolicy, SourceTraversalPolicy};
 pub use wavecrate_scan::sample_sources::ScanTracker;


### PR DESCRIPTION
## Goal

Make normal Playmark extraction publish its known artifact through one bounded committed-mutation path: authoritative path/identity, browser row/projection, metadata, and readiness, without source-wide manifest/browser/tag materialization or an unnecessary second watcher-triggered full reconciliation.

Root cause addressed: extraction metadata writers used generic upsert behavior that dirtied source path/identity revisions. The targeted scanner then observed a revision gap, while the nominal path also materialized full source snapshots. Large outputs could not be synchronously hashed/acknowledged, allowing a later duplicate watcher sync to widen again.

## Scope and non-goals

- Add typed existing-row metadata-only updates with explicit missing-row deferral; keep rating, lock, playback-tag, collection, and playback-history persistence revision-neutral.
- Build exact affected-path browser projection deltas at the committed source revision, including authoritative empty/duplicate watcher-sync revisions.
- Sequence normal Playmark metadata publication after the created source row is authoritative, preserve optimistic overlays, and avoid forced whole-source tag hydration on the healthy path.
- Fence projection application, watcher acknowledgement, readiness wake, lifecycle generations, operation IDs, identity/content generations, protected-source routing, and conservative recovery.
- Replace committed-mutation full manifest reads with bounded affected-path snapshots.
- Non-goals: Finder folder refresh, extraction DSP, Radiant changes, audio-thread work, UI redesign, or broad profiling/rearchitecture.

## Definition of Done

- Healthy normal extraction uses exact affected-path manifest and browser queries only.
- The exact browser projection revision is applied before watcher acknowledgement and readiness publication.
- Empty/duplicate watcher syncs are no-ops only when the browser already covers the exact authoritative revision.
- Metadata-only writers do not advance path/identity revisions and report missing rows explicitly.
- True revision gaps, incomplete hydration, lifecycle/root changes, unavailable roots, duplicate identities, watcher uncertainty/overflow, and schema/integrity failures retain conservative full recovery.
- Focused regression coverage covers metadata revisions/missing rows, exact browser projection, large/small sync behavior, empty watcher syncs, extraction ordering, lifecycle fencing, and bounded materialization.

## Validation

- `cargo check --locked -p wavecrate --all-targets` — passed.
- `cargo test --locked -p wavecrate-library --all-targets` — passed, 296 tests.
- `cargo test --locked -p wavecrate committed_file_mutations --lib -- --test-threads=1` — passed, 16 tests.
- `cargo test --locked -p wavecrate filesystem_sync --lib -- --test-threads=1` — passed, 7 tests.
- Focused Playmark extraction tests — passed individually, including normal/protected routing, cache eviction, metadata/rating visibility, and harvest persistence.
- `rustfmt --edition 2024 --check` on all changed Rust files — passed.
- `git diff --check` — passed.

The combined `cargo test ... playmark_extraction --lib -- --test-threads=1` reached the affected assertions but did not exit after the final fixture test; the affected tests pass individually. This is a known fixture/background-thread shutdown caveat.

Repository-wide formatting has unrelated pre-existing drift outside this change; changed-file formatting is clean.

## Known limitations

- The delegated worktree required a temporary untracked sibling `radiant` symlink for local Cargo validation; it was removed and no Radiant files are part of this PR.
- Live-app validation with real user sources and DAW/audible acceptance remains outside this automated validation.

## Review and merge

This PR is ready for independent Terra review. Explicit user approval is required before merge. Do not merge without that approval.