### PR TITLE
Add typed committed mutation fences

### DIFF
--- a/src/native_app/app/state/transactions.rs
+++ b/src/native_app/app/state/transactions.rs
@@ -1,4 +1,5 @@
 use crate::native_app::sample_library::committed_file_mutations::FileMutationChange;
+use crate::native_app::sample_library::committed_file_mutations::RevisionFirstCursor;
 use crate::native_app::transaction_history::NativeTransactionHistory;
 
 #[derive(Default)]
@@ -6,7 +7,7 @@ pub(in crate::native_app) struct TransactionState {
     pub(in crate::native_app) history: NativeTransactionHistory,
     pub(in crate::native_app) restoring: bool,
     pub(in crate::native_app) latest_committed_mutation:
-        std::collections::HashMap<String, (u64, u64)>,
+        std::collections::HashMap<String, RevisionFirstCursor>,
     pub(in crate::native_app) pending_file_mutations: Vec<FileMutationChange>,
     pub(in crate::native_app) pending_file_mutation_failures: Vec<String>,
     pub(in crate::native_app) pending_file_mutation_attempted: bool,

--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -8,7 +8,9 @@
 use std::{collections::BTreeSet, path::PathBuf, time::Instant};
 
 use radiant::prelude as ui;
-use wavecrate::sample_sources::{readiness::ReadinessStage, scanner::CommittedSourceDelta};
+use wavecrate::sample_sources::{
+    SourceId, readiness::ReadinessStage, scanner::CommittedSourceDelta,
+};
 use wavecrate::selection::SelectionRange;
 
 use crate::native_app::app::{ExtractedFilePlaybackType, GuiMessage, NativeAppState};
@@ -57,6 +59,109 @@ pub(in crate::native_app) const COMMITTED_PLAYMARK_PREP_INTENTS: SourcePrepInten
     };
 pub(in crate::native_app) const COMMITTED_MUTATION_PREP_REASON: &str = "filesystem_changed";
 
+/// Process-local, non-durable correlation for one mutation request.
+///
+/// This is intentionally distinct from a future durable operation identifier. It is only used
+/// to correlate worker results, watcher echoes, and bounded telemetry within this process.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(in crate::native_app) struct ProcessLocalMutationCorrelationId(u64);
+
+impl ProcessLocalMutationCorrelationId {
+    pub(in crate::native_app) const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub(in crate::native_app) const fn as_raw(self) -> u64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ProcessLocalMutationCorrelationId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(in crate::native_app) struct LifecycleGeneration(u64);
+
+impl LifecycleGeneration {
+    pub(in crate::native_app) const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub(in crate::native_app) const fn as_raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(in crate::native_app) struct CommittedSourceRevision(u64);
+
+impl CommittedSourceRevision {
+    pub(in crate::native_app) const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub(in crate::native_app) const fn as_raw(self) -> u64 {
+        self.0
+    }
+}
+
+/// Cursor ordering is revision-first; correlation only breaks ties within one revision.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(in crate::native_app) struct RevisionFirstCursor {
+    pub(in crate::native_app) revision: CommittedSourceRevision,
+    pub(in crate::native_app) correlation: ProcessLocalMutationCorrelationId,
+}
+
+impl RevisionFirstCursor {
+    pub(in crate::native_app) const fn new(
+        revision: CommittedSourceRevision,
+        correlation: ProcessLocalMutationCorrelationId,
+    ) -> Self {
+        Self {
+            revision,
+            correlation,
+        }
+    }
+}
+
+/// The complete internal publication fence for a committed source mutation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct CommittedMutationFence {
+    pub(in crate::native_app) source_id: SourceId,
+    pub(in crate::native_app) lifecycle_generation: LifecycleGeneration,
+    pub(in crate::native_app) cursor: RevisionFirstCursor,
+}
+
+impl CommittedMutationFence {
+    pub(in crate::native_app) fn new(
+        source_id: SourceId,
+        lifecycle_generation: LifecycleGeneration,
+        committed_source_revision: CommittedSourceRevision,
+        correlation: ProcessLocalMutationCorrelationId,
+    ) -> Self {
+        Self {
+            source_id,
+            lifecycle_generation,
+            cursor: RevisionFirstCursor::new(committed_source_revision, correlation),
+        }
+    }
+
+    pub(in crate::native_app) fn with_lifecycle_generation(
+        mut self,
+        lifecycle_generation: LifecycleGeneration,
+    ) -> Self {
+        self.lifecycle_generation = lifecycle_generation;
+        self
+    }
+
+    pub(in crate::native_app) fn correlation(&self) -> ProcessLocalMutationCorrelationId {
+        self.cursor.correlation
+    }
+}
+
 #[cfg(test)]
 pub(in crate::native_app) fn reconcile_file_mutation_for_liveness_test(
     source: wavecrate::sample_sources::SampleSource,
@@ -65,7 +170,12 @@ pub(in crate::native_app) fn reconcile_file_mutation_for_liveness_test(
     mut changes: Vec<FileMutationChange>,
 ) -> Result<CommittedFileMutation, String> {
     capture_expected_filesystem_state(&mut changes);
-    let requests = build_source_requests(operation_id, operation, changes, &[source]);
+    let requests = build_source_requests(
+        ProcessLocalMutationCorrelationId::from_raw(operation_id),
+        operation,
+        changes,
+        &[source],
+    );
     match reconcile_file_mutation_requests(requests) {
         FileMutationOutcome::Committed(mut committed) if committed.len() == 1 => {
             Ok(committed.remove(0))
@@ -352,11 +462,8 @@ impl FileMutationChange {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct CommittedFileMutation {
-    pub(in crate::native_app) source_id: String,
-    pub(in crate::native_app) lifecycle_generation: u64,
-    pub(in crate::native_app) operation_id: u64,
+    pub(in crate::native_app) fence: CommittedMutationFence,
     pub(in crate::native_app) operation: FileMutationOperation,
-    pub(in crate::native_app) committed_source_revision: u64,
     pub(in crate::native_app) changes: Vec<FileMutationChange>,
     pub(in crate::native_app) invalidated_stages: BTreeSet<ReadinessStage>,
     pub(in crate::native_app) committed_delta: CommittedSourceDelta,
@@ -369,8 +476,9 @@ pub(in crate::native_app) struct CommittedFileMutation {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct FileMutationFailure {
-    pub(in crate::native_app) source_id: Option<String>,
-    pub(in crate::native_app) operation_id: u64,
+    pub(in crate::native_app) source_id: Option<SourceId>,
+    pub(in crate::native_app) lifecycle_generation: Option<LifecycleGeneration>,
+    pub(in crate::native_app) correlation_id: ProcessLocalMutationCorrelationId,
     pub(in crate::native_app) operation: FileMutationOperation,
     pub(in crate::native_app) error: String,
 }
@@ -424,33 +532,40 @@ impl NativeAppState {
         if changes.is_empty() && reported_failures.is_empty() {
             return None;
         }
-        let operation_id = self.background.next_task_id();
+        let correlation_id =
+            ProcessLocalMutationCorrelationId::from_raw(self.background.next_task_id());
         let had_changes = !changes.is_empty();
         capture_expected_filesystem_state(&mut changes);
         let failures = reported_failures
             .into_iter()
             .map(|(source_id, error)| FileMutationFailure {
-                source_id,
-                operation_id,
+                source_id: source_id.map(SourceId::from_string),
+                lifecycle_generation: None,
+                correlation_id,
                 operation,
                 error,
             })
             .collect::<Vec<_>>();
         let sources = self.library.folder_browser.configured_sample_sources();
-        let mut requests = build_source_requests(operation_id, operation, changes, &sources);
+        let mut requests = build_source_requests(correlation_id, operation, changes, &sources);
         let lifecycle_generations = self.background.source_processing.lifecycle_generations();
         for request in &mut requests {
-            request.lifecycle_generation = lifecycle_generations
+            let lifecycle_generation = lifecycle_generations
                 .get(request.source.id.as_str())
                 .copied()
                 .unwrap_or_default();
+            request.fence = request
+                .fence
+                .clone()
+                .with_lifecycle_generation(LifecycleGeneration::from_raw(lifecycle_generation));
         }
         if requests.is_empty() {
             let mut failures = failures;
             if had_changes {
                 failures.push(FileMutationFailure {
                     source_id: None,
-                    operation_id,
+                    lifecycle_generation: None,
+                    correlation_id,
                     operation,
                     error: String::from("No configured source owns the committed mutation paths"),
                 });
@@ -462,12 +577,12 @@ impl NativeAppState {
                 },
                 context,
             );
-            return Some(operation_id);
+            return Some(correlation_id.as_raw());
         }
         context.emit(GuiMessage::CommittedFileMutationRequested(
             FileMutationWork { requests, failures },
         ));
-        Some(operation_id)
+        Some(correlation_id.as_raw())
     }
 
     pub(in crate::native_app) fn start_committed_file_mutation(
@@ -497,13 +612,15 @@ impl NativeAppState {
         error: impl Into<String>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
-        let operation_id = self.background.next_task_id();
+        let correlation_id =
+            ProcessLocalMutationCorrelationId::from_raw(self.background.next_task_id());
         self.finish_committed_file_mutation(
             FileMutationOutcome::Failed {
                 committed: Vec::new(),
                 failures: vec![FileMutationFailure {
-                    source_id,
-                    operation_id,
+                    source_id: source_id.map(SourceId::from_string),
+                    lifecycle_generation: None,
+                    correlation_id,
                     operation,
                     error: error.into(),
                 }],
@@ -519,11 +636,13 @@ impl NativeAppState {
         error: impl Into<String>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
-        let operation_id = self.background.next_task_id();
+        let correlation_id =
+            ProcessLocalMutationCorrelationId::from_raw(self.background.next_task_id());
         self.finish_committed_file_mutation(
             FileMutationOutcome::RolledBack(FileMutationFailure {
-                source_id,
-                operation_id,
+                source_id: source_id.map(SourceId::from_string),
+                lifecycle_generation: None,
+                correlation_id,
                 operation,
                 error: error.into(),
             }),
@@ -544,9 +663,13 @@ impl NativeAppState {
             } => (committed, failures),
             FileMutationOutcome::RolledBack(failure) => {
                 tracing::warn!(
-                    operation_id = failure.operation_id,
+                    correlation_id = failure.correlation_id.as_raw(),
                     operation = failure.operation.as_str(),
-                    source_id = failure.source_id.as_deref().unwrap_or("unknown"),
+                    source_id = failure
+                        .source_id
+                        .as_ref()
+                        .map(SourceId::as_str)
+                        .unwrap_or("unknown"),
                     error = %failure.error,
                     "Wavecrate-owned file mutation rolled back"
                 );
@@ -555,21 +678,24 @@ impl NativeAppState {
         };
 
         for event in committed {
+            let source_id = event.fence.source_id.clone();
+            let lifecycle_generation = event.fence.lifecycle_generation;
+            let cursor = event.fence.cursor;
             let current_lifecycle_generation = self
                 .background
                 .source_lifecycle_generations
-                .get(&event.source_id)
+                .get(source_id.as_str())
                 .copied();
             let test_fixture_lifecycle = cfg!(test)
                 && current_lifecycle_generation.is_none()
-                && event.lifecycle_generation == 0;
-            if current_lifecycle_generation != Some(event.lifecycle_generation)
+                && lifecycle_generation.as_raw() == 0;
+            if current_lifecycle_generation != Some(lifecycle_generation.as_raw())
                 && !test_fixture_lifecycle
             {
                 tracing::debug!(
-                    source_id = %event.source_id,
-                    operation_id = event.operation_id,
-                    event_lifecycle_generation = event.lifecycle_generation,
+                    source_id = %source_id,
+                    correlation_id = cursor.correlation.as_raw(),
+                    event_lifecycle_generation = lifecycle_generation.as_raw(),
                     current_lifecycle_generation = ?current_lifecycle_generation,
                     "Ignoring committed file-mutation completion from a stale source lifecycle"
                 );
@@ -578,17 +704,17 @@ impl NativeAppState {
             let last_commit = self
                 .transactions
                 .latest_committed_mutation
-                .entry(event.source_id.clone())
+                .entry(source_id.as_str().to_owned())
                 .or_default();
-            let current_commit = (event.committed_source_revision, event.operation_id);
+            let current_commit = cursor;
             let accepted_commit = *last_commit;
             if mutation_completion_is_stale_or_duplicate(accepted_commit, current_commit) {
                 tracing::debug!(
-                    source_id = %event.source_id,
-                    operation_id = event.operation_id,
-                    revision = event.committed_source_revision,
-                    accepted_revision = accepted_commit.0,
-                    accepted_operation_id = accepted_commit.1,
+                    source_id = %source_id,
+                    correlation_id = cursor.correlation.as_raw(),
+                    revision = cursor.revision.as_raw(),
+                    accepted_revision = accepted_commit.revision.as_raw(),
+                    accepted_correlation_id = accepted_commit.correlation.as_raw(),
                     "Ignoring stale committed file-mutation completion"
                 );
                 continue;
@@ -608,7 +734,7 @@ impl NativeAppState {
                     .is_some_and(|projection| {
                         self.library
                             .folder_browser
-                            .apply_committed_projection_delta(&event.source_id, projection)
+                            .apply_committed_projection_delta(source_id.as_str(), projection)
                     });
             let projection_accepted = event
                 .projection_handoff_ticket
@@ -626,7 +752,7 @@ impl NativeAppState {
                 // visible while the queued source refresh repairs the missing projection.
                 self.library
                     .folder_browser
-                    .refresh_filesystem_paths(&event.source_id, &event.affected_relative_paths);
+                    .refresh_filesystem_paths(source_id.as_str(), &event.affected_relative_paths);
                 if let (Some(post_commit), Some(path)) =
                     (extraction_post_commit.as_ref(), extraction_path.as_deref())
                 {
@@ -650,16 +776,17 @@ impl NativeAppState {
                     self.apply_committed_file_mutation_projection(projection, context);
                 }
                 self.queue_full_source_reconciliation_after_committed_mutation(
-                    event.source_id.clone(),
-                    event.committed_source_revision,
-                    event.lifecycle_generation,
+                    source_id.as_str().to_owned(),
+                    cursor.revision.as_raw(),
+                    lifecycle_generation.as_raw(),
                     context,
                 );
                 continue;
             }
-            self.transactions
-                .latest_committed_mutation
-                .insert(event.source_id.clone(), accepted_commit.max(current_commit));
+            self.transactions.latest_committed_mutation.insert(
+                source_id.as_str().to_owned(),
+                accepted_commit.max(current_commit),
+            );
             for change in &event.changes {
                 let before = change.before_path.as_deref().and_then(|path| {
                     self.library
@@ -686,9 +813,9 @@ impl NativeAppState {
                             .library
                             .folder_browser
                             .source_id_for_file_path(after_path);
-                        if after_source.as_deref() == Some(event.source_id.as_str()) {
+                        if after_source.as_deref() == Some(source_id.as_str()) {
                             self.background.rating_persist.rekey_prefix(
-                                &event.source_id,
+                                source_id.as_str(),
                                 &before,
                                 &after,
                                 false,
@@ -700,7 +827,7 @@ impl NativeAppState {
                                 .source_database_relative_file_path(after_path)
                             {
                                 self.background.rating_persist.rekey_cross_source(
-                                    &event.source_id,
+                                    source_id.as_str(),
                                     &before,
                                     &after_source,
                                     &after,
@@ -711,12 +838,12 @@ impl NativeAppState {
                         } else {
                             self.background
                                 .rating_persist
-                                .invalidate_prefix(&event.source_id, &before);
+                                .invalidate_prefix(source_id.as_str(), &before);
                         }
                     }
                     (Some(_), Some(before), Some(_), Some(after)) if before == after => {
                         self.background.rating_persist.rekey_exact(
-                            &event.source_id,
+                            source_id.as_str(),
                             &before,
                             &after,
                         );
@@ -724,7 +851,7 @@ impl NativeAppState {
                     (Some(_), Some(before), None, None) => {
                         self.background
                             .rating_persist
-                            .invalidate_prefix(&event.source_id, &before);
+                            .invalidate_prefix(source_id.as_str(), &before);
                     }
                     _ => {}
                 }
@@ -756,7 +883,7 @@ impl NativeAppState {
             {
                 self.library
                     .folder_browser
-                    .refresh_filesystem_paths(&event.source_id, &event.affected_relative_paths);
+                    .refresh_filesystem_paths(source_id.as_str(), &event.affected_relative_paths);
             }
             for projection in projections {
                 self.apply_committed_file_mutation_projection(projection, context);
@@ -772,16 +899,16 @@ impl NativeAppState {
             }
             if let Some(watcher) = self.library.source_watcher.as_ref() {
                 watcher.acknowledge_committed_paths(
-                    event.source_id.clone(),
+                    source_id.clone(),
                     event.watcher_echoes,
-                    event.operation_id,
+                    cursor,
                 );
             }
             tracing::info!(
-                source_id = %event.source_id,
-                operation_id = event.operation_id,
+                source_id = %source_id,
+                correlation_id = cursor.correlation.as_raw(),
                 operation = event.operation.as_str(),
-                revision = event.committed_source_revision,
+                revision = cursor.revision.as_raw(),
                 changes = event.changes.len(),
                 invalidated_stages = ?event.invalidated_stages,
                 "Committed Wavecrate-owned file mutation"
@@ -789,7 +916,7 @@ impl NativeAppState {
             // This call refreshes metadata projections and wakes the source-owned readiness
             // reconciler. It deliberately happens after the source DB and browser projection.
             self.queue_source_prep(
-                event.source_id,
+                source_id.as_str().to_owned(),
                 if extraction_post_commit.is_some() {
                     COMMITTED_PLAYMARK_PREP_INTENTS
                 } else {
@@ -802,9 +929,13 @@ impl NativeAppState {
 
         for failure in failures {
             tracing::warn!(
-                operation_id = failure.operation_id,
+                correlation_id = failure.correlation_id.as_raw(),
                 operation = failure.operation.as_str(),
-                source_id = failure.source_id.as_deref().unwrap_or("unknown"),
+                source_id = failure
+                    .source_id
+                    .as_ref()
+                    .map(SourceId::as_str)
+                    .unwrap_or("unknown"),
                 error = %failure.error,
                 "Wavecrate-owned file mutation failed before authoritative publication"
             );

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -26,8 +26,12 @@ fn request(
     capture_expected_filesystem_state(&mut changes);
     SourceMutationRequest {
         source: SampleSource::new_with_id(SourceId::from_string("source-a"), root.to_path_buf()),
-        lifecycle_generation: 0,
-        operation_id: 42,
+        fence: CommittedMutationFence::new(
+            SourceId::from_string("source-a"),
+            LifecycleGeneration::default(),
+            CommittedSourceRevision::default(),
+            ProcessLocalMutationCorrelationId::from_raw(42),
+        ),
         operation,
         affected_relative_paths: changes
             .iter()
@@ -85,7 +89,7 @@ fn create_commits_revision_and_invalidates_file_readiness() {
     )
     .expect("commit create");
 
-    assert!(event.committed_source_revision > 0);
+    assert!(event.fence.cursor.revision.as_raw() > 0);
     assert_eq!(event.committed_delta.created.len(), 1);
     assert!(
         event
@@ -234,14 +238,18 @@ fn cross_source_requests_keep_one_operation_id_and_distinct_sources() {
     ];
 
     let requests = build_source_requests(
-        88,
+        ProcessLocalMutationCorrelationId::from_raw(88),
         FileMutationOperation::Move,
         vec![FileMutationChange::path_only_move(before, after)],
         &sources,
     );
 
     assert_eq!(requests.len(), 2);
-    assert!(requests.iter().all(|request| request.operation_id == 88));
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.fence.correlation().as_raw() == 88)
+    );
     assert_ne!(requests[0].source.id, requests[1].source.id);
 }
 
@@ -266,7 +274,7 @@ fn cross_source_database_root_failure_keeps_valid_commit_and_explicit_failure() 
         second.path().to_path_buf(),
     );
     let requests = build_source_requests(
-        88,
+        ProcessLocalMutationCorrelationId::from_raw(88),
         FileMutationOperation::Move,
         vec![FileMutationChange::path_only_move(before, after)],
         &[first_source.clone(), second_source.clone()],
@@ -288,12 +296,9 @@ fn cross_source_database_root_failure_keeps_valid_commit_and_explicit_failure() 
         panic!("cross-source partial failure must be explicit");
     };
     assert_eq!(committed.len(), 1);
-    assert_eq!(committed[0].source_id, first_source.id.as_str());
+    assert_eq!(committed[0].fence.source_id, first_source.id);
     assert_eq!(failures.len(), 1);
-    assert_eq!(
-        failures[0].source_id.as_deref(),
-        Some(second_source.id.as_str())
-    );
+    assert_eq!(failures[0].source_id.as_ref(), Some(&second_source.id));
     assert!(failures[0].error.contains("metadata root unavailable"));
 }
 
@@ -324,7 +329,12 @@ fn failed_reconciliation_does_not_apply_browser_projection() {
         ),
     ];
     capture_expected_filesystem_state(&mut changes);
-    let requests = build_source_requests(91, FileMutationOperation::Duplicate, changes, &[source]);
+    let requests = build_source_requests(
+        ProcessLocalMutationCorrelationId::from_raw(91),
+        FileMutationOperation::Duplicate,
+        changes,
+        &[source],
+    );
     let outcome = reconcile_file_mutation_requests_with_database_roots(requests, |_| {
         Err(String::from("metadata root unavailable"))
     });
@@ -400,11 +410,13 @@ fn stale_lifecycle_completion_has_no_committed_mutation_side_effects() {
     capture_expected_filesystem_state(&mut changes);
     let watcher_echoes = watcher_echoes_for_changes(root.path(), &changes);
     let event = CommittedFileMutation {
-        source_id: String::from("source-a"),
-        lifecycle_generation: stale_lifecycle_generation,
-        operation_id: 91,
+        fence: CommittedMutationFence::new(
+            SourceId::from_string("source-a"),
+            LifecycleGeneration::from_raw(stale_lifecycle_generation),
+            CommittedSourceRevision::from_raw(7),
+            ProcessLocalMutationCorrelationId::from_raw(91),
+        ),
         operation: FileMutationOperation::Edit,
-        committed_source_revision: 7,
         changes,
         invalidated_stages: BTreeSet::from([ReadinessStage::AnalysisFeatures]),
         committed_delta: CommittedSourceDelta {
@@ -513,8 +525,9 @@ fn stale_lifecycle_completion_has_no_committed_mutation_side_effects() {
 #[test]
 fn failed_and_rolled_back_outcomes_are_explicit() {
     let failure = FileMutationFailure {
-        source_id: Some(String::from("source-a")),
-        operation_id: 9,
+        source_id: Some(SourceId::from_string("source-a")),
+        lifecycle_generation: None,
+        correlation_id: ProcessLocalMutationCorrelationId::from_raw(9),
         operation: FileMutationOperation::Move,
         error: String::from("rolled back"),
     };
@@ -548,17 +561,57 @@ fn content_only_delta_is_still_a_committed_authoritative_event() {
 
 #[test]
 fn stale_and_duplicate_completions_are_fenced_by_revision_then_operation() {
-    assert!(!mutation_completion_is_stale_or_duplicate((0, 0), (0, 1)));
-    assert!(mutation_completion_is_stale_or_duplicate((7, 11), (7, 10)));
-    assert!(mutation_completion_is_stale_or_duplicate((7, 11), (7, 11)));
-    assert!(!mutation_completion_is_stale_or_duplicate((7, 11), (8, 2)));
+    let cursor = |revision, correlation| {
+        RevisionFirstCursor::new(
+            CommittedSourceRevision::from_raw(revision),
+            ProcessLocalMutationCorrelationId::from_raw(correlation),
+        )
+    };
+    assert!(!mutation_completion_is_stale_or_duplicate(
+        cursor(0, 0),
+        cursor(0, 1)
+    ));
+    assert!(mutation_completion_is_stale_or_duplicate(
+        cursor(7, 11),
+        cursor(7, 10)
+    ));
+    assert!(mutation_completion_is_stale_or_duplicate(
+        cursor(7, 11),
+        cursor(7, 11)
+    ));
+    assert!(!mutation_completion_is_stale_or_duplicate(
+        cursor(7, 11),
+        cursor(8, 2)
+    ));
+}
+
+#[test]
+fn committed_mutation_fence_keeps_source_lifecycle_and_revision_first_cursor_typed() {
+    let fence = CommittedMutationFence::new(
+        SourceId::from_string("source-a"),
+        LifecycleGeneration::from_raw(4),
+        CommittedSourceRevision::from_raw(12),
+        ProcessLocalMutationCorrelationId::from_raw(99),
+    );
+    assert_eq!(fence.source_id.as_str(), "source-a");
+    assert_eq!(fence.lifecycle_generation.as_raw(), 4);
+    assert_eq!(fence.cursor.revision.as_raw(), 12);
+    assert_eq!(fence.cursor.correlation.as_raw(), 99);
+    assert!(
+        fence.cursor
+            > RevisionFirstCursor::new(
+                CommittedSourceRevision::from_raw(11),
+                ProcessLocalMutationCorrelationId::from_raw(u64::MAX),
+            )
+    );
 }
 
 #[test]
 fn partial_failure_keeps_commits_under_one_operation_outcome() {
     let failure = FileMutationFailure {
-        source_id: Some(String::from("source-a")),
-        operation_id: 9,
+        source_id: Some(SourceId::from_string("source-a")),
+        lifecycle_generation: None,
+        correlation_id: ProcessLocalMutationCorrelationId::from_raw(9),
         operation: FileMutationOperation::Normalize,
         error: String::from("one file failed"),
     };

--- a/src/native_app/sample_library/committed_file_mutations/worker.rs
+++ b/src/native_app/sample_library/committed_file_mutations/worker.rs
@@ -9,8 +9,10 @@ use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 use super::watcher_echo::{capture_expected_path_state, watcher_echoes_for_changes};
 use super::{
-    CommittedFileMutation, ExpectedMutationPathState, FileMutationChange, FileMutationFailure,
-    FileMutationOperation, FileMutationOutcome, FileMutationSemantics,
+    CommittedFileMutation, CommittedMutationFence, CommittedSourceRevision,
+    ExpectedMutationPathState, FileMutationChange, FileMutationFailure, FileMutationOperation,
+    FileMutationOutcome, FileMutationSemantics, LifecycleGeneration,
+    ProcessLocalMutationCorrelationId,
 };
 use crate::native_app::sample_library::folder_scan_actions::sync_source_database_paths;
 use crate::native_app::source_processing::{ExternalScanHandoff, SourceProcessingBudgetHandle};
@@ -18,8 +20,7 @@ use crate::native_app::source_processing::{ExternalScanHandoff, SourceProcessing
 #[derive(Clone, Debug)]
 pub(super) struct SourceMutationRequest {
     pub(super) source: SampleSource,
-    pub(super) lifecycle_generation: u64,
-    pub(super) operation_id: u64,
+    pub(super) fence: CommittedMutationFence,
     pub(super) operation: FileMutationOperation,
     pub(super) changes: Vec<FileMutationChange>,
     pub(super) affected_relative_paths: Vec<PathBuf>,
@@ -30,11 +31,10 @@ impl PartialEq for SourceMutationRequest {
     fn eq(&self, other: &Self) -> bool {
         self.source.id == other.source.id
             && self.source.root == other.source.root
-            && self.lifecycle_generation == other.lifecycle_generation
+            && self.fence == other.fence
             && self.source.is_protected() == other.source.is_protected()
             && self.source.is_primary() == other.source.is_primary()
             && self.source.primary_import_path() == other.source.primary_import_path()
-            && self.operation_id == other.operation_id
             && self.operation == other.operation
             && self.changes == other.changes
             && self.affected_relative_paths == other.affected_relative_paths
@@ -45,10 +45,10 @@ impl PartialEq for SourceMutationRequest {
 impl Eq for SourceMutationRequest {}
 
 pub(super) fn mutation_completion_is_stale_or_duplicate(
-    accepted: (u64, u64),
-    candidate: (u64, u64),
+    accepted: super::RevisionFirstCursor,
+    candidate: super::RevisionFirstCursor,
 ) -> bool {
-    accepted != (0, 0) && candidate <= accepted
+    accepted != super::RevisionFirstCursor::default() && candidate <= accepted
 }
 
 pub(super) fn merge_file_mutation_failures(
@@ -111,7 +111,7 @@ pub(in crate::native_app) fn cache_content_identity(path: &Path) -> Option<Strin
 }
 
 pub(super) fn build_source_requests(
-    operation_id: u64,
+    correlation_id: ProcessLocalMutationCorrelationId,
     operation: FileMutationOperation,
     changes: Vec<FileMutationChange>,
     sources: &[SampleSource],
@@ -135,8 +135,12 @@ pub(super) fn build_source_requests(
                     .entry(source_id.clone())
                     .or_insert_with(|| SourceMutationRequest {
                         source: source.clone(),
-                        lifecycle_generation: 0,
-                        operation_id,
+                        fence: CommittedMutationFence::new(
+                            source.id.clone(),
+                            LifecycleGeneration::default(),
+                            CommittedSourceRevision::default(),
+                            correlation_id,
+                        ),
                         operation,
                         changes: Vec::new(),
                         affected_relative_paths: Vec::new(),
@@ -200,13 +204,14 @@ pub(super) fn reconcile_file_mutation_requests_with_handoff(
     let mut committed = Vec::new();
     let mut failures = Vec::new();
     for request in requests {
-        let source_id = request.source.id.as_str().to_string();
-        let Some(permit) =
-            budget.acquire_scan_for_generation(&source_id, request.lifecycle_generation)
+        let source_id = request.source.id.as_str().to_owned();
+        let Some(permit) = budget
+            .acquire_scan_for_generation(&source_id, request.fence.lifecycle_generation.as_raw())
         else {
             failures.push(FileMutationFailure {
-                source_id: Some(source_id),
-                operation_id: request.operation_id,
+                source_id: Some(request.fence.source_id.clone()),
+                lifecycle_generation: Some(request.fence.lifecycle_generation),
+                correlation_id: request.fence.correlation(),
                 operation: request.operation,
                 error: String::from("source mutation reconciliation canceled"),
             });
@@ -240,8 +245,9 @@ pub(super) fn reconcile_file_mutation_requests_with_handoff(
                     reason: "committed_mutation_reconciliation_failed",
                 });
                 failures.push(FileMutationFailure {
-                    source_id: Some(source_id),
-                    operation_id: request.operation_id,
+                    source_id: Some(request.fence.source_id.clone()),
+                    lifecycle_generation: Some(request.fence.lifecycle_generation),
+                    correlation_id: request.fence.correlation(),
                     operation: request.operation,
                     error,
                 });
@@ -267,15 +273,15 @@ pub(super) fn reconcile_file_mutation_requests_with_database_roots(
     let mut committed = Vec::new();
     let mut failures = Vec::new();
     for request in requests {
-        let source_id = request.source.id.as_str().to_string();
         let result = database_root_for(&request.source).and_then(|database_root| {
             reconcile_source_mutation(request.clone(), database_root, &cancel)
         });
         match result {
             Ok(event) => committed.push(event),
             Err(error) => failures.push(FileMutationFailure {
-                source_id: Some(source_id),
-                operation_id: request.operation_id,
+                source_id: Some(request.fence.source_id.clone()),
+                lifecycle_generation: Some(request.fence.lifecycle_generation),
+                correlation_id: request.fence.correlation(),
                 operation: request.operation,
                 error,
             }),
@@ -381,11 +387,13 @@ fn reconcile_source_mutation_with_cancel(
         .collect::<Vec<_>>();
 
     Ok(CommittedFileMutation {
-        source_id: request.source.id.as_str().to_string(),
-        lifecycle_generation: request.lifecycle_generation,
-        operation_id: request.operation_id,
+        fence: CommittedMutationFence::new(
+            request.fence.source_id.clone(),
+            request.fence.lifecycle_generation,
+            CommittedSourceRevision::from_raw(committed_source_revision),
+            request.fence.correlation(),
+        ),
         operation: request.operation,
-        committed_source_revision,
         invalidated_stages: invalidated_stages(&changes),
         changes,
         committed_delta: success.committed_delta,

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -12,7 +12,7 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use wavecrate::sample_sources::SampleSource;
+use wavecrate::sample_sources::{SampleSource, SourceId};
 
 use super::classification::retain_source_refresh_candidates;
 use super::journal::{self, JournalRecovery};
@@ -27,7 +27,9 @@ use super::{
     WATCHER_START_TIMEOUT,
 };
 use crate::native_app::app::GuiMessage;
-use crate::native_app::sample_library::committed_file_mutations::CommittedWatcherEcho;
+use crate::native_app::sample_library::committed_file_mutations::{
+    CommittedWatcherEcho, RevisionFirstCursor,
+};
 
 struct ActiveSourceWatcher {
     _watcher: Box<dyn Watcher + Send>,
@@ -270,16 +272,16 @@ impl GuiSourceWatcherHandle {
 
     pub(in crate::native_app) fn acknowledge_committed_paths(
         &self,
-        source_id: String,
+        source_id: SourceId,
         echoes: Vec<CommittedWatcherEcho>,
-        operation_id: u64,
+        cursor: RevisionFirstCursor,
     ) {
         let _ = self
             .command_tx
             .send(GuiSourceWatchCommand::AcknowledgeCommittedPaths {
                 source_id,
                 echoes,
-                operation_id,
+                cursor,
             });
     }
 
@@ -374,9 +376,9 @@ enum GuiSourceWatchCommand {
     #[cfg(test)]
     ReconcileAllSources,
     AcknowledgeCommittedPaths {
-        source_id: String,
+        source_id: SourceId,
         echoes: Vec<CommittedWatcherEcho>,
-        operation_id: u64,
+        cursor: RevisionFirstCursor,
     },
     AdvanceJournalCheckpoint {
         source_id: String,
@@ -442,12 +444,12 @@ fn run_source_watcher(
             Ok(GuiSourceWatchCommand::AcknowledgeCommittedPaths {
                 source_id,
                 echoes,
-                operation_id,
+                cursor,
             }) => {
                 state.acknowledge_committed_paths(
-                    &source_id,
+                    source_id.as_str(),
                     &echoes,
-                    operation_id,
+                    cursor,
                     Instant::now(),
                 );
             }

--- a/src/native_app/sample_library/source_watcher/state.rs
+++ b/src/native_app/sample_library/source_watcher/state.rs
@@ -14,7 +14,7 @@ use super::roots::{
     source_root_is_available,
 };
 use crate::native_app::sample_library::committed_file_mutations::{
-    CommittedWatcherEcho, CommittedWatcherPathState,
+    CommittedWatcherEcho, CommittedWatcherPathState, RevisionFirstCursor,
 };
 
 #[derive(Default)]
@@ -182,7 +182,7 @@ impl GuiSourceWatchState {
         &mut self,
         source_id: &str,
         echoes: &[CommittedWatcherEcho],
-        operation_id: u64,
+        cursor: RevisionFirstCursor,
         now: Instant,
     ) {
         let deadline = now + super::SOURCE_CHANGE_DEBOUNCE.saturating_mul(2);
@@ -231,7 +231,8 @@ impl GuiSourceWatchState {
         }
         tracing::debug!(
             source_id,
-            operation_id,
+            revision = cursor.revision.as_raw(),
+            correlation_id = cursor.correlation.as_raw(),
             path_count = echoes.len(),
             "Acknowledged committed mutation paths in source watcher"
         );

--- a/src/native_app/sample_library/source_watcher/tests/committed_mutations.rs
+++ b/src/native_app/sample_library/source_watcher/tests/committed_mutations.rs
@@ -1,8 +1,16 @@
 use super::super::SOURCE_CHANGE_DEBOUNCE;
 use super::{Event, EventKind, GuiSourceWatchState, Instant, PathBuf, SampleSource, SourceId};
 use crate::native_app::sample_library::committed_file_mutations::{
-    CommittedWatcherEcho, CommittedWatcherPathState, observed_watcher_path_state,
+    CommittedSourceRevision, CommittedWatcherEcho, CommittedWatcherPathState,
+    ProcessLocalMutationCorrelationId, RevisionFirstCursor, observed_watcher_path_state,
 };
+
+fn cursor() -> RevisionFirstCursor {
+    RevisionFirstCursor::new(
+        CommittedSourceRevision::from_raw(0),
+        ProcessLocalMutationCorrelationId::from_raw(42),
+    )
+}
 
 fn missing_echo(path: &str) -> CommittedWatcherEcho {
     CommittedWatcherEcho {
@@ -33,9 +41,9 @@ fn committed_mutation_acknowledgement_removes_matching_pending_echo() {
     );
 
     state.acknowledge_committed_paths(
-        "source_id::committed",
+        SourceId::from_string("source_id::committed").as_str(),
         &[missing_echo("kick.wav")],
-        42,
+        cursor(),
         started,
     );
 
@@ -60,9 +68,9 @@ fn watcher_acknowledgement_consumes_only_one_echo() {
     };
     let started = Instant::now();
     state.acknowledge_committed_paths(
-        "source_id::fallback",
+        SourceId::from_string("source_id::fallback").as_str(),
         &[missing_echo("kick.wav")],
-        42,
+        cursor(),
         started,
     );
     let event = Event {
@@ -108,12 +116,12 @@ fn watcher_acknowledgement_does_not_hide_external_change_before_internal_echo() 
     };
     let started = Instant::now();
     state.acknowledge_committed_paths(
-        "source_id::external",
+        SourceId::from_string("source_id::external").as_str(),
         &[CommittedWatcherEcho {
             relative_path: PathBuf::from("kick.wav"),
             expected_state,
         }],
-        42,
+        cursor(),
         started,
     );
 

--- a/src/test_support/source_processing_liveness/harness.rs
+++ b/src/test_support/source_processing_liveness/harness.rs
@@ -99,7 +99,7 @@ impl LivenessHarness {
             changes,
         )
         .expect("commit Wavecrate-owned mutation");
-        assert_eq!(committed.source_id, self.source.id.as_str());
+        assert_eq!(committed.fence.source_id, self.source.id);
         self.watcher_stimulus = WatcherStimulus::InternalMutation;
         self.watcher_events_committed = operation_id;
         self.expected_source_generation = self.current_manifest_generation();


### PR DESCRIPTION
## Goal
Establish the first Phase 1 I/O-architecture contract seam by making committed file-mutation fences explicit and type-safe.

## Scope
- Add typed configured-source, lifecycle, committed-source-revision, process-local correlation, and revision-first cursor contracts.
- Thread the fence through committed mutations, requests, failures, accepted-cursor tracking, and watcher acknowledgement.
- Add focused ordering coverage and bounded disposition telemetry.

## Non-goals
No durable operation journal or target PhysicalSourceId; no schema/migration, filesystem, source-writer, Finder, readiness/artifact, UI, or user-visible behavior change.

## Definition of Done
- Preserve lifecycle and revision-first stale/duplicate fences.
- Preserve watcher acknowledgement before readiness wake.
- Make the process-local correlation explicitly non-durable.
- Keep focused mutation and watcher tests green.

## Validation
- `git diff --check`
- `cargo test -p wavecrate --lib committed_file_mutations -- --nocapture` (17 passed)
- `cargo test -p wavecrate --lib source_watcher::tests::committed_mutations -- --nocapture` (3 passed)
- Independent Terra review: approved, no findings.

## Known limitations
Full workspace suite and native-app interaction run were not performed; the liveness end-to-end test remains intentionally ignored. Existing broader formatting/boundary checks have pre-existing failures in untouched files.

Explicit user approval is required before merge.