### PR TITLE
Prepare duplicate evidence off the UI thread

### DIFF
--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -9,7 +9,7 @@ use std::{collections::BTreeSet, path::PathBuf, time::Instant};
 
 use radiant::prelude as ui;
 use wavecrate::sample_sources::{
-    SourceId, readiness::ReadinessStage, scanner::CommittedSourceDelta,
+    SourceFileEvidence, SourceId, readiness::ReadinessStage, scanner::CommittedSourceDelta,
 };
 use wavecrate::selection::SelectionRange;
 
@@ -258,17 +258,7 @@ pub(in crate::native_app) enum FileMutationPostCommitPresentation {
     Drag,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) enum ExpectedMutationPathState {
-    Missing,
-    ContentHash([u8; 32]),
-    Metadata {
-        len: u64,
-        modified_ns: Option<i64>,
-        is_dir: bool,
-    },
-    Unverifiable,
-}
+pub(super) type ExpectedMutationPathState = SourceFileEvidence;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) enum FileMutationProjection {
@@ -377,6 +367,23 @@ impl FileMutationChange {
             semantics: FileMutationSemantics::Create,
             expected_before_state: None,
             expected_after_state: None,
+            projection: None,
+            post_commit: None,
+        }
+    }
+
+    pub(in crate::native_app) fn created_prepared(
+        path: PathBuf,
+        evidence: SourceFileEvidence,
+    ) -> Self {
+        Self {
+            before_path: None,
+            after_path: Some(path),
+            before_content_identity: None,
+            after_content_identity: None,
+            semantics: FileMutationSemantics::Create,
+            expected_before_state: None,
+            expected_after_state: Some(evidence),
             projection: None,
             post_commit: None,
         }
@@ -509,7 +516,22 @@ impl NativeAppState {
         changes: Vec<FileMutationChange>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Option<u64> {
-        self.queue_file_mutation_outcome(operation, changes, Vec::new(), context)
+        self.queue_file_mutation_outcome(operation, changes, Vec::new(), false, context)
+    }
+
+    /// Reconcile a mutation whose filesystem evidence was captured by its source-owned worker.
+    ///
+    /// Unlike the legacy route, this does not inspect the filesystem on the UI thread. Callers
+    /// must provide changes created with `FileMutationChange::created_prepared` (or otherwise
+    /// carrying their expected path evidence); the worker still verifies that evidence before
+    /// touching source metadata, so an intervening rewrite is rejected.
+    pub(in crate::native_app) fn queue_prepared_committed_file_mutation(
+        &mut self,
+        operation: FileMutationOperation,
+        changes: Vec<FileMutationChange>,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) -> Option<u64> {
+        self.queue_file_mutation_outcome(operation, changes, Vec::new(), true, context)
     }
 
     pub(in crate::native_app) fn queue_partially_committed_file_mutation(
@@ -519,7 +541,7 @@ impl NativeAppState {
         failures: Vec<(Option<String>, String)>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Option<u64> {
-        self.queue_file_mutation_outcome(operation, changes, failures, context)
+        self.queue_file_mutation_outcome(operation, changes, failures, false, context)
     }
 
     fn queue_file_mutation_outcome(
@@ -527,6 +549,7 @@ impl NativeAppState {
         operation: FileMutationOperation,
         mut changes: Vec<FileMutationChange>,
         reported_failures: Vec<(Option<String>, String)>,
+        prepared: bool,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Option<u64> {
         if changes.is_empty() && reported_failures.is_empty() {
@@ -535,7 +558,9 @@ impl NativeAppState {
         let correlation_id =
             ProcessLocalMutationCorrelationId::from_raw(self.background.next_task_id());
         let had_changes = !changes.is_empty();
-        capture_expected_filesystem_state(&mut changes);
+        if !prepared {
+            capture_expected_filesystem_state(&mut changes);
+        }
         let failures = reported_failures
             .into_iter()
             .map(|(source_id, error)| FileMutationFailure {

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -6,7 +6,10 @@ use std::{
 };
 
 use wavecrate::sample_sources::scanner::ManifestIdentityDelta;
-use wavecrate::sample_sources::{SampleSource, SourceDatabase, SourceId, scanner};
+use wavecrate::sample_sources::{
+    SampleSource, SourceDatabase, SourceFileEvidence, SourceId, capture_source_file_evidence,
+    scanner,
+};
 
 use super::watcher_echo::capture_expected_path_state;
 use super::watcher_echo::watcher_echoes_for_changes;
@@ -24,6 +27,22 @@ fn request(
     mut changes: Vec<FileMutationChange>,
 ) -> SourceMutationRequest {
     capture_expected_filesystem_state(&mut changes);
+    request_without_capture(root, operation, changes)
+}
+
+fn prepared_request(
+    root: &Path,
+    operation: FileMutationOperation,
+    changes: Vec<FileMutationChange>,
+) -> SourceMutationRequest {
+    request_without_capture(root, operation, changes)
+}
+
+fn request_without_capture(
+    root: &Path,
+    operation: FileMutationOperation,
+    changes: Vec<FileMutationChange>,
+) -> SourceMutationRequest {
     SourceMutationRequest {
         source: SampleSource::new_with_id(SourceId::from_string("source-a"), root.to_path_buf()),
         fence: CommittedMutationFence::new(
@@ -224,6 +243,59 @@ fn large_create_commits_without_synchronous_deep_hashing() {
         event.watcher_echoes.is_empty(),
         "large files use conservative watcher reconciliation instead of synchronous hashing"
     );
+}
+
+#[test]
+fn prepared_create_commits_small_and_large_captured_evidence() {
+    let root = tempfile::tempdir().expect("source root");
+    let small_path = root.path().join("small.wav");
+    let large_path = root.path().join("large.wav");
+    fs::write(&small_path, b"small prepared duplicate").expect("create small file");
+    fs::write(&large_path, vec![7_u8; 9 * 1024 * 1024]).expect("create large file");
+
+    let small_evidence = capture_source_file_evidence(&small_path);
+    let large_evidence = capture_source_file_evidence(&large_path);
+    assert!(matches!(small_evidence, SourceFileEvidence::ContentHash(_)));
+    assert!(matches!(
+        large_evidence,
+        SourceFileEvidence::Metadata { .. }
+    ));
+
+    let event = reconcile_test_request(
+        prepared_request(
+            root.path(),
+            FileMutationOperation::Duplicate,
+            vec![
+                FileMutationChange::created_prepared(small_path, small_evidence),
+                FileMutationChange::created_prepared(large_path, large_evidence),
+            ],
+        ),
+        &AtomicBool::new(false),
+    )
+    .expect("commit prepared creates");
+
+    assert_eq!(event.committed_delta.created.len(), 2);
+}
+
+#[test]
+fn prepared_create_rejects_an_intervening_rewrite() {
+    let root = tempfile::tempdir().expect("source root");
+    let path = root.path().join("duplicate.wav");
+    fs::write(&path, b"captured before rewrite").expect("create file");
+    let evidence = capture_source_file_evidence(&path);
+    fs::write(&path, b"rewritten after capture").expect("rewrite file");
+
+    let error = reconcile_test_request(
+        prepared_request(
+            root.path(),
+            FileMutationOperation::Duplicate,
+            vec![FileMutationChange::created_prepared(path, evidence)],
+        ),
+        &AtomicBool::new(false),
+    )
+    .expect_err("intervening rewrite must supersede prepared mutation");
+
+    assert!(error.contains("superseded"));
 }
 
 #[test]

--- a/src/native_app/sample_library/committed_file_mutations/watcher_echo.rs
+++ b/src/native_app/sample_library/committed_file_mutations/watcher_echo.rs
@@ -3,9 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use wavecrate_library::timestamps::system_time_to_unix_nanos;
-
-const MAX_WATCHER_ECHO_HASH_BYTES: u64 = 8 * 1024 * 1024;
+use wavecrate::sample_sources::{SourceFileEvidence, capture_source_file_evidence};
 
 use super::{ExpectedMutationPathState, FileMutationChange};
 
@@ -22,25 +20,7 @@ pub(in crate::native_app) struct CommittedWatcherEcho {
 }
 
 pub(super) fn capture_expected_path_state(path: &Path) -> ExpectedMutationPathState {
-    match std::fs::metadata(path) {
-        Ok(metadata) if metadata.is_file() && metadata.len() <= MAX_WATCHER_ECHO_HASH_BYTES => {
-            match std::fs::read(path) {
-                Ok(bytes) => {
-                    ExpectedMutationPathState::ContentHash(*blake3::hash(&bytes).as_bytes())
-                }
-                Err(_) => ExpectedMutationPathState::Unverifiable,
-            }
-        }
-        Ok(metadata) => ExpectedMutationPathState::Metadata {
-            len: metadata.len(),
-            modified_ns: metadata.modified().ok().map(system_time_to_unix_nanos),
-            is_dir: metadata.is_dir(),
-        },
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            ExpectedMutationPathState::Missing
-        }
-        Err(_) => ExpectedMutationPathState::Unverifiable,
-    }
+    capture_source_file_evidence(path)
 }
 
 pub(super) fn watcher_echoes_for_changes(
@@ -88,17 +68,9 @@ pub(super) fn watcher_echoes_for_changes(
 pub(in crate::native_app) fn observed_watcher_path_state(
     path: &Path,
 ) -> Option<CommittedWatcherPathState> {
-    match std::fs::metadata(path) {
-        Ok(metadata) if metadata.is_file() && metadata.len() <= MAX_WATCHER_ECHO_HASH_BYTES => {
-            let bytes = std::fs::read(path).ok()?;
-            Some(CommittedWatcherPathState::ContentHash(
-                *blake3::hash(&bytes).as_bytes(),
-            ))
-        }
-        Ok(_) => None,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            Some(CommittedWatcherPathState::Missing)
-        }
-        Err(_) => None,
+    match capture_source_file_evidence(path) {
+        SourceFileEvidence::ContentHash(hash) => Some(CommittedWatcherPathState::ContentHash(hash)),
+        SourceFileEvidence::Missing => Some(CommittedWatcherPathState::Missing),
+        SourceFileEvidence::Metadata { .. } | SourceFileEvidence::Unverifiable => None,
     }
 }

--- a/src/native_app/workflows/context_menu_actions/duplicate.rs
+++ b/src/native_app/workflows/context_menu_actions/duplicate.rs
@@ -198,13 +198,18 @@ impl NativeAppState {
             Ok(completion) => {
                 self.ui.status.sample =
                     format!("Duplicated {}", sample_path_label(&completion.destination));
-                self.queue_committed_file_mutation(
+                self.queue_prepared_committed_file_mutation(
                     FileMutationOperation::Duplicate,
                     vec![
-                        FileMutationChange::created(completion.destination.clone())
-                            .with_projection(FileMutationProjection::SelectAndFollow {
+                        FileMutationChange::created_prepared(
+                            completion.destination.clone(),
+                            completion.destination_evidence,
+                        )
+                        .with_projection(
+                            FileMutationProjection::SelectAndFollow {
                                 path: completion.destination.clone(),
-                            }),
+                            },
+                        ),
                     ],
                     context,
                 );

--- a/src/sample_sources/duplicate_file_ops.rs
+++ b/src/sample_sources/duplicate_file_ops.rs
@@ -6,7 +6,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::sample_sources::{HarvestDerivationOperation, SourceDatabase};
+use crate::sample_sources::{
+    HarvestDerivationOperation, SourceDatabase, SourceFileEvidence, capture_source_file_evidence,
+};
 use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 use super::harvest_file_ops;
@@ -21,6 +23,7 @@ pub struct DuplicateSameRequest {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ContextSampleSameResult {
     pub destination: PathBuf,
+    pub destination_evidence: SourceFileEvidence,
 }
 
 #[derive(Clone, Debug)]
@@ -80,7 +83,11 @@ pub fn execute_duplicate_context_sample_same(
         &request.source_root,
         &request.source_database_root,
     )?;
-    Ok(ContextSampleSameResult { destination })
+    let destination_evidence = capture_source_file_evidence(&destination);
+    Ok(ContextSampleSameResult {
+        destination,
+        destination_evidence,
+    })
 }
 
 pub fn execute_duplicate_context_sample_double(
@@ -316,7 +323,7 @@ fn next_available_reserved_whole_file_harvest_copy_path(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sample_sources::{Rating, SourceDatabase};
+    use crate::sample_sources::{Rating, SourceDatabase, SourceFileEvidence};
 
     fn write_i16_wav(path: &Path, samples: &[i16]) {
         let spec = hound::WavSpec {
@@ -359,6 +366,10 @@ mod tests {
             vec![1, 2, 3, 4]
         );
         assert_eq!(
+            result.destination_evidence,
+            SourceFileEvidence::ContentHash(*blake3::hash(&[1_u8, 2, 3, 4]).as_bytes())
+        );
+        assert_eq!(
             db.tag_for_path(Path::new("kick_copy002.wav"))
                 .expect("read duplicate rating"),
             Some(Rating::new(2))
@@ -382,6 +393,30 @@ mod tests {
 
         assert!(error.contains("source file mismatch"));
         assert!(!destination.exists(), "failed duplicate should be removed");
+    }
+
+    #[test]
+    fn duplicate_same_large_destination_keeps_conservative_metadata_evidence() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let source = root.join("large.wav");
+        let bytes = vec![7_u8; 9 * 1024 * 1024];
+        fs::write(&source, &bytes).expect("write source");
+        let db = SourceDatabase::open_for_source_write(root).expect("open db");
+        db.upsert_file(Path::new("large.wav"), bytes.len() as u64, 1)
+            .expect("upsert source");
+
+        let result = execute_duplicate_context_sample_same(DuplicateSameRequest {
+            source_path: source,
+            source_root: root.to_path_buf(),
+            source_database_root: root.to_path_buf(),
+        })
+        .expect("duplicate large same");
+
+        assert!(matches!(
+            result.destination_evidence,
+            SourceFileEvidence::Metadata { len, .. } if len == bytes.len() as u64
+        ));
     }
 
     #[test]

--- a/src/sample_sources/file_evidence.rs
+++ b/src/sample_sources/file_evidence.rs
@@ -1,0 +1,53 @@
+//! Immutable filesystem evidence captured at a source-owned I/O boundary.
+
+use std::path::Path;
+
+use wavecrate_library::timestamps::system_time_to_unix_nanos;
+
+/// Files at or below this size are hashed when capturing mutation evidence.
+///
+/// This is the existing committed-mutation watcher policy. Keeping the threshold here lets
+/// source workers and watcher reconciliation make the same bounded decision without depending on
+/// native-app types.
+pub const MAX_SOURCE_FILE_EVIDENCE_HASH_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Immutable observation of a path at a filesystem boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SourceFileEvidence {
+    /// The path does not exist.
+    Missing,
+    /// A bounded-size regular file and its content digest.
+    ContentHash([u8; 32]),
+    /// Filesystem metadata used when hashing is intentionally bounded out.
+    Metadata {
+        /// File length in bytes.
+        len: u64,
+        /// Modification time in Unix nanoseconds, when available.
+        modified_ns: Option<i64>,
+        /// Whether the path identifies a directory.
+        is_dir: bool,
+    },
+    /// The path could not be observed reliably.
+    Unverifiable,
+}
+
+/// Capture immutable evidence for one path without opening a source database.
+pub fn capture_source_file_evidence(path: &Path) -> SourceFileEvidence {
+    match std::fs::metadata(path) {
+        Ok(metadata)
+            if metadata.is_file() && metadata.len() <= MAX_SOURCE_FILE_EVIDENCE_HASH_BYTES =>
+        {
+            match std::fs::read(path) {
+                Ok(bytes) => SourceFileEvidence::ContentHash(*blake3::hash(&bytes).as_bytes()),
+                Err(_) => SourceFileEvidence::Unverifiable,
+            }
+        }
+        Ok(metadata) => SourceFileEvidence::Metadata {
+            len: metadata.len(),
+            modified_ns: metadata.modified().ok().map(system_time_to_unix_nanos),
+            is_dir: metadata.is_dir(),
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => SourceFileEvidence::Missing,
+        Err(_) => SourceFileEvidence::Unverifiable,
+    }
+}

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -9,6 +9,7 @@
 pub mod config;
 #[doc(hidden)]
 pub mod duplicate_file_ops;
+mod file_evidence;
 mod file_move_metadata;
 #[doc(hidden)]
 pub mod harvest_file_ops;
@@ -79,6 +80,9 @@ pub use duplicate_file_ops::{
     WholeFileHarvestExtractionPlan, WholeFileHarvestExtractionRequest,
     WholeFileHarvestExtractionResult, execute_duplicate_context_sample_double,
     execute_duplicate_context_sample_same, execute_whole_file_harvest_extraction,
+};
+pub use file_evidence::{
+    MAX_SOURCE_FILE_EVIDENCE_HASH_BYTES, SourceFileEvidence, capture_source_file_evidence,
 };
 #[doc(hidden)]
 pub use file_move_metadata::{

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -106,6 +106,37 @@ fn source_processing_supervisor_uses_backend_neutral_events() {
 }
 
 #[test]
+fn same_source_duplicate_finish_uses_prepared_mutation_handoff() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source = fs::read_to_string(format!(
+        "{manifest_dir}/src/native_app/workflows/context_menu_actions/duplicate.rs"
+    ))
+    .expect("context-menu duplicate workflow should be readable");
+    let body = source_between(
+        &source,
+        "pub(in crate::native_app) fn finish_context_sample_same",
+        "pub(in crate::native_app) fn finish_context_sample_double",
+    );
+
+    assert!(
+        body.contains("queue_prepared_committed_file_mutation"),
+        "same-source duplicate completion must hand off worker-captured evidence"
+    );
+    for forbidden in [
+        "queue_committed_file_mutation",
+        "capture_expected_filesystem_state",
+        "capture_source_file_evidence",
+        "SourceDatabase",
+        "rusqlite",
+    ] {
+        assert!(
+            !body.contains(forbidden),
+            "same-source duplicate UI completion must not perform {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn sample_identity_fingerprints_require_wavecrate_debug_mode() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let source = fs::read_to_string(format!(


### PR DESCRIPTION
## Goal
Move same-source duplicate evidence capture into its existing worker so the UI completion never reads filesystem metadata or hashes the destination.

## Scope
- Add neutral immutable source-file evidence captured after same-source duplicate success.
- Pass it through `ContextSampleSameResult` into a prepared committed-mutation route.
- Preserve legacy unprepared admission for all other mutation families.

## Non-goals
No journal, schema, durability identity, Finder, readiness, Harvest, or user-visible behavior changes.

## Definition of Done
- UI completion uses prepared evidence only.
- Intervening rewrites remain superseded.
- Existing 8 MiB evidence policy and watcher/readiness ordering remain unchanged.

## Validation
- `git diff --check`
- `cargo test -p wavecrate --lib committed_file_mutations` (19 passed)
- `cargo test -p wavecrate --lib duplicate_file_ops` (8 passed)
- targeted GUI boundary test passed
- `cargo check --all-targets --locked` passed
- Independent Terra review: approved, no findings.

## Known limitations
Large files retain the existing metadata-only evidence policy. The full GUI-boundary suite has six pre-existing failures in unchanged modules.

Explicit user approval is required before merge.