### PR TITLE
Fail closed prepared mutation boundary

### DIFF
--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -372,23 +372,6 @@ impl FileMutationChange {
         }
     }
 
-    pub(in crate::native_app) fn created_prepared(
-        path: PathBuf,
-        evidence: SourceFileEvidence,
-    ) -> Self {
-        Self {
-            before_path: None,
-            after_path: Some(path),
-            before_content_identity: None,
-            after_content_identity: None,
-            semantics: FileMutationSemantics::Create,
-            expected_before_state: None,
-            expected_after_state: Some(evidence),
-            projection: None,
-            post_commit: None,
-        }
-    }
-
     pub(in crate::native_app) fn content_changed(path: PathBuf) -> Self {
         Self {
             before_path: Some(path.clone()),
@@ -467,6 +450,40 @@ impl FileMutationChange {
     }
 }
 
+/// A committed mutation change whose post-filesystem evidence was captured before it crossed the
+/// UI boundary. The inner change is intentionally private so prepared evidence can only be
+/// constructed through this narrow create path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct PreparedCommittedFileMutationChange(FileMutationChange);
+
+impl PreparedCommittedFileMutationChange {
+    pub(in crate::native_app) fn created(path: PathBuf, evidence: SourceFileEvidence) -> Self {
+        Self(FileMutationChange {
+            before_path: None,
+            after_path: Some(path),
+            before_content_identity: None,
+            after_content_identity: None,
+            semantics: FileMutationSemantics::Create,
+            expected_before_state: None,
+            expected_after_state: Some(evidence),
+            projection: None,
+            post_commit: None,
+        })
+    }
+
+    pub(in crate::native_app) fn with_projection(
+        mut self,
+        projection: FileMutationProjection,
+    ) -> Self {
+        self.0 = self.0.with_projection(projection);
+        self
+    }
+
+    fn into_file_mutation_change(self) -> FileMutationChange {
+        self.0
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct CommittedFileMutation {
     pub(in crate::native_app) fence: CommittedMutationFence,
@@ -513,43 +530,48 @@ impl NativeAppState {
     pub(in crate::native_app) fn queue_committed_file_mutation(
         &mut self,
         operation: FileMutationOperation,
-        changes: Vec<FileMutationChange>,
+        mut changes: Vec<FileMutationChange>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Option<u64> {
-        self.queue_file_mutation_outcome(operation, changes, Vec::new(), false, context)
+        capture_expected_filesystem_state(&mut changes);
+        self.queue_file_mutation_outcome(operation, changes, Vec::new(), context)
     }
 
     /// Reconcile a mutation whose filesystem evidence was captured by its source-owned worker.
     ///
     /// Unlike the legacy route, this does not inspect the filesystem on the UI thread. Callers
-    /// must provide changes created with `FileMutationChange::created_prepared` (or otherwise
-    /// carrying their expected path evidence); the worker still verifies that evidence before
-    /// touching source metadata, so an intervening rewrite is rejected.
+    /// must provide changes created with `PreparedCommittedFileMutationChange::created`; the
+    /// worker still verifies that evidence before touching source metadata, so an intervening
+    /// rewrite is rejected.
     pub(in crate::native_app) fn queue_prepared_committed_file_mutation(
         &mut self,
         operation: FileMutationOperation,
-        changes: Vec<FileMutationChange>,
+        changes: Vec<PreparedCommittedFileMutationChange>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Option<u64> {
-        self.queue_file_mutation_outcome(operation, changes, Vec::new(), true, context)
+        let changes = changes
+            .into_iter()
+            .map(PreparedCommittedFileMutationChange::into_file_mutation_change)
+            .collect();
+        self.queue_file_mutation_outcome(operation, changes, Vec::new(), context)
     }
 
     pub(in crate::native_app) fn queue_partially_committed_file_mutation(
         &mut self,
         operation: FileMutationOperation,
-        changes: Vec<FileMutationChange>,
+        mut changes: Vec<FileMutationChange>,
         failures: Vec<(Option<String>, String)>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Option<u64> {
-        self.queue_file_mutation_outcome(operation, changes, failures, false, context)
+        capture_expected_filesystem_state(&mut changes);
+        self.queue_file_mutation_outcome(operation, changes, failures, context)
     }
 
     fn queue_file_mutation_outcome(
         &mut self,
         operation: FileMutationOperation,
-        mut changes: Vec<FileMutationChange>,
+        changes: Vec<FileMutationChange>,
         reported_failures: Vec<(Option<String>, String)>,
-        prepared: bool,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Option<u64> {
         if changes.is_empty() && reported_failures.is_empty() {
@@ -558,9 +580,6 @@ impl NativeAppState {
         let correlation_id =
             ProcessLocalMutationCorrelationId::from_raw(self.background.next_task_id());
         let had_changes = !changes.is_empty();
-        if !prepared {
-            capture_expected_filesystem_state(&mut changes);
-        }
         let failures = reported_failures
             .into_iter()
             .map(|(source_id, error)| FileMutationFailure {

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -33,9 +33,16 @@ fn request(
 fn prepared_request(
     root: &Path,
     operation: FileMutationOperation,
-    changes: Vec<FileMutationChange>,
+    changes: Vec<PreparedCommittedFileMutationChange>,
 ) -> SourceMutationRequest {
-    request_without_capture(root, operation, changes)
+    request_without_capture(
+        root,
+        operation,
+        changes
+            .into_iter()
+            .map(PreparedCommittedFileMutationChange::into_file_mutation_change)
+            .collect(),
+    )
 }
 
 fn request_without_capture(
@@ -266,8 +273,8 @@ fn prepared_create_commits_small_and_large_captured_evidence() {
             root.path(),
             FileMutationOperation::Duplicate,
             vec![
-                FileMutationChange::created_prepared(small_path, small_evidence),
-                FileMutationChange::created_prepared(large_path, large_evidence),
+                PreparedCommittedFileMutationChange::created(small_path, small_evidence),
+                PreparedCommittedFileMutationChange::created(large_path, large_evidence),
             ],
         ),
         &AtomicBool::new(false),
@@ -289,7 +296,7 @@ fn prepared_create_rejects_an_intervening_rewrite() {
         prepared_request(
             root.path(),
             FileMutationOperation::Duplicate,
-            vec![FileMutationChange::created_prepared(path, evidence)],
+            vec![PreparedCommittedFileMutationChange::created(path, evidence)],
         ),
         &AtomicBool::new(false),
     )

--- a/src/native_app/sample_library/native_file_drop_actions.rs
+++ b/src/native_app/sample_library/native_file_drop_actions.rs
@@ -6,11 +6,11 @@ use std::{
 
 use radiant::prelude as ui;
 use radiant::runtime::{NativeFileDrop, NativeFileDropPhase};
-use wavecrate::sample_sources::{capture_source_file_evidence, SourceFileEvidence};
+use wavecrate::sample_sources::{SourceFileEvidence, capture_source_file_evidence};
 
 use crate::native_app::app::{GuiMessage, NativeAppState, NativeFileDropHover, emit_gui_action};
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation, FileMutationProjection,
+    FileMutationOperation, FileMutationProjection, PreparedCommittedFileMutationChange,
 };
 use crate::native_app::sample_library::exclusive_file_transfer::copy_file_to_unique_destination_with;
 
@@ -221,10 +221,13 @@ impl NativeAppState {
         self.queue_prepared_committed_file_mutation(
             FileMutationOperation::ImportDrop,
             vec![
-                FileMutationChange::created_prepared(prepared.path.clone(), prepared.evidence)
-                    .with_projection(FileMutationProjection::SelectAndLoad {
-                        path: prepared.path.clone(),
-                    }),
+                PreparedCommittedFileMutationChange::created(
+                    prepared.path.clone(),
+                    prepared.evidence,
+                )
+                .with_projection(FileMutationProjection::SelectAndLoad {
+                    path: prepared.path.clone(),
+                }),
             ],
             context,
         );

--- a/src/native_app/workflows/context_menu_actions/duplicate.rs
+++ b/src/native_app/workflows/context_menu_actions/duplicate.rs
@@ -10,6 +10,7 @@ use wavecrate::sample_sources::{
 use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
 use crate::native_app::sample_library::committed_file_mutations::{
     FileMutationChange, FileMutationOperation, FileMutationProjection,
+    PreparedCommittedFileMutationChange,
 };
 use crate::native_app::sample_library::context_menu_target as context_menu;
 use crate::native_app::sample_library::context_menu_target::{
@@ -201,7 +202,7 @@ impl NativeAppState {
                 self.queue_prepared_committed_file_mutation(
                     FileMutationOperation::Duplicate,
                     vec![
-                        FileMutationChange::created_prepared(
+                        PreparedCommittedFileMutationChange::created(
                             completion.destination.clone(),
                             completion.destination_evidence,
                         )

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -122,8 +122,13 @@ fn same_source_duplicate_finish_uses_prepared_mutation_handoff() {
         body.contains("queue_prepared_committed_file_mutation"),
         "same-source duplicate completion must hand off worker-captured evidence"
     );
+    assert!(
+        body.contains("PreparedCommittedFileMutationChange::created"),
+        "same-source duplicate completion must use the typed prepared mutation boundary"
+    );
     for forbidden in [
         "queue_committed_file_mutation",
+        "FileMutationChange::created_prepared",
         "capture_expected_filesystem_state",
         "capture_source_file_evidence",
         "SourceDatabase",
@@ -153,8 +158,13 @@ fn external_waveform_drop_finish_uses_prepared_mutation_handoff() {
         body.contains("queue_prepared_committed_file_mutation"),
         "external waveform drop completion must hand off worker-captured evidence"
     );
+    assert!(
+        body.contains("PreparedCommittedFileMutationChange::created"),
+        "external waveform drop completion must use the typed prepared mutation boundary"
+    );
     for forbidden in [
         "queue_committed_file_mutation",
+        "FileMutationChange::created_prepared",
         "capture_expected_filesystem_state",
         "capture_source_file_evidence",
         "std::fs::",
@@ -167,6 +177,29 @@ fn external_waveform_drop_finish_uses_prepared_mutation_handoff() {
             "external waveform drop UI completion must not perform {forbidden}"
         );
     }
+}
+
+#[test]
+fn committed_mutation_prepared_boundary_is_typed() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source = fs::read_to_string(format!(
+        "{manifest_dir}/src/native_app/sample_library/committed_file_mutations/mod.rs"
+    ))
+    .expect("committed file-mutation module should be readable");
+
+    assert!(
+        source.contains("PreparedCommittedFileMutationChange")
+            && source.contains("changes: Vec<PreparedCommittedFileMutationChange>"),
+        "prepared committed mutations must cross the UI boundary through the typed wrapper"
+    );
+    assert!(
+        !source.contains("created_prepared"),
+        "the untyped prepared constructor must not return to FileMutationChange"
+    );
+    assert!(
+        !source.contains("prepared: bool"),
+        "prepared state must be represented by the typed boundary, not a boolean flag"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Goal
Make the prepared committed-mutation route compile-time fail-closed.

Scope
- Add the private-inner PreparedCommittedFileMutationChange boundary.
- Require it at the prepared queue and migrate only duplicate and external waveform-drop completions.
- Preserve legacy capture and all reconciliation/projection/watcher/readiness ordering.

Non-goals
No journal, durability, telemetry, Harvest, Finder, cross-source, readiness-design, or other legacy caller changes.

Definition of Done
- Ordinary changes cannot enter the prepared queue.
- Prepared creation requires SourceFileEvidence and never recaptures on the UI thread.
- Evidence supersession and existing lifecycle/revision/projection/watcher/readiness behavior remain covered.

Validation
- cargo test --locked -p wavecrate --lib committed_file_mutations (19 passed)
- focused gui_boundary typed-boundary and both prepared-handoff tests (all passed)
- cargo check --all-targets --locked (passed)
- git diff --check (passed)
- cargo fmt --check is blocked by pre-existing unrelated formatting drift in background.rs, harvest_tracking/persistence.rs, source_diagnostics.rs, waveform tests/editor, and release_contract.rs.
- bash scripts/ci.sh agent was started and completed its observed phases, but its detached runner did not return a terminal status.

Known limitations
None in this scope.

User approval is required before merge.