### PR TITLE
Prepare worker-backed mutation evidence

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -4,7 +4,7 @@ use radiant::runtime::NativeFileDrop;
 use radiant::widgets::{DragHandleMessage, PointerModifiers};
 use std::{path::PathBuf, time::Instant};
 use wavecrate::sample_sources::{
-    HarvestDerivationOperation, HarvestSeenPersistResult, SampleCollection,
+    HarvestDerivationOperation, HarvestSeenPersistResult, SampleCollection, SourceFileEvidence,
     StarmapLayoutLoadResult, config::AppSettingsCore,
 };
 use wavecrate::selection::SelectionRange;
@@ -270,6 +270,7 @@ pub(in crate::native_app) enum GuiMessage {
         playback_type: ExtractedFilePlaybackType,
         source_duration_seconds: f64,
         started_at: Instant,
+        evidence: SourceFileEvidence,
         result: Result<(), String>,
     },
     FileMoveProgress(FileMoveProgress),

--- a/src/native_app/app/progress.rs
+++ b/src/native_app/app/progress.rs
@@ -2,8 +2,8 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 use crate::native_app::sample_library::folder_browser::RefreshedFileEntry;
 use crate::native_app::source_processing::SourceProcessingPresentation;
-use wavecrate::sample_sources::HarvestDerivationOperation;
 use wavecrate::sample_sources::readiness::{ReadinessStage, ReadinessStageCounts};
+use wavecrate::sample_sources::{HarvestDerivationOperation, SourceFileEvidence};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct NormalizationProgress {
@@ -100,6 +100,7 @@ pub(in crate::native_app) struct NormalizationResult {
     pub(in crate::native_app) restart_ratio: f32,
     pub(in crate::native_app) restart_span: Option<(f32, f32)>,
     pub(in crate::native_app) normalized: Vec<PathBuf>,
+    pub(in crate::native_app) normalized_evidence: Vec<(PathBuf, SourceFileEvidence)>,
     pub(in crate::native_app) refreshed_files: Vec<RefreshedFileEntry>,
     pub(in crate::native_app) skipped: Vec<PathBuf>,
     pub(in crate::native_app) failed: Vec<NormalizationFailure>,

--- a/src/native_app/audio/normalization_actions.rs
+++ b/src/native_app/audio/normalization_actions.rs
@@ -13,7 +13,7 @@ use crate::native_app::app::{
     WaveformPlaybackResume, emit_gui_action, sample_path_label,
 };
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation,
+    FileMutationOperation, PreparedCommittedFileMutationChange,
 };
 use crate::native_app::sample_library::file_actions::{
     WavNormalizationOutcome, normalize_wav_file_in_place_with_progress,
@@ -488,10 +488,16 @@ impl NativeAppState {
         let changes = normalized_paths
             .iter()
             .map(|path| {
+                let evidence = result
+                    .normalized_evidence
+                    .iter()
+                    .find(|(candidate, _)| candidate == path)
+                    .map(|(_, evidence)| evidence.clone())
+                    .unwrap_or(wavecrate::sample_sources::SourceFileEvidence::Unverifiable);
                 if copied_paths.contains(path) {
-                    FileMutationChange::created(path.clone())
+                    PreparedCommittedFileMutationChange::created(path.clone(), evidence)
                 } else {
-                    FileMutationChange::content_changed(path.clone())
+                    PreparedCommittedFileMutationChange::content_changed(path.clone(), evidence)
                 }
             })
             .collect::<Vec<_>>();
@@ -506,7 +512,7 @@ impl NativeAppState {
             .into_iter()
             .map(|failure| (Some(result.source_id.clone()), failure.error))
             .collect();
-        self.queue_partially_committed_file_mutation(
+        self.queue_prepared_partially_committed_file_mutation(
             FileMutationOperation::Normalize,
             changes,
             failures,
@@ -690,6 +696,7 @@ fn run_normalization_worker(
     let label = normalize_progress_label(total);
     let work_total = normalization_work_total(total);
     let mut normalized = Vec::new();
+    let mut normalized_evidence = Vec::new();
     let mut skipped = Vec::new();
     let mut failed = Vec::new();
     let mut pacer = NormalizationWorkerPacer::new(total > BULK_NORMALIZATION_BACKGROUND_THRESHOLD);
@@ -739,6 +746,10 @@ fn run_normalization_worker(
         }) {
             Ok(WavNormalizationOutcome::Normalized) => {
                 normalized.push(path.clone());
+                normalized_evidence.push((
+                    path.clone(),
+                    wavecrate::sample_sources::capture_source_file_evidence(path),
+                ));
                 log_normalization_worker_result(path, "normalized", None, file_started_at);
             }
             Ok(WavNormalizationOutcome::Skipped) => {
@@ -787,6 +798,7 @@ fn run_normalization_worker(
         restart_ratio: request.restart_ratio,
         restart_span: request.restart_span,
         normalized,
+        normalized_evidence,
         refreshed_files,
         skipped,
         failed,

--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -471,11 +471,78 @@ impl PreparedCommittedFileMutationChange {
         })
     }
 
+    pub(in crate::native_app) fn content_changed(
+        path: PathBuf,
+        evidence: SourceFileEvidence,
+    ) -> Self {
+        Self(FileMutationChange {
+            before_path: Some(path.clone()),
+            after_path: Some(path),
+            before_content_identity: None,
+            after_content_identity: None,
+            semantics: FileMutationSemantics::ContentChanged,
+            expected_before_state: None,
+            expected_after_state: Some(evidence),
+            projection: None,
+            post_commit: None,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(in crate::native_app) fn path_only_move(
+        before: PathBuf,
+        after: PathBuf,
+        evidence: SourceFileEvidence,
+    ) -> Self {
+        Self(FileMutationChange {
+            before_path: Some(before),
+            after_path: Some(after),
+            before_content_identity: None,
+            after_content_identity: None,
+            semantics: FileMutationSemantics::PathOnlyMove,
+            expected_before_state: Some(ExpectedMutationPathState::Missing),
+            expected_after_state: Some(evidence),
+            projection: None,
+            post_commit: None,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(in crate::native_app) fn deleted(path: PathBuf, evidence: SourceFileEvidence) -> Self {
+        Self(FileMutationChange {
+            before_path: Some(path),
+            after_path: None,
+            before_content_identity: None,
+            after_content_identity: None,
+            semantics: FileMutationSemantics::Delete,
+            expected_before_state: Some(evidence),
+            expected_after_state: None,
+            projection: None,
+            post_commit: None,
+        })
+    }
+
+    pub(in crate::native_app) fn with_before_content_identity(
+        mut self,
+        identity: Option<String>,
+    ) -> Self {
+        self.0.before_content_identity = identity;
+        self
+    }
+
     pub(in crate::native_app) fn with_projection(
         mut self,
         projection: FileMutationProjection,
     ) -> Self {
         self.0 = self.0.with_projection(projection);
+        self
+    }
+
+    pub(in crate::native_app) fn with_post_commit(
+        mut self,
+        post_commit: FileMutationPostCommit,
+    ) -> Self {
+        self.0 = self.0.with_post_commit(post_commit);
         self
     }
 
@@ -527,16 +594,6 @@ pub(in crate::native_app) struct FileMutationWork {
 
 impl NativeAppState {
     /// Reconcile one successful Wavecrate-owned filesystem operation off the UI thread.
-    pub(in crate::native_app) fn queue_committed_file_mutation(
-        &mut self,
-        operation: FileMutationOperation,
-        mut changes: Vec<FileMutationChange>,
-        context: &mut ui::UiUpdateContext<GuiMessage>,
-    ) -> Option<u64> {
-        capture_expected_filesystem_state(&mut changes);
-        self.queue_file_mutation_outcome(operation, changes, Vec::new(), context)
-    }
-
     /// Reconcile a mutation whose filesystem evidence was captured by its source-owned worker.
     ///
     /// Unlike the legacy route, this does not inspect the filesystem on the UI thread. Callers
@@ -556,6 +613,21 @@ impl NativeAppState {
         self.queue_file_mutation_outcome(operation, changes, Vec::new(), context)
     }
 
+    pub(in crate::native_app) fn queue_prepared_partially_committed_file_mutation(
+        &mut self,
+        operation: FileMutationOperation,
+        changes: Vec<PreparedCommittedFileMutationChange>,
+        failures: Vec<(Option<String>, String)>,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) -> Option<u64> {
+        let changes = changes
+            .into_iter()
+            .map(PreparedCommittedFileMutationChange::into_file_mutation_change)
+            .collect();
+        self.queue_file_mutation_outcome(operation, changes, failures, context)
+    }
+
+    /// Legacy partial route retained for synchronous transaction/UI completions.
     pub(in crate::native_app) fn queue_partially_committed_file_mutation(
         &mut self,
         operation: FileMutationOperation,

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -306,6 +306,39 @@ fn prepared_create_rejects_an_intervening_rewrite() {
 }
 
 #[test]
+fn prepared_non_create_changes_carry_post_filesystem_evidence() {
+    let root = tempfile::tempdir().expect("source root");
+    let before = root.path().join("before.wav");
+    let after = root.path().join("after.wav");
+    fs::write(&after, b"moved content").expect("create moved file");
+    let after_evidence = capture_source_file_evidence(&after);
+
+    let content =
+        PreparedCommittedFileMutationChange::content_changed(after.clone(), after_evidence.clone())
+            .into_file_mutation_change();
+    assert_eq!(content.semantics, FileMutationSemantics::ContentChanged);
+    assert_eq!(content.expected_after_state, Some(after_evidence.clone()));
+
+    let moved =
+        PreparedCommittedFileMutationChange::path_only_move(before.clone(), after, after_evidence)
+            .into_file_mutation_change();
+    assert_eq!(moved.semantics, FileMutationSemantics::PathOnlyMove);
+    assert_eq!(
+        moved.expected_before_state,
+        Some(SourceFileEvidence::Missing)
+    );
+    assert!(moved.expected_after_state.is_some());
+
+    let deleted = PreparedCommittedFileMutationChange::deleted(before, SourceFileEvidence::Missing)
+        .into_file_mutation_change();
+    assert_eq!(deleted.semantics, FileMutationSemantics::Delete);
+    assert_eq!(
+        deleted.expected_before_state,
+        Some(SourceFileEvidence::Missing)
+    );
+}
+
+#[test]
 fn cross_source_requests_keep_one_operation_id_and_distinct_sources() {
     let first = tempfile::tempdir().expect("first source");
     let second = tempfile::tempdir().expect("second source");

--- a/src/native_app/sample_library/drag_drop_actions/external.rs
+++ b/src/native_app/sample_library/drag_drop_actions/external.rs
@@ -13,7 +13,7 @@ use crate::native_app::app::{
     sample_path_label,
 };
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation,
+    FileMutationOperation, PreparedCommittedFileMutationChange,
 };
 use crate::native_app::waveform::{
     WaveformExtractionCompletion, WaveformSelectionKind, execute_waveform_extraction,
@@ -221,6 +221,9 @@ impl NativeAppState {
         let selection = completion.selection;
         match completion.result {
             Ok(path) => {
+                let evidence = completion
+                    .evidence
+                    .unwrap_or(wavecrate::sample_sources::SourceFileEvidence::Unverifiable);
                 self.evict_waveform_cache_path(&path);
                 self.waveform
                     .current
@@ -238,6 +241,7 @@ impl NativeAppState {
                         playback_type,
                         source_duration_seconds,
                         started_at,
+                        evidence,
                         result: result.into_completed(),
                     }
                 });
@@ -250,6 +254,7 @@ impl NativeAppState {
                     playback_type,
                     self.waveform.current.duration_seconds() as f64,
                     started_at,
+                    wavecrate::sample_sources::SourceFileEvidence::Unverifiable,
                     Err(error),
                     context,
                 );
@@ -265,6 +270,7 @@ impl NativeAppState {
         playback_type: ExtractedFilePlaybackType,
         source_duration_seconds: f64,
         started_at: Instant,
+        evidence: wavecrate::sample_sources::SourceFileEvidence,
         result: Result<(), String>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
@@ -296,9 +302,12 @@ impl NativeAppState {
                     started_at,
                     None,
                 );
-                self.queue_partially_committed_file_mutation(
+                self.queue_prepared_partially_committed_file_mutation(
                     FileMutationOperation::Extract,
-                    vec![FileMutationChange::created(copied_path)],
+                    vec![PreparedCommittedFileMutationChange::created(
+                        copied_path,
+                        evidence.clone(),
+                    )],
                     metadata_error
                         .into_iter()
                         .map(|error| (None, error))
@@ -325,9 +334,12 @@ impl NativeAppState {
                     );
                     let mut failures = vec![(None, error.clone())];
                     failures.extend(metadata_error.map(|error| (None, error)));
-                    self.queue_partially_committed_file_mutation(
+                    self.queue_prepared_partially_committed_file_mutation(
                         FileMutationOperation::Extract,
-                        vec![FileMutationChange::created(copied_path.clone())],
+                        vec![PreparedCommittedFileMutationChange::created(
+                            copied_path.clone(),
+                            evidence,
+                        )],
                         failures,
                         context,
                     );

--- a/src/native_app/sample_library/selected_file_actions.rs
+++ b/src/native_app/sample_library/selected_file_actions.rs
@@ -3,8 +3,8 @@ use crate::native_app::app::{
 };
 use crate::native_app::app::{emit_gui_action, sample_path_label};
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation, FileMutationPostCommit,
-    FileMutationPostCommitPresentation, FileMutationProjection,
+    FileMutationOperation, FileMutationPostCommit, FileMutationPostCommitPresentation,
+    FileMutationProjection, PreparedCommittedFileMutationChange,
 };
 use crate::native_app::sample_library::folder_browser::BrowserListingRevealReason;
 use crate::native_app::sample_library::sample_list::{
@@ -526,7 +526,13 @@ impl NativeAppState {
                     }
                     let cross_source_derivative =
                         self.extraction_derivative_crosses_sources(&completion.source_path, &path);
-                    let mut change = FileMutationChange::created(path.clone());
+                    let mut change = PreparedCommittedFileMutationChange::created(
+                        path.clone(),
+                        completion
+                            .evidence
+                            .clone()
+                            .unwrap_or(wavecrate::sample_sources::SourceFileEvidence::Unverifiable),
+                    );
                     let effective_focus_derivative = focus_derivative && cross_source_derivative;
                     if effective_focus_derivative {
                         change = change.with_projection(FileMutationProjection::FocusAndLoad {
@@ -542,7 +548,7 @@ impl NativeAppState {
                         started_at,
                         presentation: FileMutationPostCommitPresentation::Extracted,
                     });
-                    self.queue_committed_file_mutation(
+                    self.queue_prepared_committed_file_mutation(
                         FileMutationOperation::Extract,
                         vec![change],
                         context,
@@ -662,18 +668,29 @@ impl NativeAppState {
                         None,
                     );
                 }
-                self.queue_partially_committed_file_mutation(
+                self.queue_prepared_partially_committed_file_mutation(
                     FileMutationOperation::Extract,
                     vec![if drag_position.is_none() {
                         let change = if focus_derivative {
-                            FileMutationChange::created(path.clone()).with_projection(
+                            PreparedCommittedFileMutationChange::created(
+                                path.clone(),
+                                completion.evidence.clone().unwrap_or(
+                                    wavecrate::sample_sources::SourceFileEvidence::Unverifiable,
+                                ),
+                            )
+                            .with_projection(
                                 FileMutationProjection::FocusAndLoad {
                                     path,
                                     reason: BrowserListingRevealReason::LoadedFileFocus,
                                 },
                             )
                         } else {
-                            FileMutationChange::created(path)
+                            PreparedCommittedFileMutationChange::created(
+                                path,
+                                completion.evidence.clone().unwrap_or(
+                                    wavecrate::sample_sources::SourceFileEvidence::Unverifiable,
+                                ),
+                            )
                         };
                         change.with_post_commit(FileMutationPostCommit {
                             source_path: completion.source_path.clone(),
@@ -684,7 +701,13 @@ impl NativeAppState {
                             presentation: FileMutationPostCommitPresentation::Extracted,
                         })
                     } else {
-                        FileMutationChange::created(path).with_post_commit(FileMutationPostCommit {
+                        PreparedCommittedFileMutationChange::created(
+                            path,
+                            completion.evidence.clone().unwrap_or(
+                                wavecrate::sample_sources::SourceFileEvidence::Unverifiable,
+                            ),
+                        )
+                        .with_post_commit(FileMutationPostCommit {
                             source_path: completion.source_path.clone(),
                             selection: completion.selection,
                             playback_type,
@@ -818,12 +841,17 @@ impl NativeAppState {
                 .folder_browser
                 .flash_primary_source_acceptance();
         }
-        self.queue_partially_committed_file_mutation(
+        self.queue_prepared_partially_committed_file_mutation(
             FileMutationOperation::Extract,
             result
                 .copied
                 .iter()
-                .map(|copy| FileMutationChange::created(copy.output_path.clone()))
+                .map(|copy| {
+                    PreparedCommittedFileMutationChange::created(
+                        copy.output_path.clone(),
+                        copy.output_evidence.clone(),
+                    )
+                })
                 .collect(),
             result
                 .failed

--- a/src/native_app/shell/message_dispatch/files.rs
+++ b/src/native_app/shell/message_dispatch/files.rs
@@ -89,6 +89,7 @@ impl NativeAppState {
                 playback_type,
                 source_duration_seconds,
                 started_at,
+                evidence,
                 result,
             } => self.finish_waveform_selection_copy(
                 source_path,
@@ -97,6 +98,7 @@ impl NativeAppState {
                 playback_type,
                 source_duration_seconds,
                 started_at,
+                evidence,
                 result,
                 context,
             ),

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -10,6 +10,8 @@ mod random_audition;
 mod sample_loading;
 mod tagged_playback;
 
+use wavecrate::sample_sources::capture_source_file_evidence;
+
 use fixture::WaveformPlaybackScenario;
 
 static WAVEFORM_CONFIG_BASE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -843,11 +845,9 @@ fn playmark_selection_copy_extracts_into_current_folder_before_clipboard_handoff
 
     let mut context = ui::UiUpdateContext::default();
     scenario.state.copy_selected_files(&mut context);
-    let extraction_message = run_worker_message_for_tests(
-        context.into_command(),
-        "gui-copy-waveform-selection",
-    )
-    .expect("playmark copy extraction should complete");
+    let extraction_message =
+        run_worker_message_for_tests(context.into_command(), "gui-copy-waveform-selection")
+            .expect("playmark copy extraction should complete");
     let mut extraction_context = ui::UiUpdateContext::default();
     scenario
         .state
@@ -876,6 +876,7 @@ fn playmark_selection_copy_extracts_into_current_folder_before_clipboard_handoff
         crate::native_app::app::ExtractedFilePlaybackType::OneShot,
         source_duration_seconds,
         std::time::Instant::now(),
+        capture_source_file_evidence(&extracted),
         Ok(()),
         &mut copy_finished_context,
     );
@@ -994,6 +995,7 @@ fn playmark_extraction_completion_evicts_reused_output_cache() {
         crate::native_app::waveform::WaveformExtractionCompletion {
             source_path,
             selection,
+            evidence: Some(capture_source_file_evidence(&extracted)),
             result: Ok(extracted.clone()),
         },
         None,
@@ -1309,6 +1311,7 @@ fn protected_playmark_extraction_routes_to_primary_harvest_destination() {
         crate::native_app::waveform::WaveformExtractionCompletion {
             source_path: source_path.clone(),
             selection,
+            evidence: None,
             result: Err(String::from("simulated write failure")),
         },
         None,
@@ -2442,6 +2445,7 @@ fn playmark_selection_copy_flashes_on_submit_and_ready() {
         crate::native_app::app::ExtractedFilePlaybackType::OneShot,
         scenario.state.waveform.current.duration_seconds() as f64,
         std::time::Instant::now(),
+        wavecrate::sample_sources::SourceFileEvidence::Unverifiable,
         Ok(()),
         &mut context,
     );
@@ -2483,6 +2487,7 @@ fn playmark_selection_copy_ready_flash_ignores_stale_range() {
         crate::native_app::app::ExtractedFilePlaybackType::OneShot,
         scenario.state.waveform.current.duration_seconds() as f64,
         std::time::Instant::now(),
+        wavecrate::sample_sources::SourceFileEvidence::Unverifiable,
         Ok(()),
         &mut context,
     );
@@ -2567,6 +2572,7 @@ fn playmark_selection_copy_extracted_queues_platform_clipboard_handoff() {
     let completion = crate::native_app::waveform::WaveformExtractionCompletion {
         source_path,
         selection,
+        evidence: Some(capture_source_file_evidence(&extracted_path)),
         result: Ok(extracted_path.clone()),
     };
 

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -1,4 +1,5 @@
 use super::*;
+use wavecrate::sample_sources::capture_source_file_evidence;
 
 #[test]
 fn folder_activation_schedules_cache_indicator_refresh_without_ui_thread_probe() {
@@ -1672,6 +1673,10 @@ fn normalize_finish_keeps_changed_file_in_active_folder_cache_warm_queue() {
             restart_ratio: 0.0,
             restart_span: None,
             normalized: vec![sample_path.clone()],
+            normalized_evidence: vec![(
+                sample_path.clone(),
+                capture_source_file_evidence(&sample_path),
+            )],
             refreshed_files: Vec::new(),
             skipped: Vec::new(),
             failed: Vec::new(),

--- a/src/native_app/tests/waveform_playback/normalization.rs
+++ b/src/native_app/tests/waveform_playback/normalization.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::native_app::app::NormalizationResult;
+use std::path::Path;
+use wavecrate::sample_sources::capture_source_file_evidence;
 
 #[test]
 fn normalize_wav_file_in_place_scales_loaded_sample_peak() {
@@ -548,6 +550,7 @@ fn normalize_finish_evicts_stale_memory_cache_before_reselect() {
             restart_ratio: 0.0,
             restart_span: None,
             normalized: vec![path.clone()],
+            normalized_evidence: vec![(path.clone(), capture_source_file_evidence(&path))],
             refreshed_files: Vec::new(),
             skipped: Vec::new(),
             failed: Vec::new(),
@@ -637,6 +640,10 @@ fn normalize_finish_marks_normalized_samples_harvest_touched() {
             restart_ratio: 0.0,
             restart_span: None,
             normalized: vec![PathBuf::from(&selected_file)],
+            normalized_evidence: vec![(
+                PathBuf::from(&selected_file),
+                capture_source_file_evidence(Path::new(&selected_file)),
+            )],
             refreshed_files: Vec::new(),
             skipped: Vec::new(),
             failed: Vec::new(),
@@ -752,6 +759,10 @@ fn normalize_finish_reloads_selected_sample_even_when_another_waveform_was_loade
             restart_ratio: 0.0,
             restart_span: None,
             normalized: vec![extracted_path.clone()],
+            normalized_evidence: vec![(
+                extracted_path.clone(),
+                capture_source_file_evidence(&extracted_path),
+            )],
             refreshed_files: Vec::new(),
             skipped: Vec::new(),
             failed: Vec::new(),
@@ -825,6 +836,10 @@ fn normalize_finish_reloads_current_sample_without_waiting_on_queued_normalizati
             restart_ratio: 0.0,
             restart_span: None,
             normalized: vec![PathBuf::from(&selected_file)],
+            normalized_evidence: vec![(
+                PathBuf::from(&selected_file),
+                capture_source_file_evidence(Path::new(&selected_file)),
+            )],
             refreshed_files: Vec::new(),
             skipped: Vec::new(),
             failed: Vec::new(),
@@ -902,6 +917,7 @@ fn normalize_finish_resumes_loaded_playback_when_current_sample_is_skipped() {
             restart_ratio: 0.35,
             restart_span: Some((0.20, 0.80)),
             normalized: Vec::new(),
+            normalized_evidence: Vec::new(),
             refreshed_files: Vec::new(),
             skipped: vec![path],
             failed: Vec::new(),
@@ -972,6 +988,7 @@ fn normalize_finish_resumes_loaded_playback_when_current_sample_fails_before_wri
             restart_ratio: 0.30,
             restart_span: Some((0.10, 0.90)),
             normalized: Vec::new(),
+            normalized_evidence: Vec::new(),
             refreshed_files: Vec::new(),
             skipped: Vec::new(),
             failed: vec![crate::native_app::app::NormalizationFailure {
@@ -1028,6 +1045,7 @@ fn normalize_finish_reports_failed_file_without_success_count() {
             restart_ratio: 0.0,
             restart_span: None,
             normalized: Vec::new(),
+            normalized_evidence: Vec::new(),
             refreshed_files: Vec::new(),
             skipped: Vec::new(),
             failed: vec![crate::native_app::app::NormalizationFailure {

--- a/src/native_app/waveform/state_extraction.rs
+++ b/src/native_app/waveform/state_extraction.rs
@@ -3,6 +3,7 @@ use std::{
     sync::Arc,
 };
 
+use wavecrate::sample_sources::{SourceFileEvidence, capture_source_file_evidence};
 use wavecrate::selection::SelectionRange;
 
 use super::{
@@ -19,6 +20,7 @@ pub(in crate::native_app) struct WaveformExtractionCompletion {
     pub(in crate::native_app) source_path: PathBuf,
     pub(in crate::native_app) selection: SelectionRange,
     pub(in crate::native_app) result: Result<PathBuf, String>,
+    pub(in crate::native_app) evidence: Option<SourceFileEvidence>,
 }
 
 #[derive(Clone, Debug)]
@@ -372,6 +374,10 @@ pub(in crate::native_app) fn execute_waveform_extraction(
     WaveformExtractionCompletion {
         source_path: request.source_path,
         selection: request.selection,
+        evidence: result
+            .as_ref()
+            .ok()
+            .map(|path| capture_source_file_evidence(path)),
         result,
     }
 }

--- a/src/native_app/waveform_edits/completion.rs
+++ b/src/native_app/waveform_edits/completion.rs
@@ -7,7 +7,7 @@ use crate::native_app::app::{
     sample_path_label,
 };
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation, FileMutationProjection,
+    FileMutationOperation, FileMutationProjection, PreparedCommittedFileMutationChange,
 };
 use crate::native_app::sample_library::folder_browser::BrowserListingRevealReason;
 use crate::native_app::waveform::{WaveformPreservedMarks, WaveformState};
@@ -82,10 +82,16 @@ impl NativeAppState {
             );
         }
         let mut primary_change = if active.harvest_whole_file_derivation.is_some() {
-            FileMutationChange::created(applied.absolute_path.clone())
+            PreparedCommittedFileMutationChange::created(
+                applied.absolute_path.clone(),
+                applied.absolute_evidence.clone(),
+            )
         } else {
-            FileMutationChange::content_changed(applied.absolute_path.clone())
-                .with_before_content_identity(applied.before_content_identity.clone())
+            PreparedCommittedFileMutationChange::content_changed(
+                applied.absolute_path.clone(),
+                applied.absolute_evidence.clone(),
+            )
+            .with_before_content_identity(applied.before_content_identity.clone())
         };
         if let Some(output_path) = active.output_focus_path.as_ref() {
             primary_change = primary_change.with_projection(FileMutationProjection::FocusAndLoad {
@@ -95,9 +101,12 @@ impl NativeAppState {
         }
         let mut mutation_changes = vec![primary_change];
         if let Some(extracted) = applied.extracted.as_ref() {
-            mutation_changes.push(FileMutationChange::created(extracted.path.clone()));
+            mutation_changes.push(PreparedCommittedFileMutationChange::created(
+                extracted.path.clone(),
+                extracted.evidence.clone(),
+            ));
         }
-        self.queue_partially_committed_file_mutation(
+        self.queue_prepared_partially_committed_file_mutation(
             FileMutationOperation::Edit,
             mutation_changes,
             extracted_metadata_error

--- a/src/native_app/waveform_edits/worker.rs
+++ b/src/native_app/waveform_edits/worker.rs
@@ -4,7 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use wavecrate::sample_sources::SourceDatabase;
+use wavecrate::sample_sources::{SourceDatabase, SourceFileEvidence, capture_source_file_evidence};
 use wavecrate::selection::SelectionRange;
 use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
@@ -73,6 +73,7 @@ pub(in crate::native_app) struct AppliedWaveformEdit {
     pub(super) before_content_identity: Option<String>,
     pub(super) backup: OverwriteBackup,
     pub(super) extracted: Option<AppliedExtractedFile>,
+    pub(super) absolute_evidence: SourceFileEvidence,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -80,6 +81,7 @@ pub(super) struct AppliedExtractedFile {
     pub(super) path: PathBuf,
     pub(super) relative_path: PathBuf,
     backup_path: PathBuf,
+    pub(super) evidence: SourceFileEvidence,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -242,10 +244,12 @@ fn execute_destructive_edit_write(
         .map(|path| {
             let relative_path = source_relative_path(&request.source.root, &path)?;
             let backup_path = backup.capture_extracted(&path)?;
+            let evidence = capture_source_file_evidence(&path);
             Ok::<_, String>(AppliedExtractedFile {
                 path,
                 relative_path,
                 backup_path,
+                evidence,
             })
         })
         .transpose()?;
@@ -274,6 +278,7 @@ fn execute_destructive_edit_write(
         before_content_identity,
         backup,
         extracted,
+        absolute_evidence: capture_source_file_evidence(&request.absolute_path),
     })
 }
 

--- a/src/native_app/workflows/context_menu_actions/duplicate.rs
+++ b/src/native_app/workflows/context_menu_actions/duplicate.rs
@@ -9,8 +9,7 @@ use wavecrate::sample_sources::{
 
 use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation, FileMutationProjection,
-    PreparedCommittedFileMutationChange,
+    FileMutationOperation, FileMutationProjection, PreparedCommittedFileMutationChange,
 };
 use crate::native_app::sample_library::context_menu_target as context_menu;
 use crate::native_app::sample_library::context_menu_target::{
@@ -259,14 +258,19 @@ impl NativeAppState {
                 );
                 self.ui.status.sample =
                     format!("Duplicated {}", sample_path_label(&completion.destination));
-                self.queue_committed_file_mutation(
+                self.queue_prepared_committed_file_mutation(
                     FileMutationOperation::Duplicate,
                     vec![
-                        FileMutationChange::created(completion.destination.clone())
-                            .with_projection(FileMutationProjection::FocusAndLoad {
+                        PreparedCommittedFileMutationChange::created(
+                            completion.destination.clone(),
+                            completion.destination_evidence,
+                        )
+                        .with_projection(
+                            FileMutationProjection::FocusAndLoad {
                                 path: completion.destination.clone(),
                                 reason: BrowserListingRevealReason::LoadedFileFocus,
-                            }),
+                            },
+                        ),
                     ],
                     context,
                 );

--- a/src/sample_sources/duplicate_file_ops.rs
+++ b/src/sample_sources/duplicate_file_ops.rs
@@ -37,6 +37,7 @@ pub struct DuplicateDoubleRequest {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ContextSampleDoubleResult {
     pub destination: PathBuf,
+    pub destination_evidence: SourceFileEvidence,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -57,6 +58,7 @@ pub struct WholeFileHarvestExtractionCopy {
     pub source_path: PathBuf,
     pub output_path: PathBuf,
     pub operation: HarvestDerivationOperation,
+    pub output_evidence: SourceFileEvidence,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -103,7 +105,10 @@ pub fn execute_duplicate_context_sample_double(
     if result.is_err() {
         let _ = fs::remove_file(&destination);
     }
-    result.map(|()| ContextSampleDoubleResult { destination })
+    result.map(|()| ContextSampleDoubleResult {
+        destination: destination.clone(),
+        destination_evidence: capture_source_file_evidence(&destination),
+    })
 }
 
 pub fn execute_whole_file_harvest_extraction(
@@ -133,10 +138,14 @@ pub fn execute_whole_file_harvest_extraction(
                         "Could not copy selected sample",
                     )
                 })
-                .map(|()| WholeFileHarvestExtractionCopy {
-                    source_path: source_path.clone(),
-                    output_path,
-                    operation: operation.clone(),
+                .map(|()| {
+                    let output_evidence = capture_source_file_evidence(&output_path);
+                    WholeFileHarvestExtractionCopy {
+                        source_path: source_path.clone(),
+                        output_path,
+                        operation: operation.clone(),
+                        output_evidence,
+                    }
                 })
         });
         match result {


### PR DESCRIPTION
Goal
Advance phase 1 of the I/O target by moving safe worker-backed committed mutations across the UI boundary with already-captured filesystem evidence.

Scope
- Add prepared create/content/path/delete change forms and remove the ordinary committed-mutation queue.
- Carry worker-captured evidence through duplicate-double, waveform/clipboard and Harvest extraction, destructive edit, and normalization completions.
- Keep partial legacy admission only for transaction-history undo/redo, folder rename/move, and trash, which still lack worker-owned completion evidence.

Non-goals
No journal/coordinator, source schema, durable operation, cross-source, or filesystem-operation redesign.

Definition of Done
- Migrated UI completions do not recapture filesystem state.
- Existing verification/supersession, lifecycle/revision, projection/watcher/readiness behavior remains on the shared committed route.
- Synthetic success fixtures supply valid worker-equivalent evidence.

Validation
- cargo test --locked --lib native_app::sample_library::committed_file_mutations::tests (20 passed)
- focused extraction/clipboard tests passed
- cargo check --all-targets --locked (passed)
- git diff --check (passed)
- cargo fmt --check remains blocked by pre-existing unrelated formatting drift; all changed Rust files were rustfmt-formatted.
- The full gui_boundary suite has six pre-existing unrelated architectural-guard failures.

Known limitation
One existing waveform integration assertion requires an inactive source-processing fixture to be rebuilt before it can assert committed persistence; independent review confirmed this is a baseline harness limitation, not a prepared-evidence regression.

User approval is required before merge.