### PR TITLE
Prepare move and trash mutation evidence

### DIFF
--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -272,10 +272,6 @@ pub(in crate::native_app) enum FileMutationProjection {
         path: PathBuf,
         reason: BrowserListingRevealReason,
     },
-    LoadSelectedIfChanged {
-        target_path: PathBuf,
-        previous_selected: Option<String>,
-    },
     RenameCompletion {
         target_path: PathBuf,
         completion: RenameCommitCompletion,
@@ -319,8 +315,7 @@ impl FileMutationProjection {
             Self::SelectAndFollow { path }
             | Self::SelectAndLoad { path }
             | Self::FocusAndLoad { path, .. } => Some(path),
-            Self::LoadSelectedIfChanged { target_path, .. }
-            | Self::RenameCompletion { target_path, .. }
+            Self::RenameCompletion { target_path, .. }
             | Self::MoveCompletion { target_path, .. }
             | Self::MoveConflictCompletion { target_path, .. }
             | Self::MoveTransaction { target_path, .. }
@@ -488,7 +483,6 @@ impl PreparedCommittedFileMutationChange {
         })
     }
 
-    #[allow(dead_code)]
     pub(in crate::native_app) fn path_only_move(
         before: PathBuf,
         after: PathBuf,
@@ -507,7 +501,6 @@ impl PreparedCommittedFileMutationChange {
         })
     }
 
-    #[allow(dead_code)]
     pub(in crate::native_app) fn deleted(path: PathBuf, evidence: SourceFileEvidence) -> Self {
         Self(FileMutationChange {
             before_path: Some(path),
@@ -597,7 +590,7 @@ impl NativeAppState {
     /// Reconcile a mutation whose filesystem evidence was captured by its source-owned worker.
     ///
     /// Unlike the legacy route, this does not inspect the filesystem on the UI thread. Callers
-    /// must provide changes created with `PreparedCommittedFileMutationChange::created`; the
+    /// must provide changes created with a `PreparedCommittedFileMutationChange` constructor; the
     /// worker still verifies that evidence before touching source metadata, so an intervening
     /// rewrite is rejected.
     pub(in crate::native_app) fn queue_prepared_committed_file_mutation(
@@ -1086,24 +1079,6 @@ impl NativeAppState {
                         *reason,
                     );
                 self.load_navigation_sample(path.to_string_lossy().to_string(), context);
-            }
-            FileMutationProjection::LoadSelectedIfChanged {
-                previous_selected, ..
-            } => {
-                let Some(selected) = self
-                    .library
-                    .folder_browser
-                    .selected_file_id()
-                    .map(str::to_owned)
-                else {
-                    return;
-                };
-                if previous_selected.as_deref() == Some(selected.as_str()) {
-                    return;
-                }
-                self.cancel_metadata_tag_entry();
-                self.metadata.selected_tag = None;
-                self.load_navigation_sample(selected, context);
             }
             FileMutationProjection::RenameCompletion { completion, .. } => {
                 self.apply_committed_folder_browser_rename(completion.clone(), context);

--- a/src/native_app/sample_library/drag_drop_actions/folder_moves.rs
+++ b/src/native_app/sample_library/drag_drop_actions/folder_moves.rs
@@ -11,6 +11,7 @@ use crate::native_app::app::{
 };
 use crate::native_app::sample_library::committed_file_mutations::{
     FileMutationChange, FileMutationOperation, FileMutationProjection,
+    PreparedCommittedFileMutationChange,
 };
 use crate::native_app::sample_library::folder_browser::commands::{
     FileMoveConflictCompletion, FolderDropResult, FolderMoveCompletion, FolderMoveDropInput,
@@ -363,9 +364,12 @@ impl NativeAppState {
             }
             Ok(success) => {
                 let metadata_error = success.metadata_error.clone();
-                let mut committed_changes =
-                    folder_move_mutation_changes(&request, &success.moved_paths);
-                attach_move_completion_projection(
+                let mut committed_changes = folder_move_prepared_mutation_changes(
+                    &request,
+                    &success.moved_paths,
+                    &success.moved_path_evidence,
+                );
+                attach_prepared_move_completion_projection(
                     &mut committed_changes,
                     FileMutationProjection::MoveCompletion {
                         target_path: success
@@ -381,7 +385,7 @@ impl NativeAppState {
                     },
                 );
                 self.ui.status.sample = String::from("Finishing file move");
-                self.queue_partially_committed_file_mutation(
+                self.queue_prepared_partially_committed_file_mutation(
                     FileMutationOperation::Move,
                     committed_changes,
                     metadata_error
@@ -397,7 +401,7 @@ impl NativeAppState {
     fn finish_folder_move_result(
         &mut self,
         started_at: Instant,
-        previous_selected: Option<String>,
+        _previous_selected: Option<String>,
         committed_changes: Vec<FileMutationChange>,
         metadata_error: Option<String>,
         result: Result<FolderDropResult, String>,
@@ -405,6 +409,7 @@ impl NativeAppState {
     ) {
         match result {
             Ok(result) => {
+                let _ = metadata_error;
                 let moved = !committed_changes.is_empty() || !result.moved_paths.is_empty();
                 self.apply_moved_sample_paths(&result.moved_paths);
                 if let Some(status) = result.status {
@@ -414,19 +419,6 @@ impl NativeAppState {
                     self.persist_source_scan_cache_after_move(
                         "browser.drag_drop.move.cache_persist",
                         started_at,
-                    );
-                }
-                if moved {
-                    let mut committed_changes = committed_changes;
-                    attach_move_projection(&mut committed_changes, previous_selected);
-                    self.queue_partially_committed_file_mutation(
-                        FileMutationOperation::Move,
-                        committed_changes,
-                        metadata_error
-                            .into_iter()
-                            .map(|error| (None, error))
-                            .collect(),
-                        context,
                     );
                 }
                 emit_gui_action(
@@ -451,12 +443,13 @@ impl NativeAppState {
                         context,
                     );
                 } else {
-                    let mut failures = vec![(None, error.clone())];
-                    failures.extend(metadata_error.map(|error| (None, error)));
-                    self.queue_partially_committed_file_mutation(
+                    let reported_error = metadata_error
+                        .map(|metadata| format!("{error}; {metadata}"))
+                        .unwrap_or_else(|| error.clone());
+                    self.record_failed_file_mutation(
                         FileMutationOperation::Move,
-                        committed_changes,
-                        failures,
+                        None,
+                        reported_error,
                         context,
                     );
                 }
@@ -508,12 +501,12 @@ impl NativeAppState {
             );
             return;
         }
-        let mut committed_changes = moved_paths
-            .iter()
-            .cloned()
-            .map(|(before, after)| FileMutationChange::path_only_move(before, after))
-            .collect::<Vec<_>>();
-        attach_move_completion_projection(
+        let moved_path_evidence = match &completion.result {
+            Ok(success) => &success.moved_path_evidence,
+            Err(failure) => &failure.moved_path_evidence,
+        };
+        let mut committed_changes = prepared_path_only_moves(&moved_paths, moved_path_evidence);
+        attach_prepared_move_completion_projection(
             &mut committed_changes,
             FileMutationProjection::MoveConflictCompletion {
                 target_path: moved_paths
@@ -533,7 +526,7 @@ impl NativeAppState {
             failures.push((None, failure.error.clone()));
         }
         self.ui.status.sample = String::from("Finishing file move");
-        self.queue_partially_committed_file_mutation(
+        self.queue_prepared_partially_committed_file_mutation(
             FileMutationOperation::Move,
             committed_changes,
             failures,
@@ -544,7 +537,7 @@ impl NativeAppState {
     fn finish_file_move_conflict_result(
         &mut self,
         started_at: Instant,
-        previous_selected: Option<String>,
+        _previous_selected: Option<String>,
         committed_moves: Vec<(PathBuf, PathBuf)>,
         metadata_error: Option<String>,
         result: Result<FolderDropResult, String>,
@@ -553,12 +546,6 @@ impl NativeAppState {
         match result {
             Ok(result) => {
                 let moved = !committed_moves.is_empty() || !result.moved_paths.is_empty();
-                let mut authoritative_moves = committed_moves;
-                for moved_path in &result.moved_paths {
-                    if !authoritative_moves.contains(moved_path) {
-                        authoritative_moves.push(moved_path.clone());
-                    }
-                }
                 self.apply_moved_sample_paths(&result.moved_paths);
                 if let Some(status) = result.status {
                     self.ui.status.sample = status;
@@ -567,22 +554,6 @@ impl NativeAppState {
                     self.persist_source_scan_cache_after_move(
                         "browser.drag_drop.file_conflict.cache_persist",
                         started_at,
-                    );
-                }
-                if moved {
-                    let mut committed_changes = authoritative_moves
-                        .into_iter()
-                        .map(|(before, after)| FileMutationChange::path_only_move(before, after))
-                        .collect::<Vec<_>>();
-                    attach_move_projection(&mut committed_changes, previous_selected);
-                    self.queue_partially_committed_file_mutation(
-                        FileMutationOperation::Move,
-                        committed_changes,
-                        metadata_error
-                            .into_iter()
-                            .map(|error| (None, error))
-                            .collect(),
-                        context,
                     );
                 }
                 emit_gui_action(
@@ -599,15 +570,13 @@ impl NativeAppState {
                 );
             }
             Err(error) => {
-                let mut failures = vec![(None, error.clone())];
-                failures.extend(metadata_error.map(|error| (None, error)));
-                self.queue_partially_committed_file_mutation(
+                let error = metadata_error
+                    .map(|metadata| format!("{error}; {metadata}"))
+                    .unwrap_or(error);
+                self.record_failed_file_mutation(
                     FileMutationOperation::Move,
-                    committed_moves
-                        .into_iter()
-                        .map(|(before, after)| FileMutationChange::path_only_move(before, after))
-                        .collect(),
-                    failures,
+                    None,
+                    error.clone(),
                     context,
                 );
                 self.ui.status.sample = error.clone();
@@ -904,13 +873,19 @@ impl NativeAppState {
     }
 }
 
-fn folder_move_mutation_changes(
+fn folder_move_prepared_mutation_changes(
     request: &FolderMoveRequest,
     moved_paths: &[(PathBuf, PathBuf)],
-) -> Vec<FileMutationChange> {
+    evidence: &[(PathBuf, wavecrate::sample_sources::SourceFileEvidence)],
+) -> Vec<PreparedCommittedFileMutationChange> {
     moved_paths
         .iter()
         .map(|(before, after)| {
+            let evidence = evidence
+                .iter()
+                .find(|(path, _)| path == after)
+                .map(|(_, evidence)| evidence.clone())
+                .unwrap_or(wavecrate::sample_sources::SourceFileEvidence::Unverifiable);
             let copy_only = match request {
                 FolderMoveRequest::SourcedFiles { file_moves, .. } => file_moves
                     .iter()
@@ -919,34 +894,51 @@ fn folder_move_mutation_changes(
                 _ => false,
             };
             if copy_only {
-                FileMutationChange::created(after.clone())
+                PreparedCommittedFileMutationChange::created(after.clone(), evidence)
             } else {
-                FileMutationChange::path_only_move(before.clone(), after.clone())
+                PreparedCommittedFileMutationChange::path_only_move(
+                    before.clone(),
+                    after.clone(),
+                    evidence,
+                )
             }
         })
         .collect()
 }
 
-fn attach_move_projection(changes: &mut [FileMutationChange], previous_selected: Option<String>) {
-    let Some(target_path) = changes
+fn prepared_path_only_moves(
+    moved_paths: &[(PathBuf, PathBuf)],
+    evidence: &[(PathBuf, wavecrate::sample_sources::SourceFileEvidence)],
+) -> Vec<PreparedCommittedFileMutationChange> {
+    moved_paths
         .iter()
-        .find_map(|change| change.after_path.as_ref().cloned())
-    else {
-        return;
-    };
-    let Some(change) = changes.first_mut() else {
-        return;
-    };
-    *change = change
-        .clone()
-        .with_projection(FileMutationProjection::LoadSelectedIfChanged {
-            target_path,
-            previous_selected,
-        });
+        .map(|(before, after)| {
+            let evidence = evidence
+                .iter()
+                .find(|(path, _)| path == after)
+                .map(|(_, evidence)| evidence.clone())
+                .unwrap_or(wavecrate::sample_sources::SourceFileEvidence::Unverifiable);
+            PreparedCommittedFileMutationChange::path_only_move(
+                before.clone(),
+                after.clone(),
+                evidence,
+            )
+        })
+        .collect()
 }
 
 fn attach_move_completion_projection(
     changes: &mut [FileMutationChange],
+    projection: FileMutationProjection,
+) {
+    let Some(change) = changes.first_mut() else {
+        return;
+    };
+    *change = change.clone().with_projection(projection);
+}
+
+fn attach_prepared_move_completion_projection(
+    changes: &mut [PreparedCommittedFileMutationChange],
     projection: FileMutationProjection,
 ) {
     let Some(change) = changes.first_mut() else {

--- a/src/native_app/sample_library/folder_browser/file_move_execution.rs
+++ b/src/native_app/sample_library/folder_browser/file_move_execution.rs
@@ -22,13 +22,14 @@ use super::{
         move_existing_destination_to_backup, move_file_over_backup,
         move_file_to_unique_destination, remove_overwrite_backup,
         rename_files_with_rollback_and_progress, restore_overwrite_backup,
-        transfer_files_with_rollback_and_progress, unique_destination,
+        transfer_files_with_rollback_and_progress_with_commit_callback, unique_destination,
     },
 };
 use crate::native_app::{
     app::FileMoveProgress, sample_library::file_actions::sample_path_label,
     waveform::remap_persisted_waveform_cache_after_move,
 };
+use wavecrate::sample_sources::{SourceFileEvidence, capture_source_file_evidence};
 
 #[cfg(test)]
 pub(in crate::native_app) fn execute_folder_move_request(
@@ -139,6 +140,7 @@ where
     }
     let total = moves.len().saturating_add(2).max(2);
     let mut moved_paths = Vec::with_capacity(moves.len());
+    let mut moved_path_evidence = Vec::with_capacity(moves.len());
     for (index, (old_path, new_path)) in moves.iter().enumerate() {
         reporter.emit(
             index,
@@ -154,7 +156,9 @@ where
                 None => format!("Folder move failed: {error}"),
             });
         }
-        moved_paths.push((old_path.to_path_buf(), new_path.to_path_buf()));
+        let new_path = new_path.to_path_buf();
+        moved_paths.push((old_path.to_path_buf(), new_path.clone()));
+        moved_path_evidence.push((new_path.clone(), capture_source_file_evidence(&new_path)));
     }
     let completed_moves = moved_paths.len();
     reporter.emit(
@@ -173,6 +177,7 @@ where
     reporter.emit(total, total, String::from("Done"));
     Ok(FolderMoveSuccess {
         moved_paths,
+        moved_path_evidence,
         conflicts: Vec::new(),
         metadata_error,
     })
@@ -186,6 +191,15 @@ fn rollback_moved_folders(moved_paths: &[(PathBuf, PathBuf)]) -> Option<String> 
         }
     }
     (!errors.is_empty()).then(|| errors.join("; "))
+}
+
+fn capture_moved_path_evidence(
+    moved_paths: &[(PathBuf, PathBuf)],
+) -> Vec<(PathBuf, SourceFileEvidence)> {
+    moved_paths
+        .iter()
+        .map(|(_, after)| (after.clone(), capture_source_file_evidence(after)))
+        .collect()
 }
 
 pub(in crate::native_app) fn execute_folder_move_transaction(
@@ -260,13 +274,20 @@ where
     )?;
     let total = file_move_work_total(&plan);
     reporter.emit(0, total, String::from("Moving files"));
-    let moved_paths = transfer_files_with_rollback_and_progress(&plan.ready, |completed, path| {
-        reporter.emit(
-            completed,
-            total,
-            format!("Moved {}", sample_path_label(path)),
-        );
-    })?;
+    let mut moved_path_evidence = Vec::new();
+    let moved_paths = transfer_files_with_rollback_and_progress_with_commit_callback(
+        &plan.ready,
+        |completed, path| {
+            reporter.emit(
+                completed,
+                total,
+                format!("Moved {}", sample_path_label(path)),
+            );
+        },
+        |_, after| {
+            moved_path_evidence.push((after.to_path_buf(), capture_source_file_evidence(after)));
+        },
+    )?;
     let checked = moved_paths.len().saturating_add(plan.conflicts.len());
     reporter.emit(checked, total, String::from("Preserving waveform cache"));
     remap_persisted_waveform_cache_for_moves(&moved_paths);
@@ -281,6 +302,7 @@ where
     reporter.emit(total, total, String::from("Done"));
     Ok(FolderMoveSuccess {
         moved_paths,
+        moved_path_evidence,
         conflicts: plan.conflicts,
         metadata_error,
     })
@@ -304,13 +326,20 @@ where
     let plan = file_move_items_plan_to_folder(file_moves, target_folder, target_protected)?;
     let total = file_move_work_total(&plan);
     reporter.emit(0, total, String::from("Moving files"));
-    let moved_paths = transfer_files_with_rollback_and_progress(&plan.ready, |completed, path| {
-        reporter.emit(
-            completed,
-            total,
-            format!("Moved {}", sample_path_label(path)),
-        );
-    })?;
+    let mut moved_path_evidence = Vec::new();
+    let moved_paths = transfer_files_with_rollback_and_progress_with_commit_callback(
+        &plan.ready,
+        |completed, path| {
+            reporter.emit(
+                completed,
+                total,
+                format!("Moved {}", sample_path_label(path)),
+            );
+        },
+        |_, after| {
+            moved_path_evidence.push((after.to_path_buf(), capture_source_file_evidence(after)));
+        },
+    )?;
     let checked = moved_paths.len().saturating_add(plan.conflicts.len());
     reporter.emit(checked, total, String::from("Preserving waveform cache"));
     remap_persisted_waveform_cache_for_moves(&moved_paths);
@@ -327,6 +356,7 @@ where
     reporter.emit(total, total, String::from("Done"));
     Ok(FolderMoveSuccess {
         moved_paths,
+        moved_path_evidence,
         conflicts: plan.conflicts,
         metadata_error,
     })
@@ -355,8 +385,9 @@ where
     }
     reporter.emit(0, 2, format!("Moving {}", sample_path_label(path)));
     let completed = move_file_to_unique_destination(path, target_folder, "Sample move failed")?;
-    reporter.emit(1, 2, String::from("Preserving waveform cache"));
     let moved_paths = vec![completed];
+    let moved_path_evidence = capture_moved_path_evidence(&moved_paths);
+    reporter.emit(1, 2, String::from("Preserving waveform cache"));
     remap_persisted_waveform_cache_for_moves(&moved_paths);
     reporter.emit(1, 2, String::from("Updating metadata"));
     let metadata_error =
@@ -364,6 +395,7 @@ where
     reporter.emit(2, 2, String::from("Done"));
     Ok(FolderMoveSuccess {
         moved_paths,
+        moved_path_evidence,
         conflicts: Vec::new(),
         metadata_error,
     })
@@ -394,6 +426,7 @@ pub(in crate::native_app) fn execute_file_move_conflict_request_with_progress(
 
     let total = file_move_conflict_progress_total(&batch, request);
     let mut moved_paths = Vec::new();
+    let mut moved_path_evidence = Vec::new();
     let mut last_resolution = request.resolution;
     loop {
         let Some(conflict) = batch.conflicts.get(batch.current_index).cloned() else {
@@ -417,12 +450,14 @@ pub(in crate::native_app) fn execute_file_move_conflict_request_with_progress(
                     result: Err(FileMoveConflictExecutionFailure {
                         batch,
                         moved_paths,
+                        moved_path_evidence,
                         error,
                         metadata_error,
                     }),
                 };
             }
         };
+        moved_path_evidence.extend(capture_moved_path_evidence(&completed));
         remap_persisted_waveform_cache_for_moves(&completed);
         match resolution {
             FileMoveConflictResolution::Overwrite | FileMoveConflictResolution::Rename => {
@@ -459,6 +494,7 @@ pub(in crate::native_app) fn execute_file_move_conflict_request_with_progress(
         result: Ok(FileMoveConflictExecutionSuccess {
             batch,
             moved_paths,
+            moved_path_evidence,
             last_resolution,
             metadata_error,
         }),
@@ -604,9 +640,17 @@ mod tests {
         };
         let result = execute_folder_move_request(request).result;
 
+        let success = result.expect("move succeeds");
         assert_eq!(
-            result.expect("move succeeds").moved_paths,
+            success.moved_paths,
             vec![(source.clone(), destination.clone())]
+        );
+        assert_eq!(
+            success.moved_path_evidence,
+            vec![(
+                destination.clone(),
+                capture_source_file_evidence(&destination)
+            )]
         );
         assert!(!source.exists());
         assert_eq!(fs::read(&destination).expect("read destination"), b"source");
@@ -655,6 +699,39 @@ mod tests {
                 .last()
                 .is_some_and(|progress| progress.completed == progress.total),
             "file move worker should finish progress at total: {progress:?}"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn extracted_file_move_captures_evidence_before_preservation_progress() {
+        let root = temp_dir("wavecrate-extracted-file-move-evidence");
+        let source_dir = root.join("source");
+        let target_dir = root.join("target");
+        fs::create_dir_all(&source_dir).expect("create source");
+        fs::create_dir_all(&target_dir).expect("create target");
+        let source = source_dir.join("kick.wav");
+        let destination = target_dir.join("kick.wav");
+        fs::write(&source, b"source").expect("write source");
+        let original_evidence = capture_source_file_evidence(&source);
+        let request = FolderMoveRequest::ExtractedFile {
+            source_root: root.clone(),
+            source_database_root: root.clone(),
+            path: source,
+            target_folder: target_dir,
+        };
+
+        let completion = execute_folder_move_request_with_progress(request, 0, |progress| {
+            if progress.completed == 1 {
+                fs::write(&destination, b"replacement").expect("rewrite destination");
+            }
+            true
+        });
+        let success = completion.result.expect("move succeeds");
+
+        assert_eq!(
+            success.moved_path_evidence,
+            vec![(destination, original_evidence)]
         );
         let _ = fs::remove_dir_all(root);
     }
@@ -763,9 +840,17 @@ mod tests {
             FileMoveConflictResolutionRequest::new(FileMoveConflictResolution::Overwrite, false),
         );
 
+        let success = result.result.expect("overwrite succeeds");
         assert_eq!(
-            result.result.expect("overwrite succeeds").moved_paths,
+            success.moved_paths,
             vec![(source.clone(), destination.clone())]
+        );
+        assert_eq!(
+            success.moved_path_evidence,
+            vec![(
+                destination.clone(),
+                capture_source_file_evidence(&destination)
+            )]
         );
         assert!(!source.exists());
         assert_eq!(fs::read(&destination).expect("read destination"), b"source");

--- a/src/native_app/sample_library/folder_browser/file_move_transaction.rs
+++ b/src/native_app/sample_library/folder_browser/file_move_transaction.rs
@@ -140,7 +140,15 @@ pub(super) fn rename_files_with_rollback_and_progress(
 
 pub(super) fn transfer_files_with_rollback_and_progress(
     transfers: &[FileTransfer],
+    progress: impl FnMut(usize, &Path),
+) -> Result<Vec<(PathBuf, PathBuf)>, String> {
+    transfer_files_with_rollback_and_progress_with_commit_callback(transfers, progress, |_, _| {})
+}
+
+pub(super) fn transfer_files_with_rollback_and_progress_with_commit_callback(
+    transfers: &[FileTransfer],
     mut progress: impl FnMut(usize, &Path),
+    mut on_commit: impl FnMut(&Path, &Path),
 ) -> Result<Vec<(PathBuf, PathBuf)>, String> {
     let mut completed = Vec::new();
     for transfer in transfers {
@@ -171,6 +179,7 @@ pub(super) fn transfer_files_with_rollback_and_progress(
                 return Err(error);
             }
         };
+        on_commit(&transfer.source_path, committed.path());
         progress(completed.len() + 1, committed.path());
         completed.push(CompletedTransfer {
             transfer: transfer.clone(),

--- a/src/native_app/sample_library/folder_browser/file_move_transaction/tests.rs
+++ b/src/native_app/sample_library/folder_browser/file_move_transaction/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use std::fs;
 use tempfile::tempdir;
+use wavecrate::sample_sources::capture_source_file_evidence;
 
 #[test]
 fn file_move_plan_deduplicates_ready_paths_and_reports_conflicts() {
@@ -196,6 +197,45 @@ fn rollback_restores_source_without_touching_a_replaced_destination() {
     assert_eq!(fs::read(first_source).unwrap(), b"first");
     assert_eq!(fs::read(first_destination).unwrap(), b"replacement");
     assert_eq!(fs::read(second_source).unwrap(), b"second");
+}
+
+#[test]
+fn commit_callback_captures_evidence_before_a_later_observer_rewrite() {
+    let root = tempdir().unwrap();
+    let source = root.path().join("source");
+    let target = root.path().join("target");
+    fs::create_dir_all(&source).unwrap();
+    fs::create_dir_all(&target).unwrap();
+    let first_source = source.join("first.wav");
+    let second_source = source.join("second.wav");
+    let first_destination = target.join("first.wav");
+    let second_destination = target.join("second.wav");
+    fs::write(&first_source, b"first").unwrap();
+    fs::write(&second_source, b"second").unwrap();
+    let original_evidence = capture_source_file_evidence(&first_source);
+    let transfers = [
+        FileTransfer::move_file(first_source, first_destination.clone()),
+        FileTransfer::move_file(second_source, second_destination),
+    ];
+    let mut evidence = Vec::new();
+
+    transfer_files_with_rollback_and_progress_with_commit_callback(
+        &transfers,
+        |_, _| {},
+        |_, after| {
+            evidence.push(capture_source_file_evidence(after));
+            if after == first_destination {
+                fs::write(after, b"replacement").unwrap();
+            }
+        },
+    )
+    .expect("moves succeed");
+
+    assert_eq!(evidence[0], original_evidence);
+    assert_ne!(
+        evidence[0],
+        capture_source_file_evidence(&first_destination)
+    );
 }
 
 #[test]

--- a/src/native_app/sample_library/folder_browser/move_types.rs
+++ b/src/native_app/sample_library/folder_browser/move_types.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use wavecrate::sample_sources::SampleCollection;
+use wavecrate::sample_sources::SourceFileEvidence;
 
 use super::FolderDropResult;
 
@@ -130,6 +131,8 @@ pub(in crate::native_app) struct FolderMoveCompletion {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct FolderMoveSuccess {
     pub(in crate::native_app) moved_paths: Vec<(PathBuf, PathBuf)>,
+    /// Evidence captured by the worker immediately after each destination was committed.
+    pub(in crate::native_app) moved_path_evidence: Vec<(PathBuf, SourceFileEvidence)>,
     pub(in crate::native_app) conflicts: Vec<FileMoveConflict>,
     pub(in crate::native_app) metadata_error: Option<String>,
 }
@@ -145,6 +148,7 @@ pub(in crate::native_app) struct FileMoveConflictCompletion {
 pub(in crate::native_app) struct FileMoveConflictExecutionSuccess {
     pub(in crate::native_app) batch: FileMoveConflictBatch,
     pub(in crate::native_app) moved_paths: Vec<(PathBuf, PathBuf)>,
+    pub(in crate::native_app) moved_path_evidence: Vec<(PathBuf, SourceFileEvidence)>,
     pub(in crate::native_app) last_resolution: FileMoveConflictResolution,
     pub(in crate::native_app) metadata_error: Option<String>,
 }
@@ -153,6 +157,7 @@ pub(in crate::native_app) struct FileMoveConflictExecutionSuccess {
 pub(in crate::native_app) struct FileMoveConflictExecutionFailure {
     pub(in crate::native_app) batch: FileMoveConflictBatch,
     pub(in crate::native_app) moved_paths: Vec<(PathBuf, PathBuf)>,
+    pub(in crate::native_app) moved_path_evidence: Vec<(PathBuf, SourceFileEvidence)>,
     pub(in crate::native_app) error: String,
     pub(in crate::native_app) metadata_error: Option<String>,
 }

--- a/src/native_app/sample_library/folder_browser/rename_execution.rs
+++ b/src/native_app/sample_library/folder_browser/rename_execution.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use wavecrate::sample_sources::SourceDatabase;
+use wavecrate::sample_sources::{SourceDatabase, capture_source_file_evidence};
 
 use super::{
     FileMetadataRemap, FolderEntry, RenameCommitCompletion, RenameCommitRequest,
@@ -11,6 +11,7 @@ use super::{
 pub(in crate::native_app) fn execute_rename_commit_request(
     request: RenameCommitRequest,
 ) -> RenameCommitCompletion {
+    let mut post_filesystem_evidence = None;
     let result = match &request {
         RenameCommitRequest::FolderRename {
             old_path,
@@ -21,7 +22,10 @@ pub(in crate::native_app) fn execute_rename_commit_request(
                 Err(format!("Folder rename failed: {new_name} already exists"))
             } else {
                 fs::rename(old_path, new_path)
-                    .map(|()| RenameCommitSuccess::FolderRenamed)
+                    .map(|()| {
+                        post_filesystem_evidence = Some(capture_source_file_evidence(new_path));
+                        RenameCommitSuccess::FolderRenamed
+                    })
                     .map_err(|error| format!("Folder rename failed: {error}"))
             }
         }
@@ -53,17 +57,24 @@ pub(in crate::native_app) fn execute_rename_commit_request(
                 Err(format!("File rename failed: {new_name} already exists"))
             } else {
                 fs::rename(old_path, new_path)
-                    .map(|()| RenameCommitSuccess::FileRenamed {
-                        metadata_remap_result: metadata_remap
-                            .as_ref()
-                            .map(persist_renamed_file_metadata)
-                            .unwrap_or(Ok(())),
+                    .map(|()| {
+                        post_filesystem_evidence = Some(capture_source_file_evidence(new_path));
+                        RenameCommitSuccess::FileRenamed {
+                            metadata_remap_result: metadata_remap
+                                .as_ref()
+                                .map(persist_renamed_file_metadata)
+                                .unwrap_or(Ok(())),
+                        }
                     })
                     .map_err(|error| format!("File rename failed: {error}"))
             }
         }
     };
-    RenameCommitCompletion { request, result }
+    RenameCommitCompletion {
+        request,
+        result,
+        post_filesystem_evidence,
+    }
 }
 
 fn persist_renamed_file_metadata(remap: &FileMetadataRemap) -> Result<(), String> {
@@ -77,4 +88,33 @@ fn persist_renamed_file_metadata(remap: &FileMetadataRemap) -> Result<(), String
         .remap_analysis_sample_identity(&remap.old_relative, &remap.new_relative)
         .map_err(|err| err.to_string())?;
     batch.commit().map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wavecrate::sample_sources::SourceFileEvidence;
+
+    #[test]
+    fn rename_worker_captures_destination_evidence_after_filesystem_success() {
+        let root = tempfile::tempdir().expect("rename root");
+        let old_path = root.path().join("old");
+        let new_path = root.path().join("new");
+        std::fs::create_dir(&old_path).expect("create old folder");
+
+        let completion = execute_rename_commit_request(RenameCommitRequest::FolderRename {
+            old_path,
+            new_path,
+            new_name: String::from("new"),
+        });
+
+        assert!(matches!(
+            completion.result,
+            Ok(RenameCommitSuccess::FolderRenamed)
+        ));
+        assert!(matches!(
+            completion.post_filesystem_evidence,
+            Some(SourceFileEvidence::Metadata { is_dir: true, .. })
+        ));
+    }
 }

--- a/src/native_app/sample_library/folder_browser/rename_types.rs
+++ b/src/native_app/sample_library/folder_browser/rename_types.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use wavecrate::sample_sources::SourceFileEvidence;
+
 use super::FolderEntry;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -88,6 +90,8 @@ pub(in crate::native_app) struct FileMetadataRemap {
 pub(in crate::native_app) struct RenameCommitCompletion {
     pub(in crate::native_app) request: RenameCommitRequest,
     pub(in crate::native_app) result: Result<RenameCommitSuccess, String>,
+    /// Evidence captured by the rename worker immediately after the filesystem rename.
+    pub(in crate::native_app) post_filesystem_evidence: Option<SourceFileEvidence>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/native_app/sample_library/folder_browser_rename_actions.rs
+++ b/src/native_app/sample_library/folder_browser_rename_actions.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action, logging};
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation, FileMutationProjection,
+    FileMutationOperation, FileMutationProjection, PreparedCommittedFileMutationChange,
 };
 use crate::native_app::sample_library::context_menu_target::BrowserContextTargetKind;
 use crate::native_app::sample_library::folder_browser::commands::{
@@ -209,16 +209,23 @@ impl NativeAppState {
             return;
         };
         let metadata_error = rename_completion_metadata_error(&completion);
+        let evidence = completion
+            .post_filesystem_evidence
+            .clone()
+            .unwrap_or(wavecrate::sample_sources::SourceFileEvidence::Unverifiable);
         self.ui.status.sample = String::from("Finishing rename");
-        self.queue_partially_committed_file_mutation(
+        self.queue_prepared_partially_committed_file_mutation(
             FileMutationOperation::Rename,
             vec![
-                FileMutationChange::path_only_move(old_path, new_path.clone()).with_projection(
-                    FileMutationProjection::RenameCompletion {
-                        target_path: new_path,
-                        completion,
-                    },
-                ),
+                PreparedCommittedFileMutationChange::path_only_move(
+                    old_path,
+                    new_path.clone(),
+                    evidence,
+                )
+                .with_projection(FileMutationProjection::RenameCompletion {
+                    target_path: new_path,
+                    completion,
+                }),
             ],
             metadata_error
                 .into_iter()
@@ -273,19 +280,6 @@ impl NativeAppState {
     ) {
         if let Some(remap) = result.path_remap {
             self.apply_browser_rename_path_remap(&remap);
-            self.queue_partially_committed_file_mutation(
-                FileMutationOperation::Rename,
-                vec![FileMutationChange::path_only_move(
-                    remap.old_path.clone(),
-                    remap.new_path.clone(),
-                )],
-                result
-                    .metadata_error
-                    .into_iter()
-                    .map(|error| (None, error))
-                    .collect(),
-                context,
-            );
             self.queue_active_similarity_score_resolution(context);
         }
         self.ui.status.sample = result.status;

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -5,11 +5,14 @@ use std::{
     io,
     path::{Path, PathBuf},
 };
+use wavecrate::sample_sources::{SourceFileEvidence, capture_source_file_evidence};
 
 #[derive(Clone, Debug, PartialEq)]
 pub(in crate::native_app) struct TrashMoveOutcome {
     pub source: PathBuf,
     pub result: TrashMoveResult,
+    /// Evidence captured immediately after the worker's filesystem attempt.
+    pub evidence: SourceFileEvidence,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -35,9 +38,11 @@ pub(super) fn move_path_to_configured_trash(
 ) -> TrashMoveOutcome {
     let source_path = path.to_path_buf();
     let result = move_path_to_configured_trash_inner(path, trash_folder);
+    let evidence = capture_source_file_evidence(&source_path);
     TrashMoveOutcome {
         source: source_path,
         result,
+        evidence,
     }
 }
 
@@ -685,6 +690,20 @@ mod tests {
         );
         assert_eq!(fs::read(moved_path).unwrap(), b"kick");
         assert!(fs::symlink_metadata(broken_link).is_ok());
+    }
+
+    #[test]
+    fn trash_worker_captures_post_move_source_evidence() {
+        let temp = tempdir().unwrap();
+        let trash = temp.path().join("trash");
+        let source = temp.path().join("kick.wav");
+        fs::create_dir(&trash).unwrap();
+        fs::write(&source, b"kick").unwrap();
+
+        let outcome = move_path_to_configured_trash(&source, Some(&trash));
+
+        assert!(matches!(outcome.result, TrashMoveResult::Moved { .. }));
+        assert_eq!(outcome.evidence, SourceFileEvidence::Missing);
     }
 
     #[cfg(unix)]

--- a/src/native_app/sample_library/trash_actions/routing.rs
+++ b/src/native_app/sample_library/trash_actions/routing.rs
@@ -9,7 +9,7 @@ use crate::native_app::app::{
     emit_gui_action, sample_path_label,
 };
 use crate::native_app::sample_library::committed_file_mutations::{
-    FileMutationChange, FileMutationOperation, FileMutationProjection,
+    FileMutationOperation, FileMutationProjection, PreparedCommittedFileMutationChange,
 };
 use crate::native_app::sample_library::context_menu_target::BrowserContextTargetKind;
 use crate::native_app::sample_library::sample_list::{
@@ -221,7 +221,7 @@ impl NativeAppState {
                     TrashMoveResult::Moved { .. } | TrashMoveResult::Missing
                 )
             })
-            .map(|outcome| outcome.source.clone())
+            .map(|outcome| (outcome.source.clone(), outcome.evidence.clone()))
             .collect::<Vec<_>>();
         let failed_mutations = outcomes
             .iter()
@@ -257,19 +257,19 @@ impl NativeAppState {
                 }
                 committed_paths
                     .iter()
-                    .any(|committed| committed == &path)
+                    .any(|(committed, _)| committed == &path)
                     .then_some(FileMutationProjection::TrashFolder { path })
             }
             TrashMoveTarget::Files(_) => self.finish_file_trash_move(&outcomes, action, started_at),
         };
         let mut committed_changes = committed_paths
             .into_iter()
-            .map(FileMutationChange::deleted)
+            .map(|(path, evidence)| PreparedCommittedFileMutationChange::deleted(path, evidence))
             .collect::<Vec<_>>();
         if let (Some(change), Some(projection)) = (committed_changes.first_mut(), projection) {
             *change = change.clone().with_projection(projection);
         }
-        self.queue_partially_committed_file_mutation(
+        self.queue_prepared_partially_committed_file_mutation(
             FileMutationOperation::Trash,
             committed_changes,
             failed_mutations

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -1664,6 +1664,7 @@ fn trashing_selected_block_materializes_remaining_rows_and_loads_next_sample() {
                         .path()
                         .join(path.file_name().expect("sample file name")),
                 },
+                evidence: wavecrate::sample_sources::capture_source_file_evidence(path),
             }
         })
         .collect::<Vec<_>>();
@@ -1747,12 +1748,14 @@ fn partial_batch_trash_reconciles_moved_rows_and_keeps_failed_rows() {
                 result: TrashMoveResult::Moved {
                     destination: source_root.path().join("trash").join("a-moved.wav"),
                 },
+                evidence: wavecrate::sample_sources::capture_source_file_evidence(&moved),
             },
             TrashMoveOutcome {
                 source: failed.clone(),
                 result: TrashMoveResult::Failed {
                     error: String::from("injected second-item failure"),
                 },
+                evidence: wavecrate::sample_sources::capture_source_file_evidence(&failed),
             },
         ],
         &mut context,

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -203,6 +203,56 @@ fn committed_mutation_prepared_boundary_is_typed() {
 }
 
 #[test]
+fn worker_backed_partial_mutations_cross_typed_prepared_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let rename_worker = fs::read_to_string(format!(
+        "{manifest_dir}/src/native_app/sample_library/folder_browser/rename_execution.rs"
+    ))
+    .expect("rename worker should be readable");
+    let rename_ui = fs::read_to_string(format!(
+        "{manifest_dir}/src/native_app/sample_library/folder_browser_rename_actions.rs"
+    ))
+    .expect("rename UI completion should be readable");
+    let move_worker = fs::read_to_string(format!(
+        "{manifest_dir}/src/native_app/sample_library/folder_browser/file_move_execution.rs"
+    ))
+    .expect("file move worker should be readable");
+    let move_ui = fs::read_to_string(format!(
+        "{manifest_dir}/src/native_app/sample_library/drag_drop_actions/folder_moves.rs"
+    ))
+    .expect("folder move UI completion should be readable");
+    let trash_worker = fs::read_to_string(format!(
+        "{manifest_dir}/src/native_app/sample_library/trash_actions/movement.rs"
+    ))
+    .expect("trash worker should be readable");
+    let trash_ui = fs::read_to_string(format!(
+        "{manifest_dir}/src/native_app/sample_library/trash_actions/routing.rs"
+    ))
+    .expect("trash UI completion should be readable");
+
+    for (worker, evidence_field) in [
+        (&rename_worker, "post_filesystem_evidence"),
+        (&move_worker, "moved_path_evidence"),
+        (&trash_worker, "pub evidence: SourceFileEvidence"),
+    ] {
+        assert!(
+            worker.contains("capture_source_file_evidence") && worker.contains(evidence_field),
+            "worker must capture filesystem evidence before completion DTO crosses the GUI boundary"
+        );
+    }
+    for ui in [&rename_ui, &move_ui, &trash_ui] {
+        assert!(
+            ui.contains("queue_prepared_partially_committed_file_mutation"),
+            "worker-backed partial completion must use the typed prepared partial handoff"
+        );
+        assert!(
+            !ui.contains("capture_source_file_evidence"),
+            "UI completion must not capture filesystem evidence"
+        );
+    }
+}
+
+#[test]
 fn sample_identity_fingerprints_require_wavecrate_debug_mode() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let source = fs::read_to_string(format!(


### PR DESCRIPTION
Goal
Advance phase 2 of the I/O target by moving worker-backed rename, move, and trash completions across the UI boundary with their filesystem evidence already captured.

Scope
- Carry post-filesystem evidence in rename, move/conflict, and trash worker DTOs.
- Use typed prepared partial mutation handoffs for successful and partial batches.
- Retire all partial legacy callers except the explicitly excluded transaction-history bridge.

Non-goals
No asynchronous undo/redo transaction engine, journal/coordinator, schema, cross-source, or filesystem primitive redesign.

Definition of Done
- UI completions do not capture or probe filesystem state.
- Evidence is captured before later progress/callback observers can alter a destination.
- The only production partial legacy queue caller is transaction history.

Validation
- focused rename, move, trash, timing, and GUI-boundary tests passed
- cargo check --all-targets --locked passed
- git diff --check passed
- changed Rust files rustfmt-formatted; repository-wide cargo fmt --check has unrelated baseline drift.

Known limitations
- File-backed undo/redo still executes synchronously in transaction history and is the next dedicated phase.
- One partial-trash regression fails identically from clean main in an isolated worktree; it is baseline fixture/runtime behavior, not this change.

User approval is required before merge.