### PR TITLE
Add pre-intent per-volume capacity gate

### DIFF
--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -13,8 +13,11 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::native_app::transaction_history::operation_journal::{
-    JournalError, OperationDisposition, OperationIntent, OperationJournalCoordinator,
-    OperationPhase,
+    BoundedAdmissionError, JournalError, OperationDisposition, OperationIntent,
+    OperationJournalCoordinator, OperationPhase,
+};
+use crate::native_app::transaction_history::{
+    HistoryFileAction, HistoryFileIoDirection, RejectedBeforeIntent,
 };
 
 const JOURNAL_COMMAND_CAPACITY: usize = 32;
@@ -90,6 +93,8 @@ impl OperationJournalUnavailable {
 
 #[derive(Debug, thiserror::Error)]
 pub(in crate::native_app) enum JournalOperationError {
+    #[error("operation rejected before durable intent: {0}")]
+    RejectedBeforeIntent(RejectedBeforeIntent),
     #[error(transparent)]
     Journal(#[from] JournalError),
     #[error("operation journal unavailable: {0}")]
@@ -99,6 +104,14 @@ pub(in crate::native_app) enum JournalOperationError {
 }
 
 enum JournalCommand {
+    BoundedWaveformRestore {
+        intent: OperationIntent,
+        payload: Value,
+        direction: HistoryFileIoDirection,
+        actions: Vec<HistoryFileAction>,
+        result: SyncSender<Result<Uuid, JournalOperationError>>,
+    },
+    #[cfg(test)]
     Admit {
         intent: OperationIntent,
         payload: Value,
@@ -231,6 +244,7 @@ impl OperationJournalOwner {
     }
 
     /// Queue an admission without performing journal I/O on the caller thread.
+    #[cfg(test)]
     #[allow(dead_code)]
     pub(in crate::native_app) fn admit(
         &self,
@@ -245,6 +259,35 @@ impl OperationJournalOwner {
             .try_send(JournalCommand::Admit {
                 intent,
                 payload,
+                result: result_tx,
+            })
+            .map_err(|error| match error {
+                TrySendError::Full(_) => JournalOwnerQueueError::Full,
+                TrySendError::Disconnected(_) => JournalOwnerQueueError::Closed,
+            })?;
+        Ok(result_rx)
+    }
+
+    /// Queue the bounded history capacity gate.  Shape and filesystem facts are resolved only
+    /// by the owner thread before the durable intent is written.
+    #[allow(dead_code)]
+    pub(in crate::native_app) fn admit_bounded_waveform_restore(
+        &self,
+        intent: OperationIntent,
+        payload: Value,
+        direction: HistoryFileIoDirection,
+        actions: Vec<HistoryFileAction>,
+    ) -> Result<Receiver<Result<Uuid, JournalOperationError>>, JournalOwnerQueueError> {
+        self.ensure_available()?;
+        let (result_tx, result_rx) = mpsc::sync_channel(1);
+        self.commands
+            .as_ref()
+            .ok_or(JournalOwnerQueueError::Closed)?
+            .try_send(JournalCommand::BoundedWaveformRestore {
+                intent,
+                payload,
+                direction,
+                actions,
                 result: result_tx,
             })
             .map_err(|error| match error {
@@ -391,6 +434,45 @@ fn run_owner(
 
     while !stop.load(std::sync::atomic::Ordering::Acquire) {
         match command_rx.recv_timeout(OWNER_POLL_INTERVAL) {
+            Ok(JournalCommand::BoundedWaveformRestore {
+                intent,
+                payload,
+                direction,
+                actions,
+                result,
+            }) => {
+                if stop.load(std::sync::atomic::Ordering::Acquire) {
+                    let _ = result.send(Err(JournalOperationError::Closed));
+                    continue;
+                }
+                let outcome = coordinator
+                    .as_mut()
+                    .ok_or_else(|| {
+                        JournalOperationError::Unavailable(
+                            unavailable
+                                .lock()
+                                .expect("journal unavailable state")
+                                .clone()
+                                .unwrap_or(OperationJournalUnavailable::OpenFailed(String::from(
+                                    "operation journal coordinator is unavailable",
+                                ))),
+                        )
+                    })
+                    .and_then(|coordinator| {
+                        coordinator
+                            .admit_bounded_waveform_restore(intent, payload, direction, &actions)
+                            .map_err(|error| match error {
+                                BoundedAdmissionError::Rejected(rejection) => {
+                                    JournalOperationError::RejectedBeforeIntent(rejection)
+                                }
+                                BoundedAdmissionError::Journal(error) => {
+                                    JournalOperationError::Journal(error)
+                                }
+                            })
+                    });
+                let _ = result.send(outcome);
+            }
+            #[cfg(test)]
             Ok(JournalCommand::Admit {
                 intent,
                 payload,
@@ -464,9 +546,11 @@ fn run_owner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::native_app::transaction_history::HistoryFileIoDirection;
     use crate::native_app::transaction_history::operation_journal::{
         OperationActor, OperationKind,
     };
+    use crate::native_app::waveform_edits::waveform_restore_action_for_capacity_tests;
 
     fn intent() -> OperationIntent {
         OperationIntent {
@@ -474,6 +558,101 @@ mod tests {
             kind: OperationKind::FileHistory,
             label: String::from("owner test"),
         }
+    }
+
+    #[test]
+    fn owner_admits_bounded_restore_only_after_owner_thread_gate() {
+        let directory = tempfile::tempdir().expect("journal directory");
+        let files = tempfile::tempdir().expect("restore files");
+        let backup = files.path().join("before.wav");
+        let target = files.path().join("target.wav");
+        std::fs::write(&backup, vec![7_u8; 4097]).expect("backup");
+        std::fs::write(&target, vec![0_u8; 4097]).expect("target");
+        let action = waveform_restore_action_for_capacity_tests(backup, target, false);
+        let owner = OperationJournalOwner::start_with_directory(directory.path().to_path_buf());
+        assert_eq!(
+            owner
+                .statuses
+                .recv_timeout(Duration::from_secs(2))
+                .expect("initializing status"),
+            OperationJournalStatus::Initializing
+        );
+        assert!(matches!(
+            owner
+                .statuses
+                .recv_timeout(Duration::from_secs(2))
+                .expect("available status"),
+            OperationJournalStatus::Available { .. }
+        ));
+        let rejected = owner
+            .admit_bounded_waveform_restore(
+                intent(),
+                Value::Null,
+                HistoryFileIoDirection::Undo,
+                Vec::new(),
+            )
+            .expect("queue invalid shape")
+            .recv_timeout(Duration::from_secs(2))
+            .expect("invalid-shape result");
+        assert!(matches!(
+            rejected,
+            Err(JournalOperationError::RejectedBeforeIntent(
+                RejectedBeforeIntent::InvalidShape
+            ))
+        ));
+        let missing_target = files.path().join("missing-target.wav");
+        let missing_action = waveform_restore_action_for_capacity_tests(
+            files.path().join("before.wav"),
+            missing_target,
+            false,
+        );
+        let missing = owner
+            .admit_bounded_waveform_restore(
+                intent(),
+                Value::Null,
+                HistoryFileIoDirection::Undo,
+                vec![missing_action],
+            )
+            .expect("queue missing target")
+            .recv_timeout(Duration::from_secs(2))
+            .expect("missing-target result");
+        assert!(matches!(
+            missing,
+            Err(JournalOperationError::RejectedBeforeIntent(
+                RejectedBeforeIntent::MissingTarget(_)
+            ))
+        ));
+        assert_eq!(
+            std::fs::read_dir(directory.path())
+                .expect("journal entries")
+                .filter_map(Result::ok)
+                .filter(
+                    |entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json")
+                )
+                .count(),
+            0
+        );
+        let result = owner
+            .admit_bounded_waveform_restore(
+                intent(),
+                Value::Null,
+                HistoryFileIoDirection::Undo,
+                vec![action],
+            )
+            .expect("queue bounded admission")
+            .recv_timeout(Duration::from_secs(2))
+            .expect("admission result")
+            .expect("bounded admission");
+        drop(owner);
+        let record = std::fs::read_dir(directory.path())
+            .expect("journal entries")
+            .filter_map(Result::ok)
+            .find(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+            .map(|entry| std::fs::read(entry.path()).expect("record bytes"))
+            .expect("durable record");
+        let value: Value = serde_json::from_slice(&record).expect("record json");
+        assert_eq!(value["operation_id"], result.to_string());
+        assert!(value["capacity_plan"]["volumes"].is_array());
     }
 
     #[test]

--- a/src/native_app/transaction_history.rs
+++ b/src/native_app/transaction_history.rs
@@ -1,4 +1,5 @@
 mod app_state;
+mod capacity_gate;
 mod context;
 mod file_io;
 #[cfg(test)]
@@ -7,6 +8,7 @@ mod native;
 pub(in crate::native_app) mod operation_journal;
 mod summary;
 
+pub(in crate::native_app) use capacity_gate::RejectedBeforeIntent;
 pub(in crate::native_app) use context::TransactionContext;
 #[cfg(test)]
 pub(in crate::native_app) use file_io::HistoryFileIoOutput;

--- a/src/native_app/transaction_history/capacity_gate.rs
+++ b/src/native_app/transaction_history/capacity_gate.rs
@@ -1,0 +1,509 @@
+//! Bounded pre-intent capacity admission for history-backed waveform restores.
+//!
+//! This module intentionally owns no filesystem mutation.  It maps one narrowly defined
+//! history shape, discovers destination-volume facts from a live descriptor, aggregates
+//! allocation claims, and gives the journal owner the durable plan to persist.
+
+#![allow(missing_docs)]
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::file_io::{HistoryFileAction, HistoryFileIoDirection};
+
+/// Minimum free space retained after logical claims are admitted.
+pub(crate) const PROTECTED_FREE_SPACE_FLOOR: u64 = 256 * 1024 * 1024;
+
+/// Stable identity obtained from the destination file descriptor.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub(crate) struct VolumeIdentity {
+    /// Unix `st_dev`; other platforms may use their native volume serial in a future slice.
+    pub(crate) device: u64,
+}
+
+/// Physical allocation accounting class used by a capacity claim.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) enum CapacityAllocationClass {
+    /// Destination-side staging bytes (the only charged class in this bounded slice).
+    DestinationStaging,
+    /// Bytes for a future operation-journal record.
+    JournalRecord,
+    /// Bytes for a future source-database commit.
+    SourceDatabaseCommit,
+    /// Bytes for a future source-database WAL/SHM pair.
+    SourceWalShm,
+    /// Bytes for a future global-database commit.
+    GlobalDatabaseCommit,
+    /// Bytes for a future global-database WAL/SHM pair.
+    GlobalWalShm,
+    /// Existing destination allocation retained by the operation.
+    ExistingDestination,
+    /// Existing recovery payload retained by the operation.
+    ExistingRecoveryPayload,
+}
+
+/// One volume's durable capacity claim.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct DurableVolumeCapacity {
+    pub(crate) identity: VolumeIdentity,
+    pub(crate) allocation_unit: u64,
+    pub(crate) allocation_class: CapacityAllocationClass,
+    pub(crate) logical_bytes: u64,
+    pub(crate) allocated_bytes: u64,
+    #[serde(default)]
+    pub(crate) protected_free_bytes: u64,
+}
+
+/// Additive journal payload.  The field on `OperationRecord` is optional for legacy records.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct DurableCapacityPlan {
+    #[serde(default)]
+    pub(crate) volumes: Vec<DurableVolumeCapacity>,
+}
+
+/// The only history shape admitted by this bounded slice.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BoundedWaveformRestoreAdmission {
+    pub(crate) direction: HistoryFileIoDirection,
+    pub(crate) backup_path: PathBuf,
+    pub(crate) target_path: PathBuf,
+}
+
+/// Fail-closed reasons returned before an intent can be written.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub(crate) enum RejectedBeforeIntent {
+    #[error("history action shape is outside the bounded capacity gate")]
+    InvalidShape,
+    #[error("history restore backup is missing: {0}")]
+    MissingBackup(PathBuf),
+    #[error("history restore target is missing: {0}")]
+    MissingTarget(PathBuf),
+    #[error("history restore path is not a regular file: {0}")]
+    NotRegularFile(PathBuf),
+    #[error("capacity facts unavailable: {0}")]
+    Discovery(String),
+    #[error("capacity arithmetic overflow")]
+    Overflow,
+    #[error("capacity plan is invalid")]
+    InvalidPlan,
+    #[error("capacity admission is blocked by unresolved journal recovery")]
+    RecoveryBlocked,
+    #[error("insufficient free space on volume {0:?}: need {1} bytes, have {2} bytes")]
+    InsufficientSpace(VolumeIdentity, u64, u64),
+}
+
+pub(crate) type CapacityGateError = RejectedBeforeIntent;
+
+/// Pure shape mapper.  No filesystem calls occur here.
+pub(crate) fn map_waveform_restore_shape(
+    direction: HistoryFileIoDirection,
+    actions: &[HistoryFileAction],
+) -> Result<BoundedWaveformRestoreAdmission, CapacityGateError> {
+    if actions.len() != 1 {
+        return Err(CapacityGateError::InvalidShape);
+    }
+    let HistoryFileAction::WaveformRestore {
+        backup_path,
+        applied,
+    } = &actions[0]
+    else {
+        return Err(CapacityGateError::InvalidShape);
+    };
+    if applied.extracted.is_some()
+        || !backup_path.is_absolute()
+        || !applied.absolute_path.is_absolute()
+        || backup_path.as_os_str().is_empty()
+        || applied.absolute_path.as_os_str().is_empty()
+    {
+        return Err(CapacityGateError::InvalidShape);
+    }
+    if backup_path != &applied.backup.before && backup_path != &applied.backup.after {
+        return Err(CapacityGateError::InvalidShape);
+    }
+    Ok(BoundedWaveformRestoreAdmission {
+        direction,
+        backup_path: backup_path.clone(),
+        target_path: applied.absolute_path.clone(),
+    })
+}
+
+/// Facts obtained while holding an open destination descriptor.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct VolumeFacts {
+    pub(crate) identity: VolumeIdentity,
+    pub(crate) free_bytes: u64,
+    pub(crate) allocation_unit: u64,
+}
+
+/// One logical write requirement before aggregation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CapacityRequirement {
+    pub(crate) facts: VolumeFacts,
+    pub(crate) logical_bytes: u64,
+}
+
+/// Round a logical byte count to physical allocation units, rejecting zero units and overflow.
+pub(crate) fn round_up_allocation(
+    bytes: u64,
+    allocation_unit: u64,
+) -> Result<u64, CapacityGateError> {
+    if allocation_unit == 0 {
+        return Err(CapacityGateError::InvalidPlan);
+    }
+    if bytes == 0 {
+        return Ok(0);
+    }
+    let remainder = bytes % allocation_unit;
+    if remainder == 0 {
+        return Ok(bytes);
+    }
+    bytes
+        .checked_add(allocation_unit - remainder)
+        .ok_or(CapacityGateError::Overflow)
+}
+
+/// Aggregate logical requirements by descriptor-derived volume identity and enforce free space.
+pub(crate) fn aggregate_capacity_plan(
+    requirements: &[CapacityRequirement],
+    existing_claims: &BTreeMap<VolumeIdentity, u64>,
+) -> Result<DurableCapacityPlan, CapacityGateError> {
+    let mut grouped: BTreeMap<VolumeIdentity, DurableVolumeCapacity> = BTreeMap::new();
+    for requirement in requirements {
+        let allocated_bytes =
+            round_up_allocation(requirement.logical_bytes, requirement.facts.allocation_unit)?;
+        let entry = grouped
+            .entry(requirement.facts.identity.clone())
+            .or_insert_with(|| DurableVolumeCapacity {
+                identity: requirement.facts.identity.clone(),
+                allocation_unit: requirement.facts.allocation_unit,
+                allocation_class: CapacityAllocationClass::DestinationStaging,
+                logical_bytes: 0,
+                allocated_bytes: 0,
+                protected_free_bytes: PROTECTED_FREE_SPACE_FLOOR,
+            });
+        if entry.allocation_unit != requirement.facts.allocation_unit {
+            return Err(CapacityGateError::InvalidPlan);
+        }
+        entry.logical_bytes = entry
+            .logical_bytes
+            .checked_add(requirement.logical_bytes)
+            .ok_or(CapacityGateError::Overflow)?;
+        entry.allocated_bytes = entry
+            .allocated_bytes
+            .checked_add(allocated_bytes)
+            .ok_or(CapacityGateError::Overflow)?;
+    }
+    for claim in grouped.values() {
+        let already_claimed = existing_claims.get(&claim.identity).copied().unwrap_or(0);
+        let reserved = already_claimed
+            .checked_add(claim.allocated_bytes)
+            .ok_or(CapacityGateError::Overflow)?;
+        let free_bytes = requirements
+            .iter()
+            .filter(|requirement| requirement.facts.identity == claim.identity)
+            .map(|requirement| requirement.facts.free_bytes)
+            .min()
+            .ok_or(CapacityGateError::InvalidPlan)?;
+        if reserved
+            .checked_add(PROTECTED_FREE_SPACE_FLOOR)
+            .ok_or(CapacityGateError::Overflow)?
+            > free_bytes
+        {
+            return Err(CapacityGateError::InsufficientSpace(
+                claim.identity.clone(),
+                claim.allocated_bytes,
+                free_bytes
+                    .saturating_sub(already_claimed)
+                    .saturating_sub(PROTECTED_FREE_SPACE_FLOOR),
+            ));
+        }
+    }
+    Ok(DurableCapacityPlan {
+        volumes: grouped.into_values().collect(),
+    })
+}
+
+/// Discover descriptor-derived capacity facts for one target and backup pair.
+pub(crate) fn discover_requirement(
+    admission: &BoundedWaveformRestoreAdmission,
+) -> Result<CapacityRequirement, CapacityGateError> {
+    let backup = open_regular_file(&admission.backup_path, CapacityGateError::MissingBackup)?;
+    let logical_bytes = backup
+        .metadata()
+        .map_err(|error| CapacityGateError::Discovery(error.to_string()))?
+        .len();
+    let target = open_regular_file(&admission.target_path, CapacityGateError::MissingTarget)?;
+    let facts = descriptor_volume_facts(&target).map_err(|error| {
+        CapacityGateError::Discovery(format!("{}: {error}", admission.target_path.display()))
+    })?;
+    Ok(CapacityRequirement {
+        facts,
+        logical_bytes,
+    })
+}
+
+fn open_regular_file(
+    path: &Path,
+    missing: fn(PathBuf) -> CapacityGateError,
+) -> Result<File, CapacityGateError> {
+    let file = File::open(path).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            missing(path.to_path_buf())
+        } else {
+            CapacityGateError::Discovery(error.to_string())
+        }
+    })?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| CapacityGateError::Discovery(error.to_string()))?;
+    if !metadata.is_file() {
+        return Err(CapacityGateError::NotRegularFile(path.to_path_buf()));
+    }
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn descriptor_volume_facts(file: &File) -> Result<VolumeFacts, io::Error> {
+    use std::os::fd::AsRawFd;
+    let fd = file.as_raw_fd();
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::zeroed();
+    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let stat = unsafe { stat.assume_init() };
+    let mut fs_stat = std::mem::MaybeUninit::<libc::statvfs>::zeroed();
+    if unsafe { libc::fstatvfs(fd, fs_stat.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let fs_stat = unsafe { fs_stat.assume_init() };
+    let (free, unit) = statvfs_capacity_values(
+        u64::try_from(fs_stat.f_bavail)
+            .map_err(|_| io::Error::other("invalid free-space block count"))?,
+        u64::try_from(fs_stat.f_frsize)
+            .map_err(|_| io::Error::other("invalid filesystem fragment size"))?,
+        u64::try_from(fs_stat.f_bsize)
+            .map_err(|_| io::Error::other("invalid filesystem block size"))?,
+    )?;
+    Ok(VolumeFacts {
+        identity: VolumeIdentity {
+            device: stat.st_dev as u64,
+        },
+        free_bytes: free,
+        allocation_unit: unit,
+    })
+}
+
+#[cfg(unix)]
+fn statvfs_capacity_values(
+    available_blocks: u64,
+    fragment_size: u64,
+    block_size: u64,
+) -> Result<(u64, u64), io::Error> {
+    if fragment_size == 0 || block_size == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "filesystem allocation unit is zero",
+        ));
+    }
+    let free_bytes = available_blocks
+        .checked_mul(fragment_size)
+        .ok_or_else(|| io::Error::other("free-space arithmetic overflow"))?;
+    Ok((free_bytes, fragment_size))
+}
+
+#[cfg(windows)]
+fn descriptor_volume_facts(_file: &File) -> Result<VolumeFacts, io::Error> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "descriptor-derived volume facts are not implemented on Windows",
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn descriptor_volume_facts(_file: &File) -> Result<VolumeFacts, io::Error> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "descriptor-derived volume facts are not implemented on this platform",
+    ))
+}
+
+/// Build the one-action plan used by the journal owner.
+pub(crate) fn plan_waveform_restore(
+    direction: HistoryFileIoDirection,
+    actions: &[HistoryFileAction],
+    existing_claims: &BTreeMap<VolumeIdentity, u64>,
+) -> Result<(BoundedWaveformRestoreAdmission, DurableCapacityPlan), CapacityGateError> {
+    let admission = map_waveform_restore_shape(direction, actions)?;
+    let requirement = discover_requirement(&admission)?;
+    let plan = aggregate_capacity_plan(&[requirement], existing_claims)?;
+    Ok((admission, plan))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native_app::waveform_edits::waveform_restore_action_for_capacity_tests;
+
+    fn facts(device: u64, free_bytes: u64, allocation_unit: u64) -> VolumeFacts {
+        VolumeFacts {
+            identity: VolumeIdentity { device },
+            free_bytes,
+            allocation_unit,
+        }
+    }
+
+    #[test]
+    fn shape_mapper_accepts_one_restore_for_both_directions() {
+        let backup = PathBuf::from("/tmp/before.wav");
+        let target = PathBuf::from("/tmp/target.wav");
+        for direction in [HistoryFileIoDirection::Undo, HistoryFileIoDirection::Redo] {
+            let mapped = map_waveform_restore_shape(
+                direction,
+                &[waveform_restore_action_for_capacity_tests(
+                    backup.clone(),
+                    target.clone(),
+                    false,
+                )],
+            )
+            .unwrap();
+            assert_eq!(mapped.direction, direction);
+            assert_eq!(mapped.backup_path, backup);
+            assert_eq!(mapped.target_path, target);
+        }
+    }
+
+    #[test]
+    fn shape_mapper_rejects_compound_folder_extracted_and_mismatched_shapes() {
+        let backup = PathBuf::from("/tmp/before.wav");
+        let target = PathBuf::from("/tmp/target.wav");
+        let restore =
+            waveform_restore_action_for_capacity_tests(backup.clone(), target.clone(), false);
+        assert_eq!(
+            map_waveform_restore_shape(HistoryFileIoDirection::Undo, &[]),
+            Err(CapacityGateError::InvalidShape)
+        );
+        assert!(matches!(
+            map_waveform_restore_shape(
+                HistoryFileIoDirection::Undo,
+                &[restore.clone(), restore.clone()],
+            ),
+            Err(CapacityGateError::InvalidShape)
+        ));
+        assert!(matches!(
+            map_waveform_restore_shape(
+                HistoryFileIoDirection::Undo,
+                &[HistoryFileAction::FolderMove {
+                    source_root: PathBuf::from("/tmp/source"),
+                    source_database_root: PathBuf::from("/tmp/db"),
+                    moves: Vec::new(),
+                }],
+            ),
+            Err(CapacityGateError::InvalidShape)
+        ));
+        assert!(matches!(
+            map_waveform_restore_shape(
+                HistoryFileIoDirection::Undo,
+                &[waveform_restore_action_for_capacity_tests(
+                    backup.clone(),
+                    target.clone(),
+                    true,
+                )],
+            ),
+            Err(CapacityGateError::InvalidShape)
+        ));
+        let mut mismatch =
+            waveform_restore_action_for_capacity_tests(backup.clone(), target.clone(), false);
+        if let HistoryFileAction::WaveformRestore { backup_path, .. } = &mut mismatch {
+            *backup_path = PathBuf::from("/tmp/other.wav");
+        }
+        assert!(matches!(
+            map_waveform_restore_shape(HistoryFileIoDirection::Undo, &[mismatch]),
+            Err(CapacityGateError::InvalidShape)
+        ));
+        let relative = waveform_restore_action_for_capacity_tests(
+            PathBuf::from("before.wav"),
+            PathBuf::from("/tmp/target.wav"),
+            false,
+        );
+        assert!(matches!(
+            map_waveform_restore_shape(HistoryFileIoDirection::Undo, &[relative]),
+            Err(CapacityGateError::InvalidShape)
+        ));
+    }
+
+    #[test]
+    fn rounds_floor_and_exact_boundary() {
+        assert_eq!(round_up_allocation(0, 4096).unwrap(), 0);
+        assert_eq!(round_up_allocation(4096, 4096).unwrap(), 4096);
+        assert_eq!(round_up_allocation(4097, 4096).unwrap(), 8192);
+    }
+
+    #[test]
+    fn aggregates_same_and_two_volumes() {
+        let requirements = vec![
+            CapacityRequirement {
+                facts: facts(1, PROTECTED_FREE_SPACE_FLOOR + 16 * 1024, 4096),
+                logical_bytes: 4097,
+            },
+            CapacityRequirement {
+                facts: facts(1, PROTECTED_FREE_SPACE_FLOOR + 16 * 1024, 4096),
+                logical_bytes: 4096,
+            },
+            CapacityRequirement {
+                facts: facts(2, PROTECTED_FREE_SPACE_FLOOR + 8 * 1024, 4096),
+                logical_bytes: 4097,
+            },
+        ];
+        let plan = aggregate_capacity_plan(&requirements, &BTreeMap::new()).unwrap();
+        assert_eq!(plan.volumes.len(), 2);
+        assert_eq!(plan.volumes[0].logical_bytes, 8193);
+        assert_eq!(plan.volumes[0].allocated_bytes, 12288);
+        assert_eq!(plan.volumes[1].allocated_bytes, 8192);
+    }
+
+    #[test]
+    fn claims_consume_free_space_and_overflow_fails_closed() {
+        let mut claims = BTreeMap::new();
+        claims.insert(VolumeIdentity { device: 1 }, 4096);
+        assert!(matches!(
+            aggregate_capacity_plan(
+                &[CapacityRequirement {
+                    facts: facts(1, PROTECTED_FREE_SPACE_FLOOR + 8192, 4096),
+                    logical_bytes: 4097,
+                }],
+                &claims,
+            ),
+            Err(CapacityGateError::InsufficientSpace(..))
+        ));
+        assert!(matches!(
+            round_up_allocation(u64::MAX, 4096),
+            Err(CapacityGateError::Overflow)
+        ));
+        assert!(
+            aggregate_capacity_plan(
+                &[CapacityRequirement {
+                    facts: facts(3, PROTECTED_FREE_SPACE_FLOOR + 4096, 4096),
+                    logical_bytes: 4096,
+                }],
+                &BTreeMap::new(),
+            )
+            .is_ok()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn statvfs_free_bytes_use_fragment_size_not_block_size() {
+        assert_eq!(
+            statvfs_capacity_values(2, 4096, 16384).unwrap(),
+            (8192, 4096)
+        );
+        assert!(statvfs_capacity_values(2, 0, 16384).is_err());
+        assert!(statvfs_capacity_values(2, 4096, 0).is_err());
+    }
+}

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -17,6 +17,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
+use super::capacity_gate::{DurableCapacityPlan, RejectedBeforeIntent, VolumeIdentity};
+
 const CURRENT_SCHEMA_VERSION: u32 = 1;
 const MAX_RECORD_BYTES: usize = 1024 * 1024;
 const RECORD_SUFFIX: &str = ".json";
@@ -140,6 +142,10 @@ pub(crate) struct OperationRecord {
     pub(crate) disposition: OperationDisposition,
     /// Bounded coordinator metadata. Filesystem payloads are intentionally not interpreted here.
     pub(crate) payload: Value,
+    /// Optional physical-capacity claims.  `None` is retained for legacy records and blocks
+    /// bounded capacity admission while the operation remains unresolved.
+    #[serde(default)]
+    pub(crate) capacity_plan: Option<DurableCapacityPlan>,
     /// Creation timestamp in Unix milliseconds.
     pub(crate) created_unix_ms: i64,
     /// Last update timestamp in Unix milliseconds.
@@ -149,6 +155,14 @@ pub(crate) struct OperationRecord {
 impl OperationRecord {
     /// Construct a new intent record in the durable `IntentDurable` phase.
     pub(crate) fn new(intent: OperationIntent, payload: Value) -> Self {
+        Self::new_with_capacity_plan(intent, payload, None)
+    }
+
+    fn new_with_capacity_plan(
+        intent: OperationIntent,
+        payload: Value,
+        capacity_plan: Option<DurableCapacityPlan>,
+    ) -> Self {
         let now = unix_millis();
         Self {
             schema_version: CURRENT_SCHEMA_VERSION,
@@ -157,6 +171,7 @@ impl OperationRecord {
             phase: OperationPhase::IntentDurable,
             disposition: OperationDisposition::None,
             payload,
+            capacity_plan,
             created_unix_ms: now,
             updated_unix_ms: now,
         }
@@ -208,6 +223,18 @@ pub(crate) enum JournalError {
     NotFound(Uuid),
 }
 
+/// Result boundary for the bounded pre-intent capacity gate.
+///
+/// A rejected request has no durable operation record and must remain distinct from a journal
+/// failure encountered while persisting an already-admitted intent.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BoundedAdmissionError {
+    #[error(transparent)]
+    Rejected(#[from] RejectedBeforeIntent),
+    #[error(transparent)]
+    Journal(#[from] JournalError),
+}
+
 #[derive(Debug)]
 enum RetainedRecord {
     Malformed {
@@ -232,6 +259,8 @@ pub(crate) struct OperationJournalStore {
     records: BTreeMap<Uuid, OperationRecord>,
     retained: Vec<RetainedRecord>,
     recovery: RecoverySummary,
+    capacity_claims: BTreeMap<VolumeIdentity, u64>,
+    capacity_blocked: bool,
 }
 
 impl OperationJournalStore {
@@ -248,6 +277,8 @@ impl OperationJournalStore {
             records: BTreeMap::new(),
             retained: Vec::new(),
             recovery: RecoverySummary::default(),
+            capacity_claims: BTreeMap::new(),
+            capacity_blocked: false,
         };
         store.scan()?;
         Ok(store)
@@ -268,7 +299,16 @@ impl OperationJournalStore {
         self.records.values()
     }
 
+    pub(crate) fn capacity_claims(&self) -> &BTreeMap<VolumeIdentity, u64> {
+        &self.capacity_claims
+    }
+
+    pub(crate) fn capacity_blocked(&self) -> bool {
+        self.capacity_blocked
+    }
+
     /// Durably admit one record, before any future filesystem mutation.
+    #[cfg(test)]
     pub(crate) fn admit(&mut self, record: OperationRecord) -> Result<(), JournalError> {
         if record.schema_version != CURRENT_SCHEMA_VERSION {
             return Err(JournalError::Write {
@@ -279,6 +319,34 @@ impl OperationJournalStore {
         let path = self.record_path(record.operation_id);
         atomic_durable_write(&path, &record)?;
         self.records.insert(record.operation_id, record);
+        self.rebuild_capacity_claims();
+        Ok(())
+    }
+
+    pub(crate) fn admit_capacity(&mut self, record: OperationRecord) -> Result<(), JournalError> {
+        if self.capacity_blocked {
+            return Err(JournalError::Write {
+                path: self.record_path(record.operation_id),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    RejectedBeforeIntent::RecoveryBlocked.to_string(),
+                ),
+            });
+        }
+        let Some(plan) = record.capacity_plan.as_ref() else {
+            return Err(JournalError::Write {
+                path: self.record_path(record.operation_id),
+                source: io::Error::new(io::ErrorKind::InvalidInput, "capacity plan is required"),
+            });
+        };
+        validate_capacity_plan(plan).map_err(|error| JournalError::Write {
+            path: self.record_path(record.operation_id),
+            source: io::Error::new(io::ErrorKind::InvalidInput, error.to_string()),
+        })?;
+        let path = self.record_path(record.operation_id);
+        atomic_durable_write(&path, &record)?;
+        self.records.insert(record.operation_id, record);
+        self.rebuild_capacity_claims();
         Ok(())
     }
 
@@ -297,7 +365,41 @@ impl OperationJournalStore {
         let path = self.record_path(operation_id);
         atomic_durable_write(&path, &updated)?;
         self.records.insert(operation_id, updated);
+        self.rebuild_capacity_claims();
         Ok(())
+    }
+
+    fn rebuild_capacity_claims(&mut self) {
+        self.capacity_claims.clear();
+        self.capacity_blocked = self.recovery.malformed_count > 0
+            || self.recovery.unknown_version_count > 0
+            || self.recovery.oversize_count > 0;
+        for record in self.records.values() {
+            if record.phase == OperationPhase::Terminal && record.disposition.is_terminal() {
+                continue;
+            }
+            let Some(plan) = record.capacity_plan.as_ref() else {
+                self.capacity_blocked = true;
+                continue;
+            };
+            if validate_capacity_plan(plan).is_err() {
+                self.capacity_blocked = true;
+                continue;
+            }
+            for volume in &plan.volumes {
+                let current = self
+                    .capacity_claims
+                    .get(&volume.identity)
+                    .copied()
+                    .unwrap_or(0);
+                match current.checked_add(volume.allocated_bytes) {
+                    Some(total) => {
+                        self.capacity_claims.insert(volume.identity.clone(), total);
+                    }
+                    None => self.capacity_blocked = true,
+                }
+            }
+        }
     }
 
     fn record_path(&self, operation_id: Uuid) -> PathBuf {
@@ -386,6 +488,13 @@ impl OperationJournalStore {
                             .push(RetainedRecord::Malformed { path, bytes });
                         continue;
                     }
+                    if validate_capacity_plan_option(record.capacity_plan.as_ref()).is_err() {
+                        self.recovery.malformed_count += 1;
+                        self.recovery.attention_required = true;
+                        self.retained
+                            .push(RetainedRecord::Malformed { path, bytes });
+                        continue;
+                    }
                     if record.phase != OperationPhase::Terminal || !record.disposition.is_terminal()
                     {
                         self.recovery.unresolved_count += 1;
@@ -401,8 +510,39 @@ impl OperationJournalStore {
                 }
             }
         }
+        self.rebuild_capacity_claims();
         Ok(())
     }
+}
+
+fn validate_capacity_plan_option(
+    plan: Option<&DurableCapacityPlan>,
+) -> Result<(), RejectedBeforeIntent> {
+    if let Some(plan) = plan {
+        validate_capacity_plan(plan)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_capacity_plan(plan: &DurableCapacityPlan) -> Result<(), RejectedBeforeIntent> {
+    if plan.volumes.is_empty() {
+        return Err(RejectedBeforeIntent::InvalidPlan);
+    }
+    let mut identities = std::collections::BTreeSet::new();
+    for volume in &plan.volumes {
+        let expected_allocated = super::capacity_gate::round_up_allocation(
+            volume.logical_bytes,
+            volume.allocation_unit,
+        )?;
+        if !identities.insert(volume.identity.clone())
+            || volume.allocated_bytes != expected_allocated
+            || volume.protected_free_bytes != super::capacity_gate::PROTECTED_FREE_SPACE_FLOOR
+        {
+            return Err(RejectedBeforeIntent::InvalidPlan);
+        }
+    }
+    Ok(())
 }
 
 /// Coordinator boundary for future durable history operations.
@@ -431,6 +571,7 @@ impl OperationJournalCoordinator {
     }
 
     /// Admit an intent durably and return its stable operation ID.
+    #[cfg(test)]
     pub(crate) fn admit(
         &mut self,
         intent: OperationIntent,
@@ -439,6 +580,30 @@ impl OperationJournalCoordinator {
         let record = OperationRecord::new(intent, payload);
         let operation_id = record.operation_id;
         self.store.admit(record)?;
+        Ok(operation_id)
+    }
+
+    /// Admit exactly one bounded waveform restore after owner-thread capacity discovery.
+    pub(crate) fn admit_bounded_waveform_restore(
+        &mut self,
+        intent: OperationIntent,
+        payload: Value,
+        direction: super::file_io::HistoryFileIoDirection,
+        actions: &[super::file_io::HistoryFileAction],
+    ) -> Result<Uuid, BoundedAdmissionError> {
+        if self.store.capacity_blocked() {
+            return Err(RejectedBeforeIntent::RecoveryBlocked.into());
+        }
+        let (_admission, capacity_plan) = super::capacity_gate::plan_waveform_restore(
+            direction,
+            actions,
+            self.store.capacity_claims(),
+        )?;
+        let record = OperationRecord::new_with_capacity_plan(intent, payload, Some(capacity_plan));
+        let operation_id = record.operation_id;
+        self.store
+            .admit_capacity(record)
+            .map_err(BoundedAdmissionError::Journal)?;
         Ok(operation_id)
     }
 
@@ -758,6 +923,134 @@ mod tests {
         let record = journal.record(id).unwrap();
         assert_eq!(record.phase, OperationPhase::Prepared);
         assert_eq!(record.disposition, OperationDisposition::RetryPending);
+        assert!(journal.store.capacity_blocked());
+    }
+
+    #[test]
+    fn capacity_plan_claim_is_durable_and_reconstructed_after_restart() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let identity = VolumeIdentity { device: 77 };
+        let plan = DurableCapacityPlan {
+            volumes: vec![super::super::capacity_gate::DurableVolumeCapacity {
+                identity: identity.clone(),
+                allocation_unit: 4096,
+                allocation_class:
+                    super::super::capacity_gate::CapacityAllocationClass::DestinationStaging,
+                logical_bytes: 4096,
+                allocated_bytes: 4096,
+                protected_free_bytes: super::super::capacity_gate::PROTECTED_FREE_SPACE_FLOOR,
+            }],
+        };
+        {
+            let mut store = OperationJournalStore::open(dir.path().to_path_buf()).unwrap();
+            let record =
+                OperationRecord::new_with_capacity_plan(intent(), Value::Null, Some(plan.clone()));
+            store.admit_capacity(record).unwrap();
+            assert_eq!(store.capacity_claims().get(&identity), Some(&4096));
+            assert!(!store.capacity_blocked());
+        }
+        let store = OperationJournalStore::open(dir.path().to_path_buf()).unwrap();
+        assert_eq!(store.capacity_claims().get(&identity), Some(&4096));
+        assert!(!store.capacity_blocked());
+    }
+
+    #[test]
+    fn invalid_capacity_plans_are_retained_and_block_admission_after_restart() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let identity = VolumeIdentity { device: 77 };
+        for (_, plan) in [
+            (
+                "empty",
+                DurableCapacityPlan {
+                    volumes: Vec::new(),
+                },
+            ),
+            (
+                "undercharged",
+                DurableCapacityPlan {
+                    volumes: vec![super::super::capacity_gate::DurableVolumeCapacity {
+                        identity: identity.clone(),
+                        allocation_unit: 4096,
+                        allocation_class:
+                            super::super::capacity_gate::CapacityAllocationClass::DestinationStaging,
+                        logical_bytes: 4097,
+                        allocated_bytes: 4096,
+                        protected_free_bytes:
+                            super::super::capacity_gate::PROTECTED_FREE_SPACE_FLOOR,
+                    }],
+                },
+            ),
+        ] {
+            let record = OperationRecord::new_with_capacity_plan(intent(), Value::Null, Some(plan));
+            let path = dir.path().join(format!("{}.json", record.operation_id));
+            fs::write(path, serde_json::to_vec(&record).unwrap()).unwrap();
+        }
+        let store = OperationJournalStore::open(dir.path().to_path_buf()).unwrap();
+        assert_eq!(store.recovery_summary().malformed_count, 2);
+        assert!(store.capacity_blocked());
+        assert_eq!(
+            fs::read_dir(dir.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(
+                    |entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json")
+                )
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn coordinator_returns_typed_insufficient_capacity_without_a_record() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let files = tempfile::tempdir().unwrap();
+        let backup = files.path().join("before.wav");
+        let target = files.path().join("target.wav");
+        fs::write(&backup, vec![7_u8; 4097]).unwrap();
+        fs::write(&target, vec![0_u8; 4097]).unwrap();
+        let action = crate::native_app::waveform_edits::waveform_restore_action_for_capacity_tests(
+            backup, target, false,
+        );
+        let mut coordinator = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+        let (_, mut plan) =
+            crate::native_app::transaction_history::capacity_gate::plan_waveform_restore(
+                crate::native_app::transaction_history::file_io::HistoryFileIoDirection::Undo,
+                std::slice::from_ref(&action),
+                &BTreeMap::new(),
+            )
+            .unwrap();
+        let volume = &mut plan.volumes[0];
+        let logical = (1_u64 << 62) - ((1_u64 << 62) % volume.allocation_unit);
+        volume.logical_bytes = logical;
+        volume.allocated_bytes = logical;
+        let record = OperationRecord::new_with_capacity_plan(intent(), Value::Null, Some(plan));
+        coordinator.store.admit_capacity(record).unwrap();
+        let json_before = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+            .count();
+        let rejected = coordinator
+            .admit_bounded_waveform_restore(
+                intent(),
+                Value::Null,
+                crate::native_app::transaction_history::file_io::HistoryFileIoDirection::Undo,
+                std::slice::from_ref(&action),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            rejected,
+            BoundedAdmissionError::Rejected(RejectedBeforeIntent::InsufficientSpace(..))
+        ));
+        let json_after = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+            .count();
+        assert_eq!(json_after, json_before);
     }
 
     #[test]

--- a/src/native_app/waveform_edits.rs
+++ b/src/native_app/waveform_edits.rs
@@ -13,4 +13,5 @@ pub(in crate::native_app) use worker::{
 #[cfg(test)]
 pub(in crate::native_app) use worker::{
     destructive_edit_before_backup_path_for_tests, execute_destructive_edit_for_tests,
+    waveform_restore_action_for_capacity_tests,
 };

--- a/src/native_app/waveform_edits/worker.rs
+++ b/src/native_app/waveform_edits/worker.rs
@@ -9,6 +9,8 @@ use wavecrate::selection::SelectionRange;
 use wavecrate_library::timestamps::system_time_to_unix_nanos;
 
 use crate::native_app::app::{PendingWaveformDestructiveEdit, WaveformDestructiveEditKind};
+#[cfg(test)]
+use crate::native_app::transaction_history::HistoryFileAction;
 use crate::native_app::waveform::{WaveformExtractionRequest, execute_waveform_extraction};
 use crate::native_app::waveform_edit_effects::apply_edit_selection_effects;
 
@@ -195,6 +197,35 @@ pub(in crate::native_app) fn destructive_edit_before_backup_path_for_tests(
     applied: &AppliedWaveformEdit,
 ) -> PathBuf {
     applied.backup.before.clone()
+}
+
+#[cfg(test)]
+pub(in crate::native_app) fn waveform_restore_action_for_capacity_tests(
+    backup_path: PathBuf,
+    target_path: PathBuf,
+    extracted: bool,
+) -> HistoryFileAction {
+    HistoryFileAction::WaveformRestore {
+        backup_path: backup_path.clone(),
+        applied: AppliedWaveformEdit {
+            source_id: String::from("test"),
+            relative_path: PathBuf::from("sample.wav"),
+            absolute_path: target_path,
+            before_content_identity: None,
+            backup: OverwriteBackup {
+                before: backup_path.clone(),
+                after: backup_path.clone(),
+                dir: None,
+            },
+            extracted: extracted.then(|| AppliedExtractedFile {
+                path: PathBuf::from("/tmp/extracted.wav"),
+                relative_path: PathBuf::from("extracted.wav"),
+                backup_path,
+                evidence: SourceFileEvidence::Unverifiable,
+            }),
+            absolute_evidence: SourceFileEvidence::Unverifiable,
+        },
+    }
 }
 
 fn prepare_destructive_edit_copy(


### PR DESCRIPTION
## Goal
Advance the Wavecrate I/O target with a correctness-first, profile-local capacity admission boundary for one bounded file-history restore shape.

## Scope
- Add a journal-owner-only pre-intent capacity gate for exactly one non-extracted `WaveformRestore` action on undo or redo.
- Discover destination volume identity and free capacity from opened file descriptors.
- Aggregate checked per-volume allocation claims with a protected 256 MiB floor.
- Persist the complete capacity plan on the schema-v1 operation record before any future filesystem mutation.
- Reconstruct unresolved claims at restart and fail closed on legacy unresolved records, malformed/unknown/oversized records, invalid plans, and arithmetic overflow.
- Preserve typed `RejectedBeforeIntent` errors through the owner queue without creating an operation record.

## Non-goals
- No filesystem staging, replacement, deletion, folder move, extracted restore, source/global database work, projection, watcher, UI status, or production undo/redo dispatch.
- No pathname-based recovery, schema migration, capacity release/spend/reconstitution, or Windows volume implementation (unsupported platforms fail closed).

## Definition of Done
- Accepted bounded requests durably write `IntentDurable` plus a validated per-volume capacity plan in the owner thread.
- Pre-intent rejection returns a typed error, no operation ID, and no journal record.
- Restart scan preserves legacy/invalid bytes and blocks bounded admission conservatively.
- No UI-thread I/O or production history-I/O dispatch is introduced.
- Focused tests cover shape mapping, checked arithmetic/floor, descriptor-unit accounting, owner admission, durable claims/restart reconstruction, invalid-plan recovery, and no-record rejection.

## Validation
- `RUSTFLAGS='-A unused-imports' cargo test -p wavecrate --lib native_app::transaction_history::capacity_gate::tests --no-default-features -- --nocapture` (6 passed)
- `RUSTFLAGS='-A unused-imports' cargo test -p wavecrate --lib native_app::transaction_history::operation_journal::tests --no-default-features -- --nocapture` (11 passed)
- `RUSTFLAGS='-A unused-imports' cargo test -p wavecrate --lib native_app::app::state::journal::tests --no-default-features -- --nocapture` (8 passed)
- `RUSTFLAGS='-A unused-imports' cargo test -p wavecrate --lib native_app::transaction_history --no-default-features -- --nocapture` (21 passed)
- `CARGO_TARGET_DIR=/tmp/wavecrate-capacity-target-final RUSTFLAGS='-A unused-imports' cargo check --lib --locked --no-default-features` (passed)
- `rustfmt --edition 2024 --check` on all changed files (passed)
- `git diff --check` (passed)

## Known limitations
Capacity is a point-in-time pre-intent observation, not an execution guarantee. The next slice must reacquire capabilities and retain persisted claims through preparation, execution, and recovery. Full-repository formatting still reports unrelated pre-existing differences in unchanged files.

## Next architecture task
Implement the capability-backed `Prepared` transition for the same bounded waveform-restore shape: reacquire no-follow source/target capabilities, revalidate identity and capacity, and persist qualified preparation evidence without staging or replacement.

User approval is required before merge.
