### PR TITLE
Gate destructive edits on owned recovery capability

### DIFF
--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -32,6 +32,8 @@ use crate::native_app::source_processing::SourceProcessingSupervisor;
 use crate::native_app::waveform::WaveformPreservedMarks;
 
 pub(in crate::native_app) struct BackgroundTaskState {
+    pub(in crate::native_app) waveform_recovery_root:
+        Option<crate::native_app::transaction_history::operation_journal::RecoveryRootCapability>,
     pub(in crate::native_app) worker_sender: Sender<GuiMessage>,
     pub(in crate::native_app) worker_receiver: Option<Receiver<GuiMessage>>,
     pub(in crate::native_app) next_task_id: u64,
@@ -401,6 +403,10 @@ impl BackgroundTaskState {
         worker_receiver: Option<Receiver<GuiMessage>>,
         sources: Vec<wavecrate::sample_sources::SampleSource>,
     ) -> Self {
+        #[cfg(test)]
+        let recovery_root = sources.first().map(|source| source.root.join(".wavecrate"));
+        #[cfg(not(test))]
+        let recovery_root = None;
         #[cfg(not(test))]
         let source_processing = Self::start_source_processing(&worker_sender, sources);
         #[cfg(test)]
@@ -408,7 +414,12 @@ impl BackgroundTaskState {
             drop(sources);
             SourceProcessingSupervisor::dormant()
         };
-        Self::with_source_processing(worker_sender, worker_receiver, source_processing)
+        Self::with_source_processing(
+            worker_sender,
+            worker_receiver,
+            source_processing,
+            recovery_root,
+        )
     }
 
     #[cfg(any(test, feature = "legacy-controller"))]
@@ -418,7 +429,7 @@ impl BackgroundTaskState {
         sources: Vec<wavecrate::sample_sources::SampleSource>,
     ) -> Self {
         let source_processing = Self::start_source_processing(&worker_sender, sources);
-        Self::with_source_processing(worker_sender, worker_receiver, source_processing)
+        Self::with_source_processing(worker_sender, worker_receiver, source_processing, None)
     }
 
     fn start_source_processing(
@@ -435,13 +446,28 @@ impl BackgroundTaskState {
         worker_sender: Sender<GuiMessage>,
         worker_receiver: Option<Receiver<GuiMessage>>,
         source_processing: SourceProcessingSupervisor,
+        recovery_root: Option<PathBuf>,
     ) -> Self {
         let source_lifecycle_generations = source_processing.lifecycle_generations();
+        let waveform_recovery_root = recovery_root.map(|path| {
+            let file = std::fs::File::open(&path).expect("test recovery root");
+            let identity =
+                wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(
+                    &file,
+                )
+                .expect("test recovery root identity");
+            crate::native_app::transaction_history::operation_journal::RecoveryRootCapability {
+                path,
+                file: Arc::new(file),
+                identity,
+            }
+        });
         #[cfg(not(test))]
         let operation_journal = super::OperationJournalOwner::start();
         #[cfg(test)]
         let operation_journal = super::OperationJournalOwner::disabled();
         Self {
+            waveform_recovery_root,
             worker_sender,
             worker_receiver,
             next_task_id: 1,
@@ -499,9 +525,19 @@ impl BackgroundTaskState {
     }
 
     pub(in crate::native_app) fn take_operation_journal_status(
-        &self,
+        &mut self,
     ) -> Option<super::journal::OperationJournalStatus> {
-        self.operation_journal.take_status()
+        let status = self.operation_journal.take_status()?;
+        if let super::journal::OperationJournalStatus::Available { recovery_root, .. } = &status {
+            self.waveform_recovery_root = Some(recovery_root.clone());
+        } else if matches!(
+            status,
+            super::journal::OperationJournalStatus::Initializing
+                | super::journal::OperationJournalStatus::Unavailable { .. }
+        ) {
+            self.waveform_recovery_root = None;
+        }
+        Some(status)
     }
 }
 

--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::native_app::transaction_history::operation_journal::{
     BoundedAdmissionError, JournalError, OperationDisposition, OperationIntent,
-    OperationJournalCoordinator, OperationPhase,
+    OperationJournalCoordinator, OperationPhase, PreparedOperationOutcome, RecoveryRootCapability,
 };
 use crate::native_app::transaction_history::{
     HistoryFileAction, HistoryFileIoDirection, RejectedBeforeIntent,
@@ -57,6 +57,7 @@ pub(in crate::native_app) enum OperationJournalStatus {
     Initializing,
     Available {
         summary: crate::native_app::transaction_history::operation_journal::RecoverySummary,
+        recovery_root: RecoveryRootCapability,
     },
     Unavailable {
         reason: OperationJournalUnavailable,
@@ -111,6 +112,13 @@ enum JournalCommand {
         actions: Vec<HistoryFileAction>,
         result: SyncSender<Result<Uuid, JournalOperationError>>,
     },
+    PrepareBoundedWaveformRestore {
+        intent: OperationIntent,
+        payload: Value,
+        direction: HistoryFileIoDirection,
+        actions: Vec<HistoryFileAction>,
+        result: SyncSender<Result<PreparedOperationOutcome, JournalOperationError>>,
+    },
     #[cfg(test)]
     Admit {
         intent: OperationIntent,
@@ -145,6 +153,10 @@ impl OperationJournalOwner {
 
     #[cfg(test)]
     pub(in crate::native_app) fn start_with_directory(directory: PathBuf) -> Self {
+        // macOS tempfile paths commonly live below `/var`, which is a symlink to
+        // `/private/var`. Resolve that test-only harness path before the owner
+        // applies strict no-follow traversal to its capability root.
+        let directory = std::fs::canonicalize(&directory).unwrap_or(directory);
         Self::start_with_optional_directory(Some(directory))
     }
 
@@ -297,6 +309,37 @@ impl OperationJournalOwner {
         Ok(result_rx)
     }
 
+    /// Queue owner-thread admission plus typed preparation for one waveform restore.
+    #[allow(dead_code)]
+    pub(in crate::native_app) fn prepare_bounded_waveform_restore(
+        &self,
+        intent: OperationIntent,
+        payload: Value,
+        direction: HistoryFileIoDirection,
+        actions: Vec<HistoryFileAction>,
+    ) -> Result<
+        Receiver<Result<PreparedOperationOutcome, JournalOperationError>>,
+        JournalOwnerQueueError,
+    > {
+        self.ensure_available()?;
+        let (result_tx, result_rx) = mpsc::sync_channel(1);
+        self.commands
+            .as_ref()
+            .ok_or(JournalOwnerQueueError::Closed)?
+            .try_send(JournalCommand::PrepareBoundedWaveformRestore {
+                intent,
+                payload,
+                direction,
+                actions,
+                result: result_tx,
+            })
+            .map_err(|error| match error {
+                TrySendError::Full(_) => JournalOwnerQueueError::Full,
+                TrySendError::Disconnected(_) => JournalOwnerQueueError::Closed,
+            })?;
+        Ok(result_rx)
+    }
+
     /// Queue a phase update without performing journal I/O on the caller thread.
     #[allow(dead_code)]
     pub(in crate::native_app) fn update(
@@ -397,11 +440,29 @@ fn run_owner(
         match opened {
             Ok(coordinator) => {
                 let summary = coordinator.recovery_summary();
+                // The explicit journal directory is also the recovery root for
+                // test/runtime overrides. Production callers pass `None`, so
+                // the capability helper resolves the profile app root here on
+                // the owner thread.
+                let recovery_path = directory.clone();
+                let recovery_root = match crate::native_app::transaction_history::operation_journal::open_recovery_root_capability(recovery_path) {
+                    Ok(capability) => capability,
+                    Err(error) => {
+                        let reason = OperationJournalUnavailable::from_error(error);
+                        *unavailable.lock().expect("journal unavailable state") = Some(reason.clone());
+                        lifecycle.store(OwnerLifecycle::Unavailable as u8, std::sync::atomic::Ordering::Release);
+                        let _ = status_tx.send(OperationJournalStatus::Unavailable { reason });
+                        break None;
+                    }
+                };
                 lifecycle.store(
                     OwnerLifecycle::Available as u8,
                     std::sync::atomic::Ordering::Release,
                 );
-                let _ = status_tx.send(OperationJournalStatus::Available { summary });
+                let _ = status_tx.send(OperationJournalStatus::Available {
+                    summary,
+                    recovery_root,
+                });
                 break Some(coordinator);
             }
             Err(JournalError::OwnedByAnotherProcess { path }) => {
@@ -461,6 +522,44 @@ fn run_owner(
                     .and_then(|coordinator| {
                         coordinator
                             .admit_bounded_waveform_restore(intent, payload, direction, &actions)
+                            .map_err(|error| match error {
+                                BoundedAdmissionError::Rejected(rejection) => {
+                                    JournalOperationError::RejectedBeforeIntent(rejection)
+                                }
+                                BoundedAdmissionError::Journal(error) => {
+                                    JournalOperationError::Journal(error)
+                                }
+                            })
+                    });
+                let _ = result.send(outcome);
+            }
+            Ok(JournalCommand::PrepareBoundedWaveformRestore {
+                intent,
+                payload,
+                direction,
+                actions,
+                result,
+            }) => {
+                if stop.load(std::sync::atomic::Ordering::Acquire) {
+                    let _ = result.send(Err(JournalOperationError::Closed));
+                    continue;
+                }
+                let outcome = coordinator
+                    .as_mut()
+                    .ok_or_else(|| {
+                        JournalOperationError::Unavailable(
+                            unavailable
+                                .lock()
+                                .expect("journal unavailable state")
+                                .clone()
+                                .unwrap_or(OperationJournalUnavailable::OpenFailed(String::from(
+                                    "operation journal coordinator is unavailable",
+                                ))),
+                        )
+                    })
+                    .and_then(|coordinator| {
+                        coordinator
+                            .prepare_bounded_waveform_restore(intent, payload, direction, &actions)
                             .map_err(|error| match error {
                                 BoundedAdmissionError::Rejected(rejection) => {
                                     JournalOperationError::RejectedBeforeIntent(rejection)
@@ -552,6 +651,15 @@ mod tests {
     };
     use crate::native_app::waveform_edits::waveform_restore_action_for_capacity_tests;
 
+    fn fixture_directory() -> tempfile::TempDir {
+        #[cfg(target_os = "macos")]
+        {
+            return tempfile::tempdir_in("/private/tmp").expect("fixture directory");
+        }
+        #[cfg(not(target_os = "macos"))]
+        tempfile::tempdir().expect("fixture directory")
+    }
+
     fn intent() -> OperationIntent {
         OperationIntent {
             actor: OperationActor::User,
@@ -563,7 +671,7 @@ mod tests {
     #[test]
     fn owner_admits_bounded_restore_only_after_owner_thread_gate() {
         let directory = tempfile::tempdir().expect("journal directory");
-        let files = tempfile::tempdir().expect("restore files");
+        let files = fixture_directory();
         let backup = files.path().join("before.wav");
         let target = files.path().join("target.wav");
         std::fs::write(&backup, vec![7_u8; 4097]).expect("backup");
@@ -700,7 +808,7 @@ mod tests {
             .recv_timeout(Duration::from_secs(2))
             .expect("available status");
         match status {
-            OperationJournalStatus::Available { summary } => {
+            OperationJournalStatus::Available { summary, .. } => {
                 assert_eq!(summary.record_count, 1);
                 assert_eq!(summary.unresolved_count, 1);
                 assert!(summary.attention_required);

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -228,7 +228,7 @@ impl NativeAppState {
         if let Some(status) = self.background.take_operation_journal_status() {
             match status {
                 crate::native_app::app::OperationJournalStatus::Initializing => {}
-                crate::native_app::app::OperationJournalStatus::Available { summary } => {
+                crate::native_app::app::OperationJournalStatus::Available { summary, .. } => {
                     if summary.attention_required {
                         self.ui.status.sample = format!(
                             "Operation journal needs attention: {} unresolved, {} malformed, {} unknown-version, {} oversized record(s)",

--- a/src/native_app/tests.rs
+++ b/src/native_app/tests.rs
@@ -246,8 +246,31 @@ fn toggle_sample_name_view_mode() -> super::test_support::state::GuiMessage {
 }
 
 fn native_app_state_with_temp_sample(name: &str) -> (NativeAppState, tempfile::TempDir, String) {
+    native_app_state_with_temp_sample_in(name, tempfile::tempdir().expect("source root"))
+}
+
+fn native_app_state_with_temp_sample_in(
+    name: &str,
+    source_root: tempfile::TempDir,
+) -> (NativeAppState, tempfile::TempDir, String) {
     let mut state = gui_state_for_span_tests();
-    let source_root = tempfile::tempdir().expect("source root");
+    let app_root = source_root
+        .path()
+        .parent()
+        .expect("source parent")
+        .join(format!(".wavecrate-test-{}", uuid::Uuid::new_v4()));
+    fs::create_dir(&app_root).expect("source app root");
+    let file = fs::File::open(&app_root).expect("source app root open");
+    let identity =
+        wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(&file)
+            .expect("source app root identity");
+    state.background.waveform_recovery_root = Some(
+        crate::native_app::transaction_history::operation_journal::RecoveryRootCapability {
+            path: app_root,
+            file: std::sync::Arc::new(file),
+            identity,
+        },
+    );
     let sample_path = source_root.path().join(name);
     fs::write(&sample_path, []).expect("sample file");
     state.library.folder_browser =

--- a/src/native_app/tests/waveform_destructive_edit_tests.rs
+++ b/src/native_app/tests/waveform_destructive_edit_tests.rs
@@ -1,6 +1,19 @@
 use super::*;
 use crate::native_app::test_support::state::GuiMessage;
 
+fn physical_destructive_fixture_root() -> tempfile::TempDir {
+    #[cfg(target_os = "macos")]
+    {
+        return tempfile::tempdir_in("/private/tmp").expect("physical destructive fixture root");
+    }
+    #[cfg(not(target_os = "macos"))]
+    tempfile::tempdir().expect("destructive fixture root")
+}
+
+fn native_app_state_with_temp_sample(name: &str) -> (NativeAppState, tempfile::TempDir, String) {
+    super::native_app_state_with_temp_sample_in(name, physical_destructive_fixture_root())
+}
+
 #[test]
 fn crop_shortcut_routes_to_waveform_crop_request() {
     let state = crate::native_app::test_support::state::NativeAppStateFixture::default().build();
@@ -211,11 +224,11 @@ fn destructive_edit_request_blocks_locked_folder() {
 
 #[test]
 fn protected_extract_and_trim_extracts_to_primary_without_mutating_origin() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("protected-extract-trim.wav");
-    let primary_root = tempfile::tempdir().expect("primary source root");
+    let primary_root = physical_destructive_fixture_root();
     let protected_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
     let primary_source =
@@ -453,11 +466,11 @@ fn blocked_protected_source_destructive_edit_flashes_source_file_and_waveform() 
 
 #[test]
 fn protected_extract_target_source_dialog_marks_primary_and_resumes_extraction() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("protected-extract-add-target.wav");
-    let target_root = tempfile::tempdir().expect("target source root");
+    let target_root = physical_destructive_fixture_root();
     let protected_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
     state.library.folder_browser =
@@ -526,11 +539,11 @@ fn protected_extract_target_source_dialog_marks_primary_and_resumes_extraction()
 
 #[test]
 fn protected_crop_selection_renders_crop_copy_to_primary_without_mutating_origin() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("protected-crop.wav");
-    let primary_root = tempfile::tempdir().expect("primary source root");
+    let primary_root = physical_destructive_fixture_root();
     let protected_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
     let primary_source =
@@ -600,11 +613,11 @@ fn protected_crop_selection_renders_crop_copy_to_primary_without_mutating_origin
 
 #[test]
 fn normal_harvest_mode_crop_selection_renders_crop_copy_to_primary_without_mutating_origin() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("normal-harvest-crop.wav");
-    let primary_root = tempfile::tempdir().expect("primary source root");
+    let primary_root = physical_destructive_fixture_root();
     let origin_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf());
     let primary_source =
@@ -678,11 +691,11 @@ fn normal_harvest_mode_crop_selection_renders_crop_copy_to_primary_without_mutat
 
 #[test]
 fn protected_reverse_selection_renders_reverse_copy_to_primary_without_mutating_origin() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("protected-reverse.wav");
-    let primary_root = tempfile::tempdir().expect("primary source root");
+    let primary_root = physical_destructive_fixture_root();
     let protected_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
     let primary_source =
@@ -762,11 +775,11 @@ fn protected_reverse_selection_renders_reverse_copy_to_primary_without_mutating_
 
 #[test]
 fn protected_mute_selection_renders_edit_copy_to_primary_without_mutating_origin() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("protected-mute.wav");
-    let primary_root = tempfile::tempdir().expect("primary source root");
+    let primary_root = physical_destructive_fixture_root();
     let protected_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
     let primary_source =
@@ -844,11 +857,11 @@ fn protected_mute_selection_renders_edit_copy_to_primary_without_mutating_origin
 
 #[test]
 fn protected_sample_slide_renders_slide_copy_to_primary_without_mutating_origin() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("protected-slide.wav");
-    let primary_root = tempfile::tempdir().expect("primary source root");
+    let primary_root = physical_destructive_fixture_root();
     let protected_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
     let primary_source =
@@ -920,11 +933,11 @@ fn protected_sample_slide_renders_slide_copy_to_primary_without_mutating_origin(
 
 #[test]
 fn normal_harvest_mode_reverse_selection_renders_reverse_copy_to_primary_without_mutating_origin() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("normal-harvest-reverse.wav");
-    let primary_root = tempfile::tempdir().expect("primary source root");
+    let primary_root = physical_destructive_fixture_root();
     let origin_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf());
     let primary_source =
@@ -1010,7 +1023,7 @@ fn normal_harvest_mode_reverse_selection_renders_reverse_copy_to_primary_without
 fn protected_trim_selection_is_denied_with_red_feedback_even_with_primary_source() {
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("protected-trim.wav");
-    let primary_root = tempfile::tempdir().expect("primary source root");
+    let primary_root = physical_destructive_fixture_root();
     let protected_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
     let primary_source =
@@ -1088,11 +1101,11 @@ fn protected_trim_selection_is_denied_with_red_feedback_even_with_primary_source
 
 #[test]
 fn protected_apply_edit_effects_renders_edit_copy_to_primary_without_mutating_origin() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("protected-edit.wav");
-    let primary_root = tempfile::tempdir().expect("primary source root");
+    let primary_root = physical_destructive_fixture_root();
     let protected_source =
         wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
     let primary_source =
@@ -1739,7 +1752,7 @@ fn mute_request_rewrites_edit_selection_without_moving_bounds() {
 
 #[test]
 fn crop_request_marks_harvest_origin_touched_without_derivative() {
-    let config_base = tempfile::tempdir().expect("config base");
+    let config_base = physical_destructive_fixture_root();
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (mut state, _source_root, selected_file) =
         native_app_state_with_temp_sample("crop-harvest.wav");

--- a/src/native_app/transaction_history.rs
+++ b/src/native_app/transaction_history.rs
@@ -9,6 +9,7 @@ pub(in crate::native_app) mod operation_journal;
 mod summary;
 
 pub(in crate::native_app) use capacity_gate::RejectedBeforeIntent;
+pub(in crate::native_app) use capacity_gate::open_no_follow_path;
 pub(in crate::native_app) use context::TransactionContext;
 #[cfg(test)]
 pub(in crate::native_app) use file_io::HistoryFileIoOutput;

--- a/src/native_app/transaction_history/capacity_gate.rs
+++ b/src/native_app/transaction_history/capacity_gate.rs
@@ -8,8 +8,10 @@
 #![allow(dead_code)]
 
 use std::collections::BTreeMap;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -251,7 +253,7 @@ fn open_regular_file(
     path: &Path,
     missing: fn(PathBuf) -> CapacityGateError,
 ) -> Result<File, CapacityGateError> {
-    let file = File::open(path).map_err(|error| {
+    let file = open_no_follow_path(path).map_err(|error| {
         if error.kind() == io::ErrorKind::NotFound {
             missing(path.to_path_buf())
         } else {
@@ -265,6 +267,47 @@ fn open_regular_file(
         return Err(CapacityGateError::NotRegularFile(path.to_path_buf()));
     }
     Ok(file)
+}
+
+pub(crate) fn open_no_follow_path(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        use std::ffi::CString;
+        use std::os::fd::{AsRawFd, FromRawFd};
+        let mut directory = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY)
+            .open(Path::new("/"))?;
+        let components = path.components().collect::<Vec<_>>();
+        for (index, component) in components.iter().enumerate() {
+            let std::path::Component::Normal(component) = component else {
+                if matches!(component, std::path::Component::RootDir) && index == 0 {
+                    continue;
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "non-normal path component",
+                ));
+            };
+            let name = CString::new(component.as_encoded_bytes())
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "NUL in path"))?;
+            let is_leaf = index + 1 == components.len();
+            let flags = libc::O_RDONLY
+                | libc::O_CLOEXEC
+                | libc::O_NOFOLLOW
+                | if is_leaf { 0 } else { libc::O_DIRECTORY };
+            let fd = unsafe { libc::openat(directory.as_raw_fd(), name.as_ptr(), flags) };
+            if fd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            directory = unsafe { File::from_raw_fd(fd) };
+        }
+        Ok(directory)
+    }
+    #[cfg(not(unix))]
+    {
+        File::open(path)
+    }
 }
 
 #[cfg(unix)]
@@ -296,6 +339,11 @@ fn descriptor_volume_facts(file: &File) -> Result<VolumeFacts, io::Error> {
         free_bytes: free,
         allocation_unit: unit,
     })
+}
+
+/// Derive live capacity facts from an already-open, capability-backed descriptor.
+pub(crate) fn descriptor_capacity_facts(file: &File) -> Result<VolumeFacts, CapacityGateError> {
+    descriptor_volume_facts(file).map_err(|error| CapacityGateError::Discovery(error.to_string()))
 }
 
 #[cfg(unix)]

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -127,6 +128,143 @@ impl OperationDisposition {
     }
 }
 
+/// The direction captured by a prepared waveform restore.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) enum PreparedRestoreDirection {
+    Undo,
+    Redo,
+}
+
+/// Stable identity of a filesystem object observed through an open descriptor.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct PreparedObjectIdentity {
+    pub(crate) stable_id: String,
+    pub(crate) change_marker: Option<String>,
+    pub(crate) len: u64,
+}
+
+/// A root capability retained as a bounded, typed locator and identity.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct PreparedRootCapability {
+    pub(crate) path: PathBuf,
+    pub(crate) identity: PreparedObjectIdentity,
+}
+
+/// A regular leaf locator relative to one of the prepared roots.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct PreparedLeafLocator {
+    pub(crate) relative_path: PathBuf,
+    pub(crate) identity: PreparedObjectIdentity,
+}
+
+/// Advisory destination-local staging name. Preparation never creates this path.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct PreparedStagingLocator {
+    pub(crate) relative_path: PathBuf,
+    pub(crate) absent: bool,
+}
+
+/// Identity expected by the future replacement executor.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) enum ReplaceExpectedIdentity {
+    Existing(PreparedObjectIdentity),
+}
+
+/// Compact, serializable evidence captured while preparing a restore.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct PreparedRestoreEvidence {
+    pub(crate) target: PreparedFileEvidence,
+    pub(crate) backup: PreparedFileEvidence,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) enum PreparedFileEvidence {
+    Missing,
+    ContentHash([u8; 32]),
+    Metadata {
+        len: u64,
+        modified_ns: Option<i64>,
+        is_dir: bool,
+    },
+    Unverifiable,
+}
+
+/// Typed descriptor proving that one non-extracted waveform restore passed preparation.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct PreparedWaveformRestore {
+    pub(crate) direction: PreparedRestoreDirection,
+    pub(crate) source_id: String,
+    pub(crate) source_root: PreparedRootCapability,
+    pub(crate) target_root: PreparedRootCapability,
+    pub(crate) target: PreparedLeafLocator,
+    pub(crate) backup_root: PreparedRootCapability,
+    pub(crate) backup: PreparedLeafLocator,
+    pub(crate) replacement: ReplaceExpectedIdentity,
+    pub(crate) staging: PreparedStagingLocator,
+    pub(crate) evidence: PreparedRestoreEvidence,
+}
+
+/// Profile recovery root opened and identity-checked by the journal owner thread.
+#[derive(Clone, Debug)]
+pub(crate) struct RecoveryRootCapability {
+    pub(crate) path: PathBuf,
+    pub(crate) file: Arc<File>,
+    pub(crate) identity: String,
+}
+
+impl PartialEq for RecoveryRootCapability {
+    fn eq(&self, other: &Self) -> bool {
+        self.path == other.path && self.identity == other.identity
+    }
+}
+
+impl Eq for RecoveryRootCapability {}
+
+pub(crate) fn open_recovery_root_capability(
+    path_override: Option<PathBuf>,
+) -> Result<RecoveryRootCapability, JournalError> {
+    let path = match path_override {
+        Some(path) => path,
+        None => wavecrate::app_dirs::app_root_dir()
+            .map_err(|error| JournalError::AppDirectory(error.to_string()))?,
+    };
+    let file =
+        super::capacity_gate::open_no_follow_path(&path).map_err(|source| JournalError::Write {
+            path: path.clone(),
+            source,
+        })?;
+    if !file
+        .metadata()
+        .map_err(|source| JournalError::Write {
+            path: path.clone(),
+            source,
+        })?
+        .is_dir()
+    {
+        return Err(JournalError::Write {
+            path,
+            source: io::Error::new(
+                io::ErrorKind::InvalidData,
+                "recovery root is not a directory",
+            ),
+        });
+    }
+    let identity =
+        wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(&file)
+            .ok_or_else(|| JournalError::Write {
+                path: path.clone(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "recovery root identity unavailable",
+                ),
+            })?;
+    Ok(RecoveryRootCapability {
+        path,
+        file: Arc::new(file),
+        identity,
+    })
+}
+
 /// One complete, bounded durable operation record.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub(crate) struct OperationRecord {
@@ -146,6 +284,9 @@ pub(crate) struct OperationRecord {
     /// bounded capacity admission while the operation remains unresolved.
     #[serde(default)]
     pub(crate) capacity_plan: Option<DurableCapacityPlan>,
+    /// Typed preparation evidence. Legacy schema-v1 records deserialize with no evidence.
+    #[serde(default)]
+    pub(crate) prepared: Option<PreparedWaveformRestore>,
     /// Creation timestamp in Unix milliseconds.
     pub(crate) created_unix_ms: i64,
     /// Last update timestamp in Unix milliseconds.
@@ -172,6 +313,7 @@ impl OperationRecord {
             disposition: OperationDisposition::None,
             payload,
             capacity_plan,
+            prepared: None,
             created_unix_ms: now,
             updated_unix_ms: now,
         }
@@ -181,6 +323,15 @@ impl OperationRecord {
         let mut updated = self.clone();
         updated.phase = phase;
         updated.disposition = disposition;
+        updated.updated_unix_ms = unix_millis();
+        updated
+    }
+
+    fn with_prepared(&self, prepared: PreparedWaveformRestore) -> Self {
+        let mut updated = self.clone();
+        updated.phase = OperationPhase::Prepared;
+        updated.disposition = OperationDisposition::None;
+        updated.prepared = Some(prepared);
         updated.updated_unix_ms = unix_millis();
         updated
     }
@@ -221,6 +372,16 @@ pub(crate) enum JournalError {
     /// A requested update did not refer to an admitted operation.
     #[error("operation journal record not found: {0}")]
     NotFound(Uuid),
+    /// A phase transition did not follow the bounded journal state machine.
+    #[error("illegal operation journal transition for {operation_id}: {from:?} -> {to:?}")]
+    IllegalTransition {
+        operation_id: Uuid,
+        from: OperationPhase,
+        to: OperationPhase,
+    },
+    /// Preparation was requested without a typed descriptor.
+    #[error("prepared operation {0} is missing typed evidence")]
+    MissingPreparedEvidence(Uuid),
 }
 
 /// Result boundary for the bounded pre-intent capacity gate.
@@ -233,6 +394,14 @@ pub(crate) enum BoundedAdmissionError {
     Rejected(#[from] RejectedBeforeIntent),
     #[error(transparent)]
     Journal(#[from] JournalError),
+}
+
+/// Outcome after an admitted restore was freshly prepared on the journal owner thread.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PreparedOperationOutcome {
+    Prepared(Uuid),
+    RetryPending { operation_id: Uuid, reason: String },
+    JournalWriteFailed { operation_id: Uuid, reason: String },
 }
 
 #[derive(Debug)]
@@ -369,6 +538,40 @@ impl OperationJournalStore {
         Ok(())
     }
 
+    fn guarded_prepare(
+        &mut self,
+        operation_id: Uuid,
+        prepared: PreparedWaveformRestore,
+    ) -> Result<(), JournalError> {
+        let current = self
+            .records
+            .get(&operation_id)
+            .ok_or(JournalError::NotFound(operation_id))?;
+        match current.phase {
+            OperationPhase::IntentDurable => {
+                let updated = current.with_prepared(prepared);
+                let path = self.record_path(operation_id);
+                atomic_durable_write(&path, &updated)?;
+                self.records.insert(operation_id, updated);
+                self.rebuild_capacity_claims();
+                Ok(())
+            }
+            OperationPhase::Prepared => {
+                if current.prepared.is_none() {
+                    return Err(JournalError::MissingPreparedEvidence(operation_id));
+                }
+                // The descriptor was freshly validated by the caller. Replacing it is
+                // unnecessary and would make a retry non-idempotent at the byte level.
+                Ok(())
+            }
+            phase => Err(JournalError::IllegalTransition {
+                operation_id,
+                from: phase,
+                to: OperationPhase::Prepared,
+            }),
+        }
+    }
+
     fn rebuild_capacity_claims(&mut self) {
         self.capacity_claims.clear();
         self.capacity_blocked = self.recovery.malformed_count > 0
@@ -495,6 +698,13 @@ impl OperationJournalStore {
                             .push(RetainedRecord::Malformed { path, bytes });
                         continue;
                     }
+                    if record.phase == OperationPhase::Prepared && record.prepared.is_none() {
+                        self.recovery.malformed_count += 1;
+                        self.recovery.attention_required = true;
+                        self.retained
+                            .push(RetainedRecord::Malformed { path, bytes });
+                        continue;
+                    }
                     if record.phase != OperationPhase::Terminal || !record.disposition.is_terminal()
                     {
                         self.recovery.unresolved_count += 1;
@@ -548,6 +758,247 @@ fn validate_capacity_plan(plan: &DurableCapacityPlan) -> Result<(), RejectedBefo
 /// Coordinator boundary for future durable history operations.
 pub(crate) struct OperationJournalCoordinator {
     store: OperationJournalStore,
+}
+
+fn clean_relative_path(path: &Path) -> Result<(), String> {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return Err(String::from("path must be a non-empty relative locator"));
+    }
+    for component in path.components() {
+        if !matches!(component, std::path::Component::Normal(_)) {
+            return Err(String::from("path contains non-normal components"));
+        }
+    }
+    Ok(())
+}
+
+fn descriptor_identity(file: &File) -> Result<PreparedObjectIdentity, String> {
+    let metadata = file.metadata().map_err(|error| error.to_string())?;
+    let stable_id =
+        wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(file)
+            .ok_or_else(|| String::from("stable filesystem identity unavailable"))?;
+    let change_marker =
+        wavecrate_library::filesystem_identity::filesystem_change_marker(Path::new(""), &metadata);
+    Ok(PreparedObjectIdentity {
+        stable_id,
+        change_marker,
+        len: metadata.len(),
+    })
+}
+
+fn open_root(path: &Path) -> Result<(File, PreparedRootCapability), String> {
+    let file =
+        super::capacity_gate::open_no_follow_path(path).map_err(|error| error.to_string())?;
+    if !file.metadata().map_err(|error| error.to_string())?.is_dir() {
+        return Err(format!("root is not a directory: {}", path.display()));
+    }
+    let identity = descriptor_identity(&file)?;
+    Ok((
+        file,
+        PreparedRootCapability {
+            path: path.to_path_buf(),
+            identity,
+        },
+    ))
+}
+
+fn open_leaf_relative(
+    root: &File,
+    relative: &Path,
+    display: &Path,
+) -> Result<(File, PreparedObjectIdentity), String> {
+    clean_relative_path(relative)?;
+    #[cfg(unix)]
+    let file = {
+        use std::ffi::CString;
+        use std::os::fd::{AsRawFd, FromRawFd};
+        let components = relative.components().collect::<Vec<_>>();
+        let mut directory = root.try_clone().map_err(|error| error.to_string())?;
+        for (index, component) in components.iter().enumerate() {
+            let std::path::Component::Normal(component) = component else {
+                return Err(String::from("locator contains non-normal component"));
+            };
+            let name = CString::new(component.as_encoded_bytes())
+                .map_err(|_| String::from("locator contains NUL"))?;
+            let is_leaf = index + 1 == components.len();
+            let flags = libc::O_RDONLY
+                | libc::O_CLOEXEC
+                | libc::O_NOFOLLOW
+                | if is_leaf { 0 } else { libc::O_DIRECTORY };
+            let fd = unsafe { libc::openat(directory.as_raw_fd(), name.as_ptr(), flags) };
+            if fd < 0 {
+                return Err(std::io::Error::last_os_error().to_string());
+            }
+            let next = unsafe { File::from_raw_fd(fd) };
+            if is_leaf {
+                directory = next;
+            } else {
+                directory = next;
+            }
+        }
+        directory
+    };
+    #[cfg(not(unix))]
+    let file = File::open(display).map_err(|error| error.to_string())?;
+    let metadata = file.metadata().map_err(|error| error.to_string())?;
+    if !metadata.is_file() {
+        return Err(format!("leaf is not a regular file: {}", display.display()));
+    }
+    let identity = descriptor_identity(&file)?;
+    Ok((file, identity))
+}
+
+fn infer_root(path: &Path, relative: &Path) -> Result<PathBuf, String> {
+    clean_relative_path(relative)?;
+    let mut root = path.to_path_buf();
+    for _ in relative.components() {
+        root = root
+            .parent()
+            .ok_or_else(|| String::from("relative locator exceeds target path"))?
+            .to_path_buf();
+    }
+    if !root.is_absolute() || root.join(relative) != path {
+        return Err(String::from(
+            "target path is not source-relative to its root",
+        ));
+    }
+    Ok(root)
+}
+
+fn prepared_file_evidence(file: &File) -> PreparedFileEvidence {
+    let Ok(metadata) = file.metadata() else {
+        return PreparedFileEvidence::Unverifiable;
+    };
+    if metadata.is_file()
+        && metadata.len() <= wavecrate::sample_sources::MAX_SOURCE_FILE_EVIDENCE_HASH_BYTES
+    {
+        let mut clone = match file.try_clone() {
+            Ok(clone) => clone,
+            Err(_) => return PreparedFileEvidence::Unverifiable,
+        };
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        if clone.read_to_end(&mut bytes).is_ok() {
+            return PreparedFileEvidence::ContentHash(*blake3::hash(&bytes).as_bytes());
+        }
+    }
+    PreparedFileEvidence::Metadata {
+        len: metadata.len(),
+        modified_ns: metadata
+            .modified()
+            .ok()
+            .map(wavecrate_library::timestamps::system_time_to_unix_nanos),
+        is_dir: metadata.is_dir(),
+    }
+}
+
+fn prepare_descriptor(
+    operation_id: Uuid,
+    direction: super::file_io::HistoryFileIoDirection,
+    actions: &[super::file_io::HistoryFileAction],
+    capacity_plan: &DurableCapacityPlan,
+    existing_claims: &BTreeMap<VolumeIdentity, u64>,
+) -> Result<PreparedWaveformRestore, String> {
+    let admission = super::capacity_gate::map_waveform_restore_shape(direction, actions)
+        .map_err(|error| error.to_string())?;
+    let super::file_io::HistoryFileAction::WaveformRestore { applied, .. } = &actions[0] else {
+        return Err(String::from("invalid waveform restore shape"));
+    };
+    let Some(volume) = capacity_plan.volumes.as_slice().first() else {
+        return Err(String::from("capacity claim is empty"));
+    };
+    if capacity_plan.volumes.len() != 1 {
+        return Err(String::from("capacity claim has unexpected volumes"));
+    }
+    let target_root_path = infer_root(&applied.absolute_path, &applied.relative_path)?;
+    let backup_name = admission
+        .backup_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|_| admission.backup_path.parent().is_some())
+        .ok_or_else(|| String::from("backup locator is not a clean leaf"))?
+        .to_owned();
+    let backup_root_path = admission
+        .backup_path
+        .parent()
+        .ok_or_else(|| String::from("backup has no root"))?
+        .to_path_buf();
+    let (_source_root_file, source_root) =
+        open_root(&target_root_path).map_err(|error| format!("source root: {error}"))?;
+    let (target_root_file, target_root) =
+        open_root(&target_root_path).map_err(|error| format!("target root: {error}"))?;
+    let (backup_root_file, backup_root) =
+        open_root(&backup_root_path).map_err(|error| format!("backup root: {error}"))?;
+    let (target_file, target_identity) = open_leaf_relative(
+        &target_root_file,
+        &applied.relative_path,
+        &applied.absolute_path,
+    )?;
+    let backup_relative = PathBuf::from(&backup_name);
+    let (backup_file, backup_identity) =
+        open_leaf_relative(&backup_root_file, &backup_relative, &admission.backup_path)?;
+    // This is the single post-intent capacity revalidation. It observes live facts from the
+    // already-open, capability-relative descriptors and removes this operation's own claim.
+    let requirement = super::capacity_gate::CapacityRequirement {
+        facts: super::capacity_gate::descriptor_capacity_facts(&target_file)
+            .map_err(|error| error.to_string())?,
+        logical_bytes: backup_file
+            .metadata()
+            .map_err(|error| error.to_string())?
+            .len(),
+    };
+    if requirement.facts.identity != volume.identity
+        || requirement.facts.allocation_unit != volume.allocation_unit
+        || requirement.logical_bytes != volume.logical_bytes
+        || super::capacity_gate::round_up_allocation(
+            requirement.logical_bytes,
+            requirement.facts.allocation_unit,
+        )
+        .map_err(|error| error.to_string())?
+            != volume.allocated_bytes
+    {
+        return Err(String::from("capacity claim no longer matches live facts"));
+    }
+    let mut claims_without_own = existing_claims.clone();
+    match claims_without_own.get_mut(&volume.identity) {
+        Some(claim) if *claim >= volume.allocated_bytes => {
+            *claim -= volume.allocated_bytes;
+            if *claim == 0 {
+                claims_without_own.remove(&volume.identity);
+            }
+        }
+        _ => return Err(String::from("capacity claim ownership changed")),
+    }
+    super::capacity_gate::aggregate_capacity_plan(&[requirement], &claims_without_own)
+        .map_err(|error| error.to_string())?;
+    let staging = PathBuf::from(format!(".wavecrate-restore-{operation_id}.stage"));
+    let direction = match direction {
+        super::file_io::HistoryFileIoDirection::Undo => PreparedRestoreDirection::Undo,
+        super::file_io::HistoryFileIoDirection::Redo => PreparedRestoreDirection::Redo,
+    };
+    Ok(PreparedWaveformRestore {
+        direction,
+        source_id: applied.source_id.clone(),
+        source_root,
+        target_root,
+        target: PreparedLeafLocator {
+            relative_path: applied.relative_path.clone(),
+            identity: target_identity.clone(),
+        },
+        backup_root,
+        backup: PreparedLeafLocator {
+            relative_path: PathBuf::from(backup_name),
+            identity: backup_identity,
+        },
+        replacement: ReplaceExpectedIdentity::Existing(target_identity),
+        staging: PreparedStagingLocator {
+            relative_path: staging,
+            absent: true,
+        },
+        evidence: PreparedRestoreEvidence {
+            target: prepared_file_evidence(&target_file),
+            backup: prepared_file_evidence(&backup_file),
+        },
+    })
 }
 
 impl OperationJournalCoordinator {
@@ -607,6 +1058,58 @@ impl OperationJournalCoordinator {
         Ok(operation_id)
     }
 
+    /// Admit and then prepare one non-extracted waveform restore on the journal owner thread.
+    /// Post-intent validation failures retain the operation and its capacity claim.
+    pub(crate) fn prepare_bounded_waveform_restore(
+        &mut self,
+        intent: OperationIntent,
+        payload: Value,
+        direction: super::file_io::HistoryFileIoDirection,
+        actions: &[super::file_io::HistoryFileAction],
+    ) -> Result<PreparedOperationOutcome, BoundedAdmissionError> {
+        let operation_id =
+            self.admit_bounded_waveform_restore(intent, payload, direction, actions)?;
+        let capacity_plan = self
+            .store
+            .record(operation_id)
+            .and_then(|record| record.capacity_plan.clone())
+            .ok_or_else(|| {
+                BoundedAdmissionError::Journal(JournalError::MissingPreparedEvidence(operation_id))
+            })?;
+        let prepared = match prepare_descriptor(
+            operation_id,
+            direction,
+            actions,
+            &capacity_plan,
+            self.store.capacity_claims(),
+        ) {
+            Ok(prepared) => prepared,
+            Err(reason) => {
+                return match self.store.update(
+                    operation_id,
+                    OperationPhase::IntentDurable,
+                    OperationDisposition::RetryPending,
+                ) {
+                    Ok(()) => Ok(PreparedOperationOutcome::RetryPending {
+                        operation_id,
+                        reason,
+                    }),
+                    Err(error) => Ok(PreparedOperationOutcome::JournalWriteFailed {
+                        operation_id,
+                        reason: error.to_string(),
+                    }),
+                };
+            }
+        };
+        match self.store.guarded_prepare(operation_id, prepared) {
+            Ok(()) => Ok(PreparedOperationOutcome::Prepared(operation_id)),
+            Err(error) => Ok(PreparedOperationOutcome::JournalWriteFailed {
+                operation_id,
+                reason: error.to_string(),
+            }),
+        }
+    }
+
     /// Advance phase/disposition through one atomic durable record replacement.
     pub(crate) fn update(
         &mut self,
@@ -614,7 +1117,27 @@ impl OperationJournalCoordinator {
         phase: OperationPhase,
         disposition: OperationDisposition,
     ) -> Result<(), JournalError> {
+        if phase == OperationPhase::Prepared {
+            return Err(JournalError::IllegalTransition {
+                operation_id,
+                from: self
+                    .store
+                    .record(operation_id)
+                    .ok_or(JournalError::NotFound(operation_id))?
+                    .phase,
+                to: OperationPhase::Prepared,
+            });
+        }
         self.store.update(operation_id, phase, disposition)
+    }
+
+    /// Guarded, idempotent IntentDurable -> Prepared transition for validated evidence.
+    pub(crate) fn guarded_prepare(
+        &mut self,
+        operation_id: Uuid,
+        prepared: PreparedWaveformRestore,
+    ) -> Result<(), JournalError> {
+        self.store.guarded_prepare(operation_id, prepared)
     }
 
     /// Return a typed operation record, if present.
@@ -742,7 +1265,7 @@ impl OwnershipLock {
 
         #[cfg(all(not(unix), not(windows)))]
         Err(JournalError::Write {
-            path,
+            path: path.to_path_buf(),
             source: io::Error::new(
                 io::ErrorKind::Unsupported,
                 "no verified profile ownership primitive on this platform",
@@ -881,6 +1404,15 @@ mod tests {
 
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
+    fn fixture_directory() -> tempfile::TempDir {
+        #[cfg(target_os = "macos")]
+        {
+            return tempfile::tempdir_in("/private/tmp").expect("fixture directory");
+        }
+        #[cfg(not(target_os = "macos"))]
+        tempfile::tempdir().expect("fixture directory")
+    }
+
     fn intent() -> OperationIntent {
         OperationIntent {
             actor: OperationActor::User,
@@ -914,14 +1446,14 @@ mod tests {
             journal
                 .update(
                     id,
-                    OperationPhase::Prepared,
+                    OperationPhase::IntentDurable,
                     OperationDisposition::RetryPending,
                 )
                 .unwrap();
         }
         let journal = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
         let record = journal.record(id).unwrap();
-        assert_eq!(record.phase, OperationPhase::Prepared);
+        assert_eq!(record.phase, OperationPhase::IntentDurable);
         assert_eq!(record.disposition, OperationDisposition::RetryPending);
         assert!(journal.store.capacity_blocked());
     }
@@ -1006,7 +1538,7 @@ mod tests {
     fn coordinator_returns_typed_insufficient_capacity_without_a_record() {
         let _lock = TEST_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
-        let files = tempfile::tempdir().unwrap();
+        let files = fixture_directory();
         let backup = files.path().join("before.wav");
         let target = files.path().join("target.wav");
         fs::write(&backup, vec![7_u8; 4097]).unwrap();
@@ -1054,6 +1586,68 @@ mod tests {
     }
 
     #[test]
+    fn waveform_restore_prepares_typed_descriptor_without_filesystem_mutation() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let files = fixture_directory();
+        let backup = files.path().join("before.wav");
+        let target = files.path().join("target.wav");
+        fs::write(&backup, vec![7_u8; 4097]).unwrap();
+        fs::write(&target, vec![0_u8; 4097]).unwrap();
+        let before_backup = fs::read(&backup).unwrap();
+        let before_target = fs::read(&target).unwrap();
+        let before_names = fs::read_dir(files.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        let action = crate::native_app::waveform_edits::waveform_restore_action_for_capacity_tests(
+            backup.clone(),
+            target.clone(),
+            false,
+        );
+        let mut coordinator = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+        let outcome = coordinator
+            .prepare_bounded_waveform_restore(
+                intent(),
+                Value::Null,
+                super::super::file_io::HistoryFileIoDirection::Undo,
+                std::slice::from_ref(&action),
+            )
+            .unwrap();
+        let id = match outcome {
+            PreparedOperationOutcome::Prepared(id) => id,
+            other => panic!("expected prepared, got {other:?}"),
+        };
+        let record = coordinator.record(id).unwrap();
+        assert_eq!(record.phase, OperationPhase::Prepared);
+        assert_eq!(record.disposition, OperationDisposition::None);
+        assert!(record.prepared.is_some());
+        assert_eq!(fs::read(&backup).unwrap(), before_backup);
+        assert_eq!(fs::read(&target).unwrap(), before_target);
+        assert_eq!(
+            fs::read_dir(files.path())
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name())
+                .collect::<Vec<_>>(),
+            before_names
+        );
+        drop(coordinator);
+        let reopened = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+        let reopened_record = reopened.record(id).unwrap();
+        assert_eq!(reopened_record.phase, OperationPhase::Prepared);
+        assert_eq!(reopened_record.disposition, OperationDisposition::None);
+        let prepared = reopened_record.prepared.as_ref().unwrap();
+        assert_eq!(prepared.source_id, "test");
+        assert_eq!(prepared.target.relative_path, PathBuf::from("target.wav"));
+        assert_eq!(prepared.backup.relative_path, PathBuf::from("before.wav"));
+        assert_eq!(
+            prepared.staging.relative_path.as_os_str().to_string_lossy(),
+            format!(".wavecrate-restore-{id}.stage")
+        );
+        assert_eq!(reopened.store.capacity_claims().len(), 1);
+    }
+
+    #[test]
     fn malformed_and_unknown_records_are_retained_and_reported() {
         let _lock = TEST_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
@@ -1072,6 +1666,22 @@ mod tests {
             fs::read(dir.path().join("malformed.json")).unwrap(),
             b"not json"
         );
+    }
+
+    #[test]
+    fn prepared_record_without_evidence_is_retained_verbatim() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut record = OperationRecord::new(intent(), Value::Null);
+        record.phase = OperationPhase::Prepared;
+        let path = dir.path().join(format!("{}.json", record.operation_id));
+        let bytes = serde_json::to_vec(&record).unwrap();
+        fs::write(&path, &bytes).unwrap();
+        let journal = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+        assert_eq!(journal.recovery_summary().malformed_count, 1);
+        assert!(journal.recovery_summary().attention_required);
+        assert!(journal.record(record.operation_id).is_none());
+        assert_eq!(fs::read(path).unwrap(), bytes);
     }
 
     #[test]

--- a/src/native_app/waveform_edits/queue.rs
+++ b/src/native_app/waveform_edits/queue.rs
@@ -40,6 +40,11 @@ impl NativeAppState {
         options: WaveformDestructiveEditQueueOptions,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Result<(), String> {
+        let recovery_root = self
+            .background
+            .waveform_recovery_root
+            .clone()
+            .ok_or_else(|| String::from("waveform recovery root is not ready"))?;
         if let Some(error) = self
             .library
             .folder_browser
@@ -74,8 +79,11 @@ impl NativeAppState {
         self.audio.clear_sample_playback_session();
 
         let preserved_marks = self.preserved_marks_after_destructive_edit(&request);
-        let mut worker_request =
-            WaveformDestructiveEditWorkerRequest::new(request.clone(), extraction_request);
+        let mut worker_request = WaveformDestructiveEditWorkerRequest::new(
+            request.clone(),
+            extraction_request,
+            recovery_root,
+        );
         if let Some(copy_source_path) = options.copy_source_path.clone() {
             worker_request = worker_request.with_copy_source(copy_source_path);
         }

--- a/src/native_app/waveform_edits/worker.rs
+++ b/src/native_app/waveform_edits/worker.rs
@@ -1,7 +1,8 @@
 use std::{
-    fs,
+    fs, io,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
+    sync::Arc,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use wavecrate::sample_sources::{SourceDatabase, SourceFileEvidence, capture_source_file_evidence};
@@ -18,24 +19,282 @@ use self::atomic_write::{AtomicWriteFailure, write_wav_atomically};
 
 mod atomic_write;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
+struct RecoveryDirectory {
+    path: PathBuf,
+    parent: fs::File,
+    name: String,
+    identity: String,
+    armed: AtomicBool,
+}
+
+impl Drop for RecoveryDirectory {
+    fn drop(&mut self) {
+        if !self.armed.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        #[cfg(not(unix))]
+        return;
+        #[cfg(unix)]
+        {
+            let Ok(directory) = open_child_directory(&self.parent, &self.name) else {
+                return;
+            };
+            let Some(identity) =
+                wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(
+                    &directory,
+                )
+            else {
+                return;
+            };
+            if identity == self.identity {
+                let _ = unlink_child(&directory, "before.wav");
+                let _ = unlink_child(&directory, "after.wav");
+                let _ = unlink_child(&directory, "extracted.wav");
+                let _ = unlink_directory(&self.parent, &self.name);
+            }
+        }
+    }
+}
+
+fn create_recovery_directory(
+    capability: &crate::native_app::transaction_history::operation_journal::RecoveryRootCapability,
+) -> Result<(Arc<RecoveryDirectory>, fs::File), String> {
+    let identity =
+        wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(
+            &capability.file,
+        )
+        .ok_or_else(|| String::from("recovery root identity unavailable"))?;
+    if identity != capability.identity {
+        return Err(String::from("recovery root identity changed"));
+    }
+    let root = capability
+        .file
+        .try_clone()
+        .map_err(|error| error.to_string())?;
+    if !root.metadata().map_err(|error| error.to_string())?.is_dir() {
+        return Err(String::from("recovery root is not a directory"));
+    }
+    let recovery = create_directory_at(&root, "session_recovery")?;
+    let edits = create_directory_at(&recovery, "waveform_edits")?;
+    let mut attempts = 0_u8;
+    let (name, edit) = loop {
+        if attempts >= 8 {
+            return Err(String::from(
+                "recovery directory collision budget exhausted",
+            ));
+        }
+        attempts += 1;
+        let name = format!("edit-{}", uuid::Uuid::new_v4());
+        match create_unique_directory_at(&edits, &name) {
+            Ok(edit) => break (name, edit),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.to_string()),
+        }
+    };
+    let path = capability
+        .path
+        .join("session_recovery")
+        .join("waveform_edits")
+        .join(&name);
+    Ok((
+        Arc::new(RecoveryDirectory {
+            path,
+            parent: edits.try_clone().map_err(|error| error.to_string())?,
+            name,
+            identity:
+                wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(
+                    &edit,
+                )
+                .ok_or_else(|| String::from("recovery directory identity unavailable"))?,
+            armed: AtomicBool::new(true),
+        }),
+        edit,
+    ))
+}
+
+#[cfg(unix)]
+fn open_child_directory(parent: &fs::File, name: &str) -> Result<fs::File, String> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    let name = CString::new(name).map_err(|_| String::from("invalid recovery name"))?;
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd < 0 {
+        return Err(io::Error::last_os_error().to_string());
+    }
+    Ok(unsafe { fs::File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn unlink_child(directory: &fs::File, name: &str) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+    let name =
+        CString::new(name).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "NUL"))?;
+    let result = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn unlink_directory(parent: &fs::File, name: &str) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+    let name =
+        CString::new(name).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "NUL"))?;
+    let result = unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn create_directory_at(parent: &fs::File, name: &str) -> Result<fs::File, String> {
+    #[cfg(unix)]
+    {
+        use std::ffi::CString;
+        use std::os::fd::{AsRawFd, FromRawFd};
+        let name = CString::new(name).map_err(|_| String::from("invalid recovery name"))?;
+        let result = unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) };
+        if result != 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::AlreadyExists {
+                return Err(error.to_string());
+            }
+        }
+        let fd = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error().to_string());
+        }
+        return Ok(unsafe { fs::File::from_raw_fd(fd) });
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (parent, name);
+        Err(String::from(
+            "strict recovery directories unsupported on this platform",
+        ))
+    }
+}
+
+fn create_unique_directory_at(parent: &fs::File, name: &str) -> Result<fs::File, io::Error> {
+    #[cfg(unix)]
+    {
+        use std::ffi::CString;
+        use std::os::fd::{AsRawFd, FromRawFd};
+        let name = CString::new(name)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid recovery name"))?;
+        let result = unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) };
+        if result != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let fd = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        return Ok(unsafe { fs::File::from_raw_fd(fd) });
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (parent, name);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "strict recovery directories unsupported on this platform",
+        ))
+    }
+}
+
+#[derive(Clone, Debug)]
 pub(in crate::native_app) struct OverwriteBackup {
     pub(in crate::native_app) before: PathBuf,
     pub(in crate::native_app) after: PathBuf,
-    dir: Option<PathBuf>,
+    dir: Option<Arc<RecoveryDirectory>>,
+}
+
+impl PartialEq for OverwriteBackup {
+    fn eq(&self, other: &Self) -> bool {
+        self.before == other.before
+            && self.after == other.after
+            && self.dir.as_ref().map(|dir| &dir.path) == other.dir.as_ref().map(|dir| &dir.path)
+    }
 }
 
 impl OverwriteBackup {
-    fn capture_before(target: &Path) -> Result<Self, String> {
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|err| format!("Clock error: {err}"))?
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("wavecrate-native-edit-{stamp}"));
-        fs::create_dir_all(&dir).map_err(|err| format!("Failed to create undo folder: {err}"))?;
-        let before = dir.join("before.wav");
-        let after = dir.join("after.wav");
-        fs::copy(target, &before).map_err(|err| format!("Failed to snapshot audio file: {err}"))?;
+    fn capture_before(
+        target: &Path,
+        capability: &crate::native_app::transaction_history::operation_journal::RecoveryRootCapability,
+    ) -> Result<Self, String> {
+        let (dir, edit_directory) = create_recovery_directory(capability)?;
+        let before = dir.path.join("before.wav");
+        let after = dir.path.join("after.wav");
+        let mut source = match crate::native_app::transaction_history::open_no_follow_path(target) {
+            Ok(source) => source,
+            Err(error) => {
+                return Err(error.to_string());
+            }
+        };
+        let source_permissions = source
+            .metadata()
+            .map_err(|error| error.to_string())?
+            .permissions();
+        #[cfg(unix)]
+        let mut before_file = {
+            use std::ffi::CString;
+            use std::os::fd::{AsRawFd, FromRawFd};
+            let name = CString::new("before.wav").expect("static recovery name");
+            let fd = unsafe {
+                libc::openat(
+                    edit_directory.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_WRONLY
+                        | libc::O_CREAT
+                        | libc::O_EXCL
+                        | libc::O_CLOEXEC
+                        | libc::O_NOFOLLOW,
+                    0o600,
+                )
+            };
+            if fd < 0 {
+                return Err(io::Error::last_os_error().to_string());
+            }
+            unsafe { fs::File::from_raw_fd(fd) }
+        };
+        #[cfg(not(unix))]
+        let mut before_file = {
+            let _ = edit_directory;
+            return Err(String::from(
+                "strict recovery files unsupported on this platform",
+            ));
+        };
+        if let Err(error) = io::copy(&mut source, &mut before_file) {
+            return Err(format!("Failed to snapshot audio file: {error}"));
+        }
+        before_file
+            .set_permissions(source_permissions)
+            .map_err(|error| format!("Failed to preserve snapshot permissions: {error}"))?;
+        before_file
+            .sync_all()
+            .map_err(|error| format!("Failed to sync snapshot: {error}"))?;
         Ok(Self {
             before,
             after,
@@ -48,6 +307,7 @@ impl OverwriteBackup {
             .dir
             .as_ref()
             .expect("active waveform backup directory")
+            .path
             .join("extracted.wav");
         fs::copy(target, &extracted)
             .map_err(|err| format!("Failed to snapshot extracted audio file: {err}"))?;
@@ -55,16 +315,14 @@ impl OverwriteBackup {
     }
 
     fn retain_recovery_copy(&mut self) {
-        self.dir = None;
+        if let Some(dir) = self.dir.as_ref() {
+            dir.armed.store(false, Ordering::Release);
+        }
     }
 }
 
 impl Drop for OverwriteBackup {
-    fn drop(&mut self) {
-        if let Some(dir) = self.dir.as_ref() {
-            let _ = fs::remove_dir_all(dir);
-        }
-    }
+    fn drop(&mut self) {}
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -102,17 +360,21 @@ pub(super) struct WaveformDestructiveEditWorkerRequest {
     edit: PendingWaveformDestructiveEdit,
     extraction: Option<WaveformExtractionRequest>,
     copy_source: Option<PathBuf>,
+    recovery_root:
+        crate::native_app::transaction_history::operation_journal::RecoveryRootCapability,
 }
 
 impl WaveformDestructiveEditWorkerRequest {
     pub(super) fn new(
         edit: PendingWaveformDestructiveEdit,
         extraction: Option<WaveformExtractionRequest>,
+        recovery_root: crate::native_app::transaction_history::operation_journal::RecoveryRootCapability,
     ) -> Self {
         Self {
             edit,
             extraction,
             copy_source: None,
+            recovery_root,
         }
     }
 
@@ -162,8 +424,11 @@ pub(super) fn execute_destructive_edit(
         }
         None => None,
     };
-    let result = match execute_destructive_edit_write(&worker_request.edit, extracted_path.clone())
-    {
+    let result = match execute_destructive_edit_write(
+        &worker_request.edit,
+        extracted_path.clone(),
+        &worker_request.recovery_root,
+    ) {
         Ok(applied) => Ok(applied),
         Err(error) => {
             if let Some(path) = extracted_path {
@@ -187,9 +452,28 @@ pub(super) fn execute_destructive_edit(
 pub(in crate::native_app) fn execute_destructive_edit_for_tests(
     edit: PendingWaveformDestructiveEdit,
 ) -> AppliedWaveformEdit {
-    execute_destructive_edit(WaveformDestructiveEditWorkerRequest::new(edit, None))
-        .result
-        .expect("destructive edit should succeed")
+    let app_root = edit
+        .source
+        .root
+        .parent()
+        .expect("test source parent")
+        .join(format!(".wavecrate-test-{}", uuid::Uuid::new_v4()));
+    let _ = fs::create_dir(&app_root);
+    let file = fs::File::open(&app_root).expect("test waveform app root");
+    let identity =
+        wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(&file)
+            .expect("test waveform app root identity");
+    execute_destructive_edit(WaveformDestructiveEditWorkerRequest::new(
+        edit,
+        None,
+        crate::native_app::transaction_history::operation_journal::RecoveryRootCapability {
+            path: app_root,
+            file: Arc::new(file),
+            identity,
+        },
+    ))
+    .result
+    .expect("destructive edit should succeed")
 }
 
 #[cfg(test)]
@@ -209,7 +493,10 @@ pub(in crate::native_app) fn waveform_restore_action_for_capacity_tests(
         backup_path: backup_path.clone(),
         applied: AppliedWaveformEdit {
             source_id: String::from("test"),
-            relative_path: PathBuf::from("sample.wav"),
+            relative_path: target_path
+                .file_name()
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("sample.wav")),
             absolute_path: target_path,
             before_content_identity: None,
             backup: OverwriteBackup {
@@ -267,10 +554,11 @@ pub(super) fn validate_destructive_edit_target(path: &Path) -> Result<(), String
 fn execute_destructive_edit_write(
     request: &PendingWaveformDestructiveEdit,
     extracted_path: Option<PathBuf>,
+    recovery_root: &crate::native_app::transaction_history::operation_journal::RecoveryRootCapability,
 ) -> Result<AppliedWaveformEdit, String> {
     validate_destructive_edit_target(&request.absolute_path)?;
     let before_content_identity = cache_content_identity(&request.absolute_path);
-    let mut backup = OverwriteBackup::capture_before(&request.absolute_path)?;
+    let mut backup = OverwriteBackup::capture_before(&request.absolute_path, recovery_root)?;
     let extracted = extracted_path
         .map(|path| {
             let relative_path = source_relative_path(&request.source.root, &path)?;

--- a/src/native_app/waveform_edits/worker/atomic_write/tests.rs
+++ b/src/native_app/waveform_edits/worker/atomic_write/tests.rs
@@ -180,3 +180,32 @@ fn successful_commit_publishes_a_complete_synced_wav() {
     assert_eq!(reader.spec().sample_rate, 48_000);
     assert_eq!(reader.samples::<f32>().count(), 4);
 }
+
+#[cfg(unix)]
+#[test]
+fn explicit_read_write_modes_survive_commit_and_rollback() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (directory, target, recovery) = fixture();
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o640)).unwrap();
+    fs::set_permissions(&recovery, fs::Permissions::from_mode(0o440)).unwrap();
+    let after = directory.path().join("after.wav");
+    write_wav_atomically_with(
+        &target,
+        &recovery,
+        &after,
+        1,
+        48_000,
+        &[0.0, 0.25, -0.25, 0.5],
+        &TestAtomicEditIo::new(InjectedFailure::None),
+    )
+    .unwrap();
+    assert_eq!(
+        fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+        0o640
+    );
+    assert_eq!(
+        fs::metadata(&recovery).unwrap().permissions().mode() & 0o777,
+        0o440
+    );
+}


### PR DESCRIPTION
## Goal
Advance the Wavecrate I/O target by making waveform destructive-edit admission depend on a validated, profile-local recovery capability owned by the background journal worker.

## Scope
- Open and identity-check the recovery root on the operation-journal owner thread.
- Publish the retained descriptor capability through journal readiness and adopt/clear it in background state.
- Reject destructive-edit requests before playback, UI context, copy, or worker side effects when readiness is unavailable.
- Carry the capability into the worker and retain descriptor-relative, identity-checked recovery mutations.
- Preserve the prepared journal transition, strict no-follow traversal, capacity gate, cleanup, collision, permission, and physical-volume fixture behavior.

## Non-goals
- No coordinator phase redesign or prepared-restore execution.
- No source-processing lifecycle redesign; the existing source-supervisor profile resolution remains outside this correction.
- No pathname-based recovery fallback or broad platform publication changes.

## Definition of Done
- Production UI-state construction performs no new recovery-root filesystem I/O.
- Journal startup publishes `Initializing` followed by either `Available` with an owned capability or typed `Unavailable` without panic.
- Destructive edits fail closed before UI/playback/task/filesystem side effects unless the capability is ready.
- Worker recovery remains descriptor-relative and rejects replaced roots.
- Existing focused journal, capacity, atomic-write, and physical recovery behavior remains green.

## Validation
- `RUSTFLAGS='-Aunused-imports' cargo check -p wavecrate --lib --locked --no-default-features` (passed; normal check is limited by unrelated dirty sibling Radiant imports)
- Journal-owner tests: 8 passed
- Operation-journal tests: 13 passed
- Capacity-gate tests: 6 passed
- Atomic-write tests: 7 passed
- Physical protected-crop representative test: passed
- `rustfmt --edition 2024 --check` on changed files (passed)
- `git diff --check` (passed)
- The broader destructive-edit module still has known asynchronous status/rating/selection harness failures and a protected-extraction hang; these were not expanded into this bounded correction.

## Known limitations
- Runtime acceptance of asynchronous destructive-edit completion remains user-owned.
- The existing source-supervisor startup path still contains its pre-existing synchronous profile-root resolution; removing that broader debt is a separate lifecycle slice.

User approval is required before merge.
