### PR TITLE
Verify prepared restore staging absence

### DIFF
--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -848,6 +848,57 @@ fn open_leaf_relative(
     Ok((file, identity))
 }
 
+fn verify_relative_absent(root: &File, relative: &Path, display: &Path) -> Result<(), String> {
+    clean_relative_path(relative)?;
+    let mut components = relative.components();
+    let Some(std::path::Component::Normal(component)) = components.next() else {
+        return Err(String::from("locator must contain one normal component"));
+    };
+    if components.next().is_some() {
+        return Err(String::from("locator must be a destination-local leaf"));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::ffi::CString;
+        use std::os::fd::AsRawFd;
+
+        let name = CString::new(component.as_encoded_bytes())
+            .map_err(|_| String::from("locator contains NUL"))?;
+        let mut metadata = std::mem::MaybeUninit::<libc::stat>::zeroed();
+        let result = unsafe {
+            libc::fstatat(
+                root.as_raw_fd(),
+                name.as_ptr(),
+                metadata.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if result == 0 {
+            return Err(format!(
+                "staging locator is occupied: {}",
+                display.display()
+            ));
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() == io::ErrorKind::NotFound {
+            return Ok(());
+        }
+        return Err(format!(
+            "could not verify staging locator absence at {}: {error}",
+            display.display()
+        ));
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (root, display);
+        Err(String::from(
+            "staging locator absence cannot be verified on this platform",
+        ))
+    }
+}
+
 fn infer_root(path: &Path, relative: &Path) -> Result<PathBuf, String> {
     clean_relative_path(relative)?;
     let mut root = path.to_path_buf();
@@ -926,6 +977,12 @@ fn prepare_descriptor(
         open_root(&target_root_path).map_err(|error| format!("source root: {error}"))?;
     let (target_root_file, target_root) =
         open_root(&target_root_path).map_err(|error| format!("target root: {error}"))?;
+    let staging = PathBuf::from(format!(".wavecrate-restore-{operation_id}.stage"));
+    verify_relative_absent(
+        &target_root_file,
+        &staging,
+        &target_root_path.join(&staging),
+    )?;
     let (backup_root_file, backup_root) =
         open_root(&backup_root_path).map_err(|error| format!("backup root: {error}"))?;
     let (target_file, target_identity) = open_leaf_relative(
@@ -970,7 +1027,6 @@ fn prepare_descriptor(
     }
     super::capacity_gate::aggregate_capacity_plan(&[requirement], &claims_without_own)
         .map_err(|error| error.to_string())?;
-    let staging = PathBuf::from(format!(".wavecrate-restore-{operation_id}.stage"));
     let direction = match direction {
         super::file_io::HistoryFileIoDirection::Undo => PreparedRestoreDirection::Undo,
         super::file_io::HistoryFileIoDirection::Redo => PreparedRestoreDirection::Redo,
@@ -1069,6 +1125,15 @@ impl OperationJournalCoordinator {
     ) -> Result<PreparedOperationOutcome, BoundedAdmissionError> {
         let operation_id =
             self.admit_bounded_waveform_restore(intent, payload, direction, actions)?;
+        self.prepare_admitted_bounded_waveform_restore(operation_id, direction, actions)
+    }
+
+    fn prepare_admitted_bounded_waveform_restore(
+        &mut self,
+        operation_id: Uuid,
+        direction: super::file_io::HistoryFileIoDirection,
+        actions: &[super::file_io::HistoryFileAction],
+    ) -> Result<PreparedOperationOutcome, BoundedAdmissionError> {
         let capacity_plan = self
             .store
             .record(operation_id)
@@ -1645,6 +1710,65 @@ mod tests {
             format!(".wavecrate-restore-{id}.stage")
         );
         assert_eq!(reopened.store.capacity_claims().len(), 1);
+    }
+
+    #[test]
+    fn occupied_staging_entry_retries_without_mutation_and_reopens_unresolved() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let files = fixture_directory();
+        let backup = files.path().join("before.wav");
+        let target = files.path().join("target.wav");
+        let staging_bytes = b"occupied staging entry";
+        fs::write(&backup, vec![7_u8; 4097]).unwrap();
+        fs::write(&target, vec![0_u8; 4097]).unwrap();
+        let action = crate::native_app::waveform_edits::waveform_restore_action_for_capacity_tests(
+            backup,
+            target.clone(),
+            false,
+        );
+        let mut coordinator = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+        let id = coordinator
+            .admit_bounded_waveform_restore(
+                intent(),
+                Value::Null,
+                super::super::file_io::HistoryFileIoDirection::Undo,
+                std::slice::from_ref(&action),
+            )
+            .unwrap();
+        let staging = files.path().join(format!(".wavecrate-restore-{id}.stage"));
+        fs::write(&staging, staging_bytes).unwrap();
+        let claims_before = coordinator.store.capacity_claims().clone();
+        let outcome = coordinator
+            .prepare_admitted_bounded_waveform_restore(
+                id,
+                super::super::file_io::HistoryFileIoDirection::Undo,
+                std::slice::from_ref(&action),
+            )
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            PreparedOperationOutcome::RetryPending { operation_id, .. } if operation_id == id
+        ));
+        let record = coordinator.record(id).unwrap();
+        assert_eq!(record.phase, OperationPhase::IntentDurable);
+        assert_eq!(record.disposition, OperationDisposition::RetryPending);
+        assert!(record.prepared.is_none());
+        assert_eq!(coordinator.store.capacity_claims(), &claims_before);
+        assert_eq!(fs::read(&staging).unwrap(), staging_bytes);
+        assert_eq!(fs::read(&target).unwrap(), vec![0_u8; 4097]);
+        drop(coordinator);
+
+        let reopened = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+        let reopened_record = reopened.record(id).unwrap();
+        assert_eq!(reopened_record.phase, OperationPhase::IntentDurable);
+        assert_eq!(
+            reopened_record.disposition,
+            OperationDisposition::RetryPending
+        );
+        assert!(reopened_record.prepared.is_none());
+        assert_eq!(reopened.store.capacity_claims(), &claims_before);
+        assert_eq!(fs::read(&staging).unwrap(), staging_bytes);
     }
 
     #[test]


### PR DESCRIPTION
## Goal

Advance the Wavecrate I/O target by making the bounded waveform-restore preparation boundary prove that its destination-local staging entry is absent before publishing `Prepared`.

## Scope and non-goals

- Inspect the generated staging leaf through the already-open no-follow target-root capability.
- Treat any existing entry, including regular files, directories, symlinks/reparse points, or unverifiable platform state, as fail-closed preparation failure.
- Preserve the durable `IntentDurable` plus `RetryPending` state and capacity claim when preparation cannot proceed.
- Add restart-preserving regression coverage for an occupied staging entry.
- Non-goals: staging copy, final replacement, production history dispatch, source/global database reconciliation, schema changes, UI changes, Radiant changes, or PR #980.

## Definition of Done

- `PreparedWaveformRestore` is persisted only after descriptor-relative staging absence is verified.
- Unix inspection uses `fstatat` with `AT_SYMLINK_NOFOLLOW`; non-Unix platforms fail closed without a pathname fallback.
- Occupied staging leaves remain byte-for-byte untouched; the target remains untouched; the operation remains `IntentDurable + RetryPending`; its capacity claim survives restart.
- Existing successful preparation behavior remains green and no UI-thread I/O is introduced.

## Validation

- `rustfmt --edition 2024 --check src/native_app/transaction_history/operation_journal.rs` — passed.
- `git diff --check` — passed.
- `RUSTFLAGS='-A unused-imports' cargo test -p wavecrate --lib native_app::transaction_history::operation_journal::tests --no-default-features -- --nocapture` — 14 passed.
- `RUSTFLAGS='-A unused-imports' cargo test -p wavecrate --lib native_app::transaction_history::capacity_gate::tests --no-default-features -- --nocapture` — 6 passed.
- `CARGO_TARGET_DIR=/tmp/wavecrate-prepared-staging-target RUSTFLAGS='-A unused-imports' cargo check -p wavecrate --lib --locked --no-default-features` — passed.
- Independent Terra persistence/filesystem specialist review — APPROVE, no required findings.

## Known limitations

- Full Windows/MSVC compilation was not available on this macOS host; the non-Unix implementation fails closed by construction and was reviewed statically.
- This PR establishes preparation evidence only. Production history dispatch and the subsequent `Prepared -> FilesystemStaged` copy-validation transition remain separate work.
- Runtime acceptance of asynchronous destructive-edit completion remains user-owned.

## Next architecture task

Implement the bounded `Prepared -> FilesystemStaged` transition: reacquire and revalidate the recorded capabilities/identities, copy completely into destination-local staging, durably record `CopyValidated`, and preserve retry/audit evidence without final replacement.

User approval is required before merge.