### PR TITLE
feat: make waveform panel vertically resizable

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -56,6 +56,7 @@ pub(in crate::native_app) enum TrashMoveTarget {
 #[derive(Clone, Debug, PartialEq)]
 pub(in crate::native_app) enum GuiMessage {
     ResizeFolder(DragHandleMessage),
+    ResizeWaveformPanel(DragHandleMessage),
     FolderBrowser(FolderBrowserMessage),
     AddSourceDialogFinished(ui::PlatformResult),
     ContextPathCopyFinished {

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -35,6 +35,8 @@ pub(in crate::native_app) use source_processing_events::GuiSourceProcessingEvent
 #[cfg(test)]
 pub(in crate::native_app) use state::DEFAULT_VOLUME;
 #[cfg(test)]
+pub(in crate::native_app) use state::DEFAULT_WAVEFORM_PANEL_HEIGHT;
+#[cfg(test)]
 pub(in crate::native_app) use state::ReleaseUpdateStatus;
 pub(in crate::native_app) use state::{
     AudioAppState, AudioOpenCompletion, AudioOpenTaskCompletion, AudioOptionsRefreshResult,
@@ -42,17 +44,18 @@ pub(in crate::native_app) use state::{
     CutFileClipboard, ExtractedFilePlaybackType, FolderScanWorkerEvent,
     HarvestSelectionDerivationBatchResult, HarvestTouchedPersistAdmission,
     HarvestTouchedPersistBatchResult, LibraryAppState, MAX_BEAT_GUIDE_COUNT, MIN_BEAT_GUIDE_COUNT,
-    MetadataAppState, NativeAppState, OperationJournalStatus, OverflowFadeAnimations,
-    PendingFolderDelete, PendingHistoryCommit, PendingPlaySelectionRetargetCycle,
-    PendingPlaybackStart, PendingProtectedExtractionAction, PendingProtectedExtractionTargetSource,
-    PendingTrashFolderSetup, PendingWaveformDestructiveEdit, PlaybackSpanRetargetRejection,
-    RatingPersistBatchResult, SampleBrowserDisplayMode, SamplePlaybackHistory,
-    SamplePlaybackIntent, SamplePlaybackNormalization, SamplePlaybackRequest,
-    SamplePlaybackSession, SamplePlaybackSessionState, SamplePlaybackSourceProbe,
-    SamplePlaybackVisibility, SettingsAppState, SourceFilesystemChangePlan, SourceRefreshCause,
-    SourceRefreshRequest, SourceScanFinish, SourceSelectionRequest, StarmapAuditionDragState,
-    StarmapViewport, StarmapViewportChange, StartupState, StatusState, TransactionState,
-    UiAppState, UnsupportedFilesDialogState, WaveformAppState, WaveformDestructiveEditKind,
+    MIN_WAVEFORM_PANEL_HEIGHT, MetadataAppState, NativeAppState, OperationJournalStatus,
+    OverflowFadeAnimations, PendingFolderDelete, PendingHistoryCommit,
+    PendingPlaySelectionRetargetCycle, PendingPlaybackStart, PendingProtectedExtractionAction,
+    PendingProtectedExtractionTargetSource, PendingTrashFolderSetup,
+    PendingWaveformDestructiveEdit, PlaybackSpanRetargetRejection, RatingPersistBatchResult,
+    SampleBrowserDisplayMode, SamplePlaybackHistory, SamplePlaybackIntent,
+    SamplePlaybackNormalization, SamplePlaybackRequest, SamplePlaybackSession,
+    SamplePlaybackSessionState, SamplePlaybackSourceProbe, SamplePlaybackVisibility,
+    SettingsAppState, SourceFilesystemChangePlan, SourceRefreshCause, SourceRefreshRequest,
+    SourceScanFinish, SourceSelectionRequest, StarmapAuditionDragState, StarmapViewport,
+    StarmapViewportChange, StartupState, StatusState, TransactionState, UiAppState,
+    UnsupportedFilesDialogState, WaveformAppState, WaveformDestructiveEditKind,
     WaveformDestructiveEditPrompt, WaveformDestructiveEditTarget, WaveformDestructiveEditUiContext,
     WaveformEditSelectionSnapshot, WaveformPlaySelectionSnapshot, WaveformVisualSnapshot,
     run_folder_scan_worker,

--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -39,11 +39,13 @@ pub(in crate::native_app) use source_scan_workflow::{
 };
 pub(in crate::native_app) use transactions::{PendingHistoryCommit, TransactionState};
 #[cfg(test)]
+pub(in crate::native_app) use ui_state::DEFAULT_WAVEFORM_PANEL_HEIGHT;
+#[cfg(test)]
 pub(in crate::native_app) use ui_state::ReleaseUpdateStatus;
 pub(in crate::native_app) use ui_state::{
     ChromeUiState, ClipboardHandoffTarget, CutFileClipboard, ExtractedFilePlaybackType,
-    MAX_BEAT_GUIDE_COUNT, MIN_BEAT_GUIDE_COUNT, OverflowFadeAnimations, PendingFolderDelete,
-    PendingProtectedExtractionAction, PendingProtectedExtractionTargetSource,
+    MAX_BEAT_GUIDE_COUNT, MIN_BEAT_GUIDE_COUNT, MIN_WAVEFORM_PANEL_HEIGHT, OverflowFadeAnimations,
+    PendingFolderDelete, PendingProtectedExtractionAction, PendingProtectedExtractionTargetSource,
     PendingTrashFolderSetup, PendingWaveformDestructiveEdit, SampleBrowserDisplayMode,
     SettingsAppState, StarmapAuditionDragState, StarmapViewport, StarmapViewportChange,
     StartupState, StatusState, UiAppState, UnsupportedFilesDialogState,

--- a/src/native_app/app/state/ui_state.rs
+++ b/src/native_app/app/state/ui_state.rs
@@ -22,6 +22,9 @@ use crate::native_app::waveform::WaveformContextMenu;
 pub(in crate::native_app) const DEFAULT_BEAT_GUIDE_COUNT: u8 = 4;
 pub(in crate::native_app) const MIN_BEAT_GUIDE_COUNT: u8 = 2;
 pub(in crate::native_app) const MAX_BEAT_GUIDE_COUNT: u8 = 32;
+pub(in crate::native_app) const DEFAULT_WAVEFORM_PANEL_HEIGHT: f32 = 226.0;
+pub(in crate::native_app) const MIN_WAVEFORM_PANEL_HEIGHT: f32 = 94.0;
+pub(in crate::native_app) const MAX_WAVEFORM_PANEL_HEIGHT: f32 = 512.0;
 
 pub(in crate::native_app) struct UiAppState {
     pub(in crate::native_app) chrome: ChromeUiState,
@@ -52,6 +55,7 @@ impl UiAppState {
 
 pub(in crate::native_app) struct ChromeUiState {
     pub(in crate::native_app) folder_panel: panel_ui::PanelResizeState,
+    pub(in crate::native_app) waveform_panel: panel_ui::PanelResizeState,
     pub(in crate::native_app) job_details_open: bool,
     pub(in crate::native_app) transaction_list_open: bool,
     pub(in crate::native_app) shortcut_help_open: bool,
@@ -311,6 +315,7 @@ impl ChromeUiState {
     pub(in crate::native_app) fn new(folder_width: f32) -> Self {
         Self {
             folder_panel: panel_ui::PanelResizeState::new(folder_width),
+            waveform_panel: panel_ui::PanelResizeState::new(DEFAULT_WAVEFORM_PANEL_HEIGHT),
             job_details_open: false,
             transaction_list_open: false,
             shortcut_help_open: false,
@@ -328,6 +333,25 @@ impl ChromeUiState {
             beat_guide_count: DEFAULT_BEAT_GUIDE_COUNT,
             overflow_fades: OverflowFadeAnimations::default(),
         }
+    }
+
+    pub(in crate::native_app) fn waveform_panel_height(&self) -> f32 {
+        self.waveform_panel
+            .size()
+            .clamp(MIN_WAVEFORM_PANEL_HEIGHT, MAX_WAVEFORM_PANEL_HEIGHT)
+    }
+
+    pub(in crate::native_app) fn resize_waveform_panel(
+        &mut self,
+        message: radiant::widgets::DragHandleMessage,
+    ) {
+        self.waveform_panel.resize(
+            message,
+            panel_ui::PanelResizeConstraints::bottom(
+                MIN_WAVEFORM_PANEL_HEIGHT,
+                MAX_WAVEFORM_PANEL_HEIGHT,
+            ),
+        );
     }
 
     pub(in crate::native_app) fn set_beat_guide_count(&mut self, count: u8) {

--- a/src/native_app/app_chrome/view_models/waveform_panel.rs
+++ b/src/native_app/app_chrome/view_models/waveform_panel.rs
@@ -6,6 +6,7 @@ use crate::native_app::waveform::WaveformState;
 
 pub(in crate::native_app) struct WaveformPanelViewModel<'a> {
     pub(in crate::native_app) waveform: &'a WaveformState,
+    pub(in crate::native_app) panel_height: f32,
     pub(in crate::native_app) drop_hover: Option<&'a NativeFileDropHover>,
     pub(in crate::native_app) loading_label: Option<&'a str>,
     pub(in crate::native_app) failed_label: Option<String>,
@@ -26,6 +27,7 @@ impl<'a> WaveformPanelViewModel<'a> {
     pub(in crate::native_app) fn from_app_state(state: &'a NativeAppState) -> Self {
         Self {
             waveform: &state.waveform.current,
+            panel_height: state.ui.chrome.waveform_panel_height(),
             drop_hover: state.ui.browser_interaction.native_file_drop_hover.as_ref(),
             loading_label: state.waveform.load.label.as_deref(),
             failed_label: state.waveform.load.selection.failed_waveform_label(),

--- a/src/native_app/app_chrome/waveform_panel.rs
+++ b/src/native_app/app_chrome/waveform_panel.rs
@@ -1,6 +1,8 @@
 use radiant::prelude as ui;
 
-use crate::native_app::app::GuiMessage;
+#[cfg(test)]
+use crate::native_app::app::DEFAULT_WAVEFORM_PANEL_HEIGHT;
+use crate::native_app::app::{GuiMessage, MIN_WAVEFORM_PANEL_HEIGHT};
 use crate::native_app::app_chrome::view_models::waveform_panel::WaveformPanelViewModel;
 use crate::native_app::ui::ids as widget_ids;
 use crate::native_app::waveform::{
@@ -8,9 +10,16 @@ use crate::native_app::waveform::{
 };
 
 const WAVEFORM_STATUS_HEIGHT: f32 = 16.0;
+const WAVEFORM_SCROLLBAR_HEIGHT: f32 = 6.0;
+const WAVEFORM_RESIZE_HANDLE_HEIGHT: f32 = 8.0;
 const WAVEFORM_SAMPLE_DRAG_HANDLE_WIDTH: f32 = 14.0;
-pub(in crate::native_app) const WAVEFORM_VIEW_HEIGHT: f32 = 196.0;
-pub(in crate::native_app) const WAVEFORM_PANEL_HEIGHT: f32 = 226.0;
+#[cfg(test)]
+pub(in crate::native_app) const WAVEFORM_PANEL_HEIGHT: f32 = DEFAULT_WAVEFORM_PANEL_HEIGHT;
+#[cfg(test)]
+pub(in crate::native_app) const WAVEFORM_VIEW_HEIGHT: f32 = WAVEFORM_PANEL_HEIGHT
+    - WAVEFORM_STATUS_HEIGHT
+    - WAVEFORM_SCROLLBAR_HEIGHT
+    - WAVEFORM_RESIZE_HANDLE_HEIGHT;
 
 pub(in crate::native_app) fn waveform_panel(
     model: WaveformPanelViewModel<'_>,
@@ -25,22 +34,38 @@ pub(in crate::native_app) fn waveform_panel(
             model.failed_label.as_deref(),
             model.help_tooltips_enabled,
         ),
-        waveform_viewport_with_loading_state(&model),
+        waveform_viewport_with_loading_state(&model, waveform_view_height(model.panel_height)),
         waveform_scrollbar(model.waveform),
+        waveform_resize_handle(model.help_tooltips_enabled),
     ])
     .spacing(0.0)
     .fill_width()
-    .height(WAVEFORM_PANEL_HEIGHT)
+    .height(model.panel_height)
+}
+
+fn waveform_view_height(panel_height: f32) -> f32 {
+    (panel_height
+        - WAVEFORM_STATUS_HEIGHT
+        - WAVEFORM_SCROLLBAR_HEIGHT
+        - WAVEFORM_RESIZE_HANDLE_HEIGHT)
+        .max(
+            MIN_WAVEFORM_PANEL_HEIGHT
+                - WAVEFORM_STATUS_HEIGHT
+                - WAVEFORM_SCROLLBAR_HEIGHT
+                - WAVEFORM_RESIZE_HANDLE_HEIGHT,
+        )
 }
 
 fn waveform_viewport_with_loading_state(
     model: &WaveformPanelViewModel<'_>,
+    viewport_height: f32,
 ) -> ui::View<GuiMessage> {
     let tooltip = model.help_tooltips_enabled.then_some(
         "Waveform: click to set playback start, drag to select, Z zooms to selection, X zooms out.",
     );
     let viewport = waveform::waveform_viewport_view_with_tooltip(
         model.waveform,
+        viewport_height,
         tooltip,
         model.beat_guides_enabled,
         model.bpm_snap_enabled,
@@ -49,19 +74,19 @@ fn waveform_viewport_with_loading_state(
         model.playhead_occlusion_rect,
     )
     .fill_width()
-    .height(WAVEFORM_VIEW_HEIGHT);
+    .height(viewport_height);
     ui::overlay_stack(viewport)
         .overlay_opt(
             model
                 .drop_hover
-                .map(|hover| waveform_drop_hover_visual(hover.supported)),
+                .map(|hover| waveform_drop_hover_visual(hover.supported, viewport_height)),
         )
         .input_opt(waveform_loading_input_blocker(model))
         .into_view()
         .accepts_native_file_drop()
         .on_native_file_drop(GuiMessage::WaveformFileDrop)
         .fill_width()
-        .height(WAVEFORM_VIEW_HEIGHT)
+        .height(viewport_height)
 }
 
 fn waveform_loading_input_blocker(
@@ -73,11 +98,11 @@ fn waveform_loading_input_blocker(
             .key("waveform-loading-input-blocker")
             .input_only()
             .fill_width()
-            .height(WAVEFORM_VIEW_HEIGHT)
+            .height(waveform_view_height(model.panel_height))
     })
 }
 
-fn waveform_drop_hover_visual(supported: bool) -> ui::View<GuiMessage> {
+fn waveform_drop_hover_visual(supported: bool, viewport_height: f32) -> ui::View<GuiMessage> {
     let color = if supported {
         ui::Rgba8::new(74, 178, 116, 255)
     } else {
@@ -98,7 +123,19 @@ fn waveform_drop_hover_visual(supported: bool) -> ui::View<GuiMessage> {
         .view()
         .key("waveform-drop-hover-visual")
         .fill_width()
-        .height(WAVEFORM_VIEW_HEIGHT)
+        .height(viewport_height)
+}
+
+fn waveform_resize_handle(help_tooltips_enabled: bool) -> ui::View<GuiMessage> {
+    ui::drag_handle()
+        .hover_chrome_only()
+        .mapped(GuiMessage::ResizeWaveformPanel)
+        .key("waveform-resize-handle")
+        .id(widget_ids::WAVEFORM_RESIZE_HANDLE_ID)
+        .style(ui::WidgetStyle::subtle(ui::WidgetTone::Accent))
+        .tooltip_if(help_tooltips_enabled, "Resize waveform height")
+        .fill_width()
+        .height(WAVEFORM_RESIZE_HANDLE_HEIGHT)
 }
 
 fn waveform_title_row(
@@ -185,5 +222,5 @@ fn waveform_scrollbar(waveform: &WaveformState) -> ui::View<GuiMessage> {
             GuiMessage::Waveform(WaveformInteraction::ScrollTo { offset_fraction })
         })
         .fill_width()
-        .height(6.0)
+        .height(WAVEFORM_SCROLLBAR_HEIGHT)
 }

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -209,7 +209,8 @@ impl NativeAppState {
             | GuiMessage::HistoryFileIoFinished(_)
             | GuiMessage::NativeAudioDocumentOpenValidated { .. }
             | GuiMessage::WaveformFileDrop(_) => self.apply_file_dispatch(message, context),
-            GuiMessage::ToggleJobDetails
+            GuiMessage::ResizeWaveformPanel(_)
+            | GuiMessage::ToggleJobDetails
             | GuiMessage::CloseJobDetails
             | GuiMessage::RetryActiveSourceScan
             | GuiMessage::CancelActiveSourceScan
@@ -381,6 +382,7 @@ fn gui_message_profile_label(message: &GuiMessage) -> &'static str {
         GuiMessage::SampleBrowserWindowChanged(_) => "SampleBrowserWindowChanged",
         GuiMessage::FolderTreeWindowChanged(_) => "FolderTreeWindowChanged",
         GuiMessage::BrowserScrollAccepted(_) => "BrowserScrollAccepted",
+        GuiMessage::ResizeWaveformPanel(_) => "ResizeWaveformPanel",
         GuiMessage::FolderBrowser(message) => folder_browser_profile_label(message),
         GuiMessage::FolderScanProgress(_) => "FolderScanProgress",
         GuiMessage::FolderScanDiscoveryBatch(_) => "FolderScanDiscoveryBatch",

--- a/src/native_app/shell/message_dispatch/chrome.rs
+++ b/src/native_app/shell/message_dispatch/chrome.rs
@@ -11,6 +11,9 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         match message {
+            GuiMessage::ResizeWaveformPanel(message) => {
+                self.ui.chrome.resize_waveform_panel(message);
+            }
             GuiMessage::ToggleJobDetails => {
                 let job_active = StatusBarViewModel::from_app_state(self)
                     .job_details

--- a/src/native_app/tests/waveform_panel.rs
+++ b/src/native_app/tests/waveform_panel.rs
@@ -4,7 +4,10 @@ use crate::native_app::{
         waveform_panel::{WAVEFORM_PANEL_HEIGHT, WAVEFORM_VIEW_HEIGHT, waveform_panel},
     },
     test_support::state::NativeAppStateFixture,
-    ui::ids::{WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID, WAVEFORM_PLAYMARK_LABEL_ID},
+    ui::ids::{
+        WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID, WAVEFORM_PLAYMARK_LABEL_ID,
+        WAVEFORM_RESIZE_HANDLE_ID,
+    },
 };
 use radiant::prelude::{self as ui, IntoView};
 
@@ -12,6 +15,58 @@ use radiant::prelude::{self as ui, IntoView};
 fn waveform_panel_uses_the_taller_editorial_viewport() {
     assert_eq!(WAVEFORM_VIEW_HEIGHT, 196.0);
     assert_eq!(WAVEFORM_PANEL_HEIGHT, 226.0);
+}
+
+#[test]
+fn waveform_panel_resize_handle_routes_drag_messages() {
+    let state = NativeAppStateFixture::default().build();
+    let drag = ui::DragHandleMessage::started(ui::Point::new(320.0, 222.0));
+    let surface = waveform_panel(WaveformPanelViewModel::from_app_state(&state)).into_surface();
+
+    assert!(surface.find_widget(WAVEFORM_RESIZE_HANDLE_ID).is_some());
+    assert_eq!(
+        waveform_panel(WaveformPanelViewModel::from_app_state(&state)).view_dispatch_widget_output(
+            WAVEFORM_RESIZE_HANDLE_ID,
+            ui::WidgetOutput::typed(drag.clone()),
+        ),
+        Some(crate::native_app::app::GuiMessage::ResizeWaveformPanel(
+            drag
+        )),
+    );
+}
+
+#[test]
+fn waveform_panel_resize_updates_panel_and_viewport_height() {
+    let mut state = NativeAppStateFixture::default().build();
+    let initial_height = state.ui.chrome.waveform_panel_height();
+    let delta = 64.0;
+
+    state.apply_message(
+        crate::native_app::app::GuiMessage::ResizeWaveformPanel(ui::DragHandleMessage::started(
+            ui::Point::new(320.0, initial_height),
+        )),
+        &mut ui::UiUpdateContext::default(),
+    );
+    state.apply_message(
+        crate::native_app::app::GuiMessage::ResizeWaveformPanel(ui::DragHandleMessage::moved(
+            ui::Point::new(320.0, initial_height + delta),
+        )),
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert_eq!(
+        state.ui.chrome.waveform_panel_height(),
+        initial_height + delta
+    );
+    let frame = waveform_panel(WaveformPanelViewModel::from_app_state(&state))
+        .view_frame_at_size_with_default_theme(ui::Vector2::new(800.0, initial_height + delta));
+    let waveform = frame
+        .layout
+        .rects
+        .get(&crate::native_app::ui::ids::WAVEFORM_WIDGET_ID)
+        .expect("resized waveform should be laid out");
+
+    assert_eq!(waveform.height(), WAVEFORM_VIEW_HEIGHT + delta);
 }
 
 fn loaded_sample_drag_handle_tooltip(

--- a/src/native_app/ui/ids.rs
+++ b/src/native_app/ui/ids.rs
@@ -43,6 +43,7 @@ pub(in crate::native_app) const WAVEFORM_SIGNAL_WIDGET_ID: u64 = WAVEFORM.id(11)
 pub(in crate::native_app) const WAVEFORM_WIDGET_ID: u64 = WAVEFORM.id(12);
 pub(in crate::native_app) const WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID: u64 = WAVEFORM.id(13);
 pub(in crate::native_app) const WAVEFORM_PLAYMARK_LABEL_ID: u64 = WAVEFORM.id(14);
+pub(in crate::native_app) const WAVEFORM_RESIZE_HANDLE_ID: u64 = WAVEFORM.id(15);
 
 pub(in crate::native_app) const FOLDER_TREE_LIST_ID: u64 = FOLDER_TREE.id(0);
 pub(in crate::native_app) const FOLDER_TREE_INCLUDE_SUBFOLDERS_TOGGLE_ID: u64 = FOLDER_TREE.id(1);

--- a/src/native_app/ui/ids/registry.rs
+++ b/src/native_app/ui/ids/registry.rs
@@ -78,6 +78,11 @@ const REGISTERED_WIDGET_IDS: &[RegisteredWidgetId] = &[
         WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID,
         "waveform.loaded_sample_drag_handle"
     ),
+    registered_widget_id!(
+        Waveform,
+        WAVEFORM_RESIZE_HANDLE_ID,
+        "waveform.resize_handle"
+    ),
     registered_widget_id!(FolderTree, FOLDER_TREE_LIST_ID, "folder_tree.list"),
     registered_widget_id!(
         FolderTree,

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -52,6 +52,7 @@ pub(in crate::native_app::waveform) struct LiveSelectionPreviewAnchor {
 
 pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
     state: &WaveformState,
+    viewport_height: f32,
     tooltip: Option<&'static str>,
     beat_guides_enabled: bool,
     bpm_snap_enabled: bool,
@@ -66,6 +67,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
         beat_guide_count,
         playhead_occlusion_rect,
     );
+    let viewport_size = (WAVEFORM_WIDTH as f32, viewport_height);
     let interaction = ui::custom_widget(
         WaveformWidget::new(props.clone()).with_external_playmark_label_owner(),
         |output| {
@@ -75,7 +77,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
         },
     )
     .id(WAVEFORM_WIDGET_ID)
-    .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32);
+    .size(viewport_size.0, viewport_size.1);
     let interaction = if let Some(tooltip) = tooltip {
         interaction.tooltip(tooltip)
     } else {
@@ -95,7 +97,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
                 .map(GuiMessage::PlaymarkLabel)
         })
         .id(widget_ids::WAVEFORM_PLAYMARK_LABEL_ID)
-        .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
+        .size(viewport_size.0, viewport_size.1)
     });
     let layers = [
         waveform_signal_surface_view(
@@ -104,7 +106,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
             state.pending_sample_slide_frame_offset,
         )
         .id(WAVEFORM_SIGNAL_WIDGET_ID)
-        .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32),
+        .size(viewport_size.0, viewport_size.1),
         interaction,
     ]
     .into_iter()
@@ -112,7 +114,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
 
     ui::stack(layers)
         .id(widget_ids::WAVEFORM_VIEWPORT_STACK_ID)
-        .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
+        .size(viewport_size.0, viewport_size.1)
 }
 
 pub(super) fn signal_edit_selection_for_state(


### PR DESCRIPTION
## Goal

Allow the native waveform panel to be resized vertically by dragging its bottom handle.

## Scope and non-goals

- Add a stable bottom resize handle to the waveform panel.
- Keep the current panel height in UI state for the running session.
- Clamp the panel height to 94-512 px.
- Propagate the resized viewport height through waveform rendering and overlays.
- Add routing and layout regression coverage.
- Non-goal: change waveform audio/rendering semantics or add persistent-on-disk panel preferences.

## Definition of Done

- Dragging the waveform resize handle updates panel height.
- The waveform viewport, loading blocker, and drop-hover overlay track the resized height.
- Minimum and maximum bounds remain enforced.
- Release builds pass the repository warning-deny lint.
- A macOS app bundle is produced for native testing.

## Validation

- cargo test --lib native_app::tests::waveform_panel -- --nocapture — 10 passed.
- cargo test --lib native_app::ui::ids -- --nocapture — 2 passed.
- cargo test --lib native_app::tests::window_chrome::primary_waveform -- --nocapture — 5 passed.
- cargo test --lib native_app::tests::window_chrome::secondary_waveform -- --nocapture — 5 passed.
- scripts/build.sh --release -- --locked — passed.
- macOS app bundle codesign verification and Info.plist lint — passed.
- git diff --check — passed.

Known limitation: native interactive drag acceptance remains a macOS app test.