### PR TITLE
Improve production waveform edge antialiasing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "82043f13510fb60c4bf0114159d38e43e7df8987"
+revision = "ff67e43238dbcfa3615e762ddb3cd0274d9f2e2e"
 path = "../radiant"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "8bde063ed86b4e825c8368a888ff19eea25cd5ff"
+revision = "e0b604006fc970fa733b672e99a547b289b7bbc5"
 path = "../radiant"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "ff67e43238dbcfa3615e762ddb3cd0274d9f2e2e"
+revision = "8bde063ed86b4e825c8368a888ff19eea25cd5ff"
 path = "../radiant"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "e0b604006fc970fa733b672e99a547b289b7bbc5"
+revision = "13ae1f524313a5257fee6691679799a1aca99d32"
 path = "../radiant"
 
 [package]

--- a/radiant-dependency.toml
+++ b/radiant-dependency.toml
@@ -4,5 +4,5 @@
 # sibling may remain on a feature branch or contain uncommitted work. Setup,
 # CI, and release helpers provision this exact revision into a clean checkout.
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "8bde063ed86b4e825c8368a888ff19eea25cd5ff"
+revision = "e0b604006fc970fa733b672e99a547b289b7bbc5"
 path = "../radiant"

--- a/radiant-dependency.toml
+++ b/radiant-dependency.toml
@@ -4,5 +4,5 @@
 # sibling may remain on a feature branch or contain uncommitted work. Setup,
 # CI, and release helpers provision this exact revision into a clean checkout.
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "82043f13510fb60c4bf0114159d38e43e7df8987"
+revision = "8bde063ed86b4e825c8368a888ff19eea25cd5ff"
 path = "../radiant"

--- a/radiant-dependency.toml
+++ b/radiant-dependency.toml
@@ -4,5 +4,5 @@
 # sibling may remain on a feature branch or contain uncommitted work. Setup,
 # CI, and release helpers provision this exact revision into a clean checkout.
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "e0b604006fc970fa733b672e99a547b289b7bbc5"
+revision = "13ae1f524313a5257fee6691679799a1aca99d32"
 path = "../radiant"

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -114,8 +114,18 @@ impl NativeAppState {
                 beat_count: self.ui.chrome.beat_guide_count,
             },
         );
-        if waveform_clipping_signature(self) != clipping_signature_before {
+        let clipping_signature_after = waveform_clipping_signature(self);
+        if clipping_signature_after != clipping_signature_before {
             self.ui.chrome.overflow_fades.arm();
+        }
+        if let Some(scope) = waveform_viewport_repaint_scope(
+            &message,
+            active_drag,
+            clipping_signature_before,
+            clipping_signature_after,
+        ) {
+            context.repaint(scope);
+        } else if clipping_signature_after != clipping_signature_before {
             context.request_paint_only();
         }
         self.queue_waveform_detail_refinement(context);
@@ -387,6 +397,33 @@ struct WaveformClippingSignature {
     visible_fraction_bits: u32,
 }
 
+fn waveform_viewport_repaint_scope(
+    interaction: &WaveformInteraction,
+    active_drag: Option<WaveformActiveDragKind>,
+    before: WaveformClippingSignature,
+    after: WaveformClippingSignature,
+) -> Option<ui::RepaintScope> {
+    let is_viewport_projection = matches!(
+        interaction,
+        WaveformInteraction::Wheel { .. }
+            | WaveformInteraction::ZoomToPlaySelection
+            | WaveformInteraction::ZoomFull
+            | WaveformInteraction::ScrollTo { .. }
+            | WaveformInteraction::BeginPan { .. }
+    ) || (matches!(
+        interaction,
+        WaveformInteraction::UpdateSelection { .. } | WaveformInteraction::FinishSelection { .. }
+    ) && active_drag == Some(WaveformActiveDragKind::Pan));
+    if !is_viewport_projection {
+        return None;
+    }
+    Some(if before.fully_zoomed_out != after.fully_zoomed_out {
+        ui::RepaintScope::Layout
+    } else {
+        ui::RepaintScope::Projection
+    })
+}
+
 fn waveform_clipping_signature(state: &NativeAppState) -> WaveformClippingSignature {
     let waveform = &state.waveform.current;
     WaveformClippingSignature {
@@ -642,6 +679,143 @@ fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'st
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn viewport_interactions_use_projection_until_scrollbar_visibility_changes() {
+        let before = WaveformClippingSignature {
+            fully_zoomed_out: false,
+            offset_fraction_bits: 0,
+            visible_fraction_bits: 0,
+        };
+        let after = WaveformClippingSignature {
+            fully_zoomed_out: false,
+            offset_fraction_bits: 1,
+            visible_fraction_bits: 2,
+        };
+
+        assert_eq!(
+            waveform_viewport_repaint_scope(
+                &WaveformInteraction::ScrollTo {
+                    offset_fraction: 0.5,
+                },
+                None,
+                before,
+                after,
+            ),
+            Some(ui::RepaintScope::Projection)
+        );
+        assert_eq!(
+            waveform_viewport_repaint_scope(&WaveformInteraction::ZoomFull, None, before, after),
+            Some(ui::RepaintScope::Projection)
+        );
+    }
+
+    #[test]
+    fn viewport_interactions_use_layout_when_scrollbar_visibility_changes() {
+        let before = WaveformClippingSignature {
+            fully_zoomed_out: true,
+            offset_fraction_bits: 0,
+            visible_fraction_bits: 1,
+        };
+        let after = WaveformClippingSignature {
+            fully_zoomed_out: false,
+            offset_fraction_bits: 0,
+            visible_fraction_bits: 2,
+        };
+
+        assert_eq!(
+            waveform_viewport_repaint_scope(
+                &WaveformInteraction::Wheel {
+                    delta: radiant::gui::types::Vector2::new(0.0, 1.0),
+                    anchor_ratio: 0.5,
+                    expand_silence_margin: false,
+                },
+                None,
+                before,
+                after,
+            ),
+            Some(ui::RepaintScope::Layout)
+        );
+    }
+
+    #[test]
+    fn side_effecting_waveform_interactions_keep_default_repaint_policy() {
+        let signature = WaveformClippingSignature {
+            fully_zoomed_out: false,
+            offset_fraction_bits: 0,
+            visible_fraction_bits: 0,
+        };
+
+        assert_eq!(
+            waveform_viewport_repaint_scope(
+                &WaveformInteraction::FinishSampleSlide { visible_ratio: 0.5 },
+                None,
+                signature,
+                signature,
+            ),
+            None
+        );
+        assert_eq!(
+            waveform_viewport_repaint_scope(
+                &WaveformInteraction::DragLoadedSample(radiant::widgets::DragHandleMessage::ended(
+                    radiant::gui::types::Point::new(0.0, 0.0),
+                )),
+                None,
+                signature,
+                signature,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn waveform_pan_uses_projection_repaint_only_for_its_active_drag() {
+        let before = WaveformClippingSignature {
+            fully_zoomed_out: false,
+            offset_fraction_bits: 0,
+            visible_fraction_bits: 0,
+        };
+        let after = WaveformClippingSignature {
+            fully_zoomed_out: false,
+            offset_fraction_bits: 1,
+            visible_fraction_bits: 2,
+        };
+
+        assert_eq!(
+            waveform_viewport_repaint_scope(
+                &WaveformInteraction::BeginPan { visible_ratio: 0.5 },
+                None,
+                before,
+                after,
+            ),
+            Some(ui::RepaintScope::Projection)
+        );
+        for interaction in [
+            WaveformInteraction::UpdateSelection { visible_ratio: 0.4 },
+            WaveformInteraction::FinishSelection { visible_ratio: 0.4 },
+        ] {
+            assert_eq!(
+                waveform_viewport_repaint_scope(
+                    &interaction,
+                    Some(WaveformActiveDragKind::Pan),
+                    before,
+                    after,
+                ),
+                Some(ui::RepaintScope::Projection)
+            );
+            assert_eq!(
+                waveform_viewport_repaint_scope(
+                    &interaction,
+                    Some(WaveformActiveDragKind::Selection(
+                        WaveformSelectionKind::Play,
+                    )),
+                    before,
+                    after,
+                ),
+                None
+            );
+        }
+    }
     use crate::native_app::waveform::{WaveformEditFadeHandle, WaveformSelectionEdge};
 
     #[test]

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -182,6 +182,7 @@ pub(in crate::native_app::waveform) fn waveform_signal_surface_view(
         GpuSurfaceCapabilities {
             fast_pointer_move: true,
             coalesce_vertical_wheel: true,
+            coalesce_horizontal_wheel: true,
             runtime_overlays: Default::default(),
         },
     )

--- a/tests/radiant_dependency_contract.rs
+++ b/tests/radiant_dependency_contract.rs
@@ -3,6 +3,8 @@
 use std::fs;
 use std::path::Path;
 
+use toml::Value;
+
 #[test]
 fn canonical_radiant_dependency_uses_the_standalone_sibling_contract() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -10,11 +12,24 @@ fn canonical_radiant_dependency_uses_the_standalone_sibling_contract() {
     let metadata =
         fs::read_to_string(root.join("radiant-dependency.toml")).expect("radiant-dependency.toml");
     let env_docs = fs::read_to_string(root.join("docs/ENV_VARS.md")).expect("docs/ENV_VARS.md");
+    let manifest_value: Value = manifest.parse().expect("valid Cargo.toml");
+    let metadata_value: Value = metadata.parse().expect("valid radiant-dependency.toml");
 
     assert!(manifest.contains("radiant = { path = \"../radiant\" }"));
     assert!(metadata.contains("repository = \"https://github.com/PORTALSURFER/radiant.git\""));
-    assert!(metadata.contains("revision = \"82043f13510fb60c4bf0114159d38e43e7df8987\""));
     assert!(metadata.contains("path = \"../radiant\""));
+    let workspace_revision = manifest_value
+        .get("workspace")
+        .and_then(|workspace| workspace.get("metadata"))
+        .and_then(|metadata| metadata.get("radiant"))
+        .and_then(|radiant| radiant.get("revision"))
+        .and_then(Value::as_str)
+        .expect("workspace.metadata.radiant.revision");
+    let dependency_revision = metadata_value
+        .get("revision")
+        .and_then(Value::as_str)
+        .expect("radiant-dependency.toml revision");
+    assert_eq!(dependency_revision, workspace_revision);
     assert!(!root.join(".gitmodules").exists());
     assert!(!root.join("vendor/radiant").exists());
     assert!(!env_docs.contains("WAVECRATE_RADIANT_DIR"));


### PR DESCRIPTION
## Goal

Make native waveform zooming and panning update smoothly at high input rates while keeping repaint and rendering work tightly bounded, with improved max-zoom edge quality.

## Scope

- Adopt Radiant PR #1523 at exact commit `13ae1f524313a5257fee6691679799a1aca99d32`.
- Classify waveform viewport interactions as projection-only refreshes, escalating to layout only when scrollbar visibility changes.
- Enable horizontal and vertical GPU-surface wheel coalescing while preserving pan/zoom semantic-axis behavior, including diagonal and mixed-axis input.
- Keep colored-band interpolation bounded to `min(one physical pixel, one summary bucket)`.
- Preserve exact nearest-bucket sampling for the raw fourth-band carrier and isolated transients.
- Keep the clean sibling dependency contract pinned to the exact Radiant commit.

## Non-goals

No app-side renderer duplication, palette or normalization redesign, LOD/cache-format redesign, playback, selection, fade, cursor, or unrelated interaction changes.

## Definition of Done

- Zoom and pan repaint on the current redraw cadence without requiring a follow-up click.
- Stable viewport movement uses `Projection`; layout is used only for scrollbar-visibility transitions.
- Same-axis wheel input coalesces without changing Wavecrate’s pan/zoom classification; axis changes flush in semantic order.
- Colored-band smoothing is constant-time and bounded to one physical pixel; raw transient sampling remains nearest-bucket.
- Visible summary uploads add at most one clamped guard bucket per side.
- Clean provisioning resolves the exact Radiant dependency revision.

## Validation

- Radiant PR #1523 at `13ae1f524313a5257fee6691679799a1aca99d32`: `cargo test -p radiant gpu_surface_runtime` — 53 passed; `cargo check -p radiant` — passed; `cargo fmt --all -- --check` — passed.
- Radiant generic-surface guardrails: 3 passed.
- Wavecrate viewport repaint tests: 3 passed; native signal-widget suite: 17 passed.
- Wavecrate dependency contract: 1 passed; `cargo check -p wavecrate` and `cargo metadata --locked --no-deps` — passed.
- `scripts/radiant.sh provision --clean` — exact SHA match and clean sibling.
- `bash scripts/build.sh --release` — passed; final app bundle launched for native testing.

## Known limitations

No hardware-rendered visual/frame-time capture was performed. Native macOS testing with diagonal trackpad input and transient-heavy, bass-heavy, and noisy samples remains user-owned acceptance.

User approval is required before merge.