### PR TITLE
Replace metronome toolbar icon

### DIFF
--- a/src/native_app/app_chrome/toolbar/icons.rs
+++ b/src/native_app/app_chrome/toolbar/icons.rs
@@ -124,10 +124,8 @@ static BEAT_GUIDES_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(
 
 static METRONOME_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(
     r#"<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-  <path d="M4 13 6.8 3h2.4L12 13H4z"/>
-  <rect x="3" y="13" width="10" height="1.5"/>
-  <rect x="7.25" y="1.5" width="1.5" height="2.8"/>
-  <rect x="8.25" y="5.25" width="1.25" height="1.25"/>
+  <path d="M3 3h.5c1.7 0 3 2.2 3 5s-1.3 5-3 5H3z"/>
+  <path d="M13 3h-.5c-1.7 0-3 2.2-3 5s1.3 5 3 5h.5z"/>
 </svg>"#,
 );
 


### PR DESCRIPTION
## Goal

Replace the metronome toolbar icon with the supplied two-lobed reference silhouette.

## Scope and non-goals

- Scope: replace the inline metronome SVG in `src/native_app/app_chrome/toolbar/icons.rs`.
- Non-goals: no changes to toolbar behavior, state, tinting, button identity, layout, or playback.

## Definition of Done

- The icon renders as two separate mirrored rounded vertical lobes with a centered gap.
- Existing enabled, active, and disabled tinting remains intact.
- Metronome interaction and toolbar layout remain unchanged.

## Validation

- `rustfmt --edition 2024 --check src/native_app/app_chrome/toolbar/icons.rs` — passed.
- `git diff --check` — passed.
- `scripts/build.sh --release --variant metronome-icon-test -- --locked` — passed; release app bundle produced.
- Native app bundle launched for user acceptance with the new icon.
- A temporary sibling link to a clean local Radiant worktree supplied the missing declared `../radiant` path during the build; the link was removed afterward.

## Known limitations

- No separate focused Cargo test was run; the full release build compiled successfully.
- None affecting the requested icon change.

User approval was received in Codex before merge.