### PR TITLE
Add capability-bound expected-identity publication seam

### DIFF
--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -668,9 +668,19 @@ fn run_owner(
                         match coordinator
                             .prepare_bounded_waveform_restore(intent, payload, direction, &actions)
                         {
-                            Ok(PreparedOperationOutcome::Prepared(operation_id)) => coordinator
-                                .stage_admitted_bounded_waveform_restore(operation_id)
-                                .map_err(JournalOperationError::Journal),
+                            Ok(PreparedOperationOutcome::Prepared(operation_id)) => {
+                                match coordinator
+                                    .stage_admitted_bounded_waveform_restore(operation_id)
+                                    .map_err(JournalOperationError::Journal)?
+                                {
+                                    FilesystemStageOutcome::FilesystemStaged(operation_id) => {
+                                        coordinator
+                                            .attempt_publish_staged_waveform_restore(operation_id)
+                                            .map_err(JournalOperationError::Journal)
+                                    }
+                                    outcome => Ok(outcome),
+                                }
+                            }
                             Ok(PreparedOperationOutcome::RetryPending {
                                 operation_id,
                                 reason,
@@ -888,7 +898,7 @@ mod tests {
     }
 
     #[test]
-    fn owner_prepares_and_stages_bounded_restore_without_target_publication() {
+    fn owner_prepares_stages_and_fail_closed_publication_without_target_mutation() {
         let directory = tempfile::tempdir().expect("journal directory");
         let files = fixture_directory();
         let backup = files.path().join("before.wav");
@@ -949,8 +959,8 @@ mod tests {
             .expect("prepare and stage result")
             .expect("prepare and stage")
         {
-            FilesystemStageOutcome::FilesystemStaged(operation_id) => operation_id,
-            other => panic!("expected filesystem-staged outcome, got {other:?}"),
+            FilesystemStageOutcome::RetryPending { operation_id, .. } => operation_id,
+            other => panic!("expected retry-pending outcome, got {other:?}"),
         };
         assert_eq!(
             std::fs::read(&target).expect("target after staging"),
@@ -975,7 +985,7 @@ mod tests {
         let record = reopened.record(operation_id).expect("staged record");
         assert_eq!(record.payload, payload);
         assert_eq!(record.phase, OperationPhase::FilesystemStaged);
-        assert_eq!(record.disposition, OperationDisposition::None);
+        assert_eq!(record.disposition, OperationDisposition::RetryPending);
         assert!(matches!(
             record.staged.as_ref().map(|staged| &staged.participant),
             Some(FilesystemStagedParticipant::CopyValidated { .. })

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -78,6 +78,7 @@ fn begin_owner_restore_for_tests(
 fn owner_staging_outcomes_retain_history_and_operation_identity() {
     let outcomes = [
         FilesystemStageOutcome::FilesystemStaged(Uuid::new_v4()),
+        FilesystemStageOutcome::FilesystemPublished(Uuid::new_v4()),
         FilesystemStageOutcome::RetryPending {
             operation_id: Uuid::new_v4(),
             reason: String::from("staging collision"),
@@ -96,6 +97,7 @@ fn owner_staging_outcomes_retain_history_and_operation_identity() {
         let command = begin_owner_restore_for_tests(&mut state);
         let operation_id = match &outcome {
             FilesystemStageOutcome::FilesystemStaged(operation_id)
+            | FilesystemStageOutcome::FilesystemPublished(operation_id)
             | FilesystemStageOutcome::RetryPending { operation_id, .. }
             | FilesystemStageOutcome::AuditRequired { operation_id, .. }
             | FilesystemStageOutcome::JournalWriteFailed { operation_id, .. } => *operation_id,

--- a/src/native_app/transaction_history.rs
+++ b/src/native_app/transaction_history.rs
@@ -1,6 +1,7 @@
 mod app_state;
 mod capacity_gate;
 mod context;
+mod expected_identity_replacement;
 mod file_io;
 #[cfg(test)]
 mod generic;

--- a/src/native_app/transaction_history/app_state.rs
+++ b/src/native_app/transaction_history/app_state.rs
@@ -558,6 +558,7 @@ impl NativeAppState {
 fn operation_id_for_stage_outcome(outcome: &FilesystemStageOutcome) -> Uuid {
     match outcome {
         FilesystemStageOutcome::FilesystemStaged(operation_id)
+        | FilesystemStageOutcome::FilesystemPublished(operation_id)
         | FilesystemStageOutcome::RetryPending { operation_id, .. }
         | FilesystemStageOutcome::AuditRequired { operation_id, .. }
         | FilesystemStageOutcome::JournalWriteFailed { operation_id, .. } => *operation_id,
@@ -588,6 +589,9 @@ fn owner_staging_status(
     match outcome {
         FilesystemStageOutcome::FilesystemStaged(operation_id) => format!(
             "{verb} {label} staged (operation {operation_id}); final publication is pending"
+        ),
+        FilesystemStageOutcome::FilesystemPublished(operation_id) => format!(
+            "{verb} {label} published (operation {operation_id}); history completion is pending"
         ),
         FilesystemStageOutcome::RetryPending {
             operation_id,

--- a/src/native_app/transaction_history/expected_identity_replacement.rs
+++ b/src/native_app/transaction_history/expected_identity_replacement.rs
@@ -1,0 +1,246 @@
+//! Capability-bound seam for a future expected-identity replacement primitive.
+//!
+//! This module deliberately contains no namespace mutation.  The production adapter is
+//! fail-closed until a platform-specific implementation can prove the complete contract.
+
+use std::fs::File;
+use std::path::Path;
+
+use super::capacity_gate::VolumeIdentity;
+use super::operation_journal::{PreparedFileEvidence, PreparedObjectIdentity};
+use super::publication::{
+    PublicationSynchronization, PublicationVisibility, WholePublicationAtomicity,
+};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Handles and relative names supplied by the journal owner after all pre-attempt checks.
+///
+/// The request intentionally has no absolute mutation-authoritative pathname.  The retained
+/// target-parent, target, and staging handles are the capabilities an implementation may use;
+/// relative names are included only to describe the already-validated namespace entries.
+pub(super) struct ExpectedIdentityReplacementRequest<'a> {
+    pub(super) target_parent: &'a File,
+    pub(super) target: &'a File,
+    pub(super) staging: &'a File,
+    pub(super) target_leaf: &'a Path,
+    pub(super) staging_leaf: &'a Path,
+    pub(super) target_parent_identity: &'a PreparedObjectIdentity,
+    pub(super) expected_target: &'a PreparedObjectIdentity,
+    pub(super) staging_identity: &'a PreparedObjectIdentity,
+    pub(super) staging_content: &'a PreparedFileEvidence,
+    pub(super) volume: &'a VolumeIdentity,
+}
+
+/// A sealed result that contains all evidence needed to construct publication evidence.
+///
+/// Only adapter implementations in this module can construct this type.  In particular, the
+/// journal cannot turn a pathname, metadata-only observation, or arbitrary test fixture into a
+/// successful publication claim.
+pub(super) struct QualifiedExpectedIdentityReplacement {
+    expected_target: PreparedObjectIdentity,
+    displaced_target: PreparedObjectIdentity,
+    reopened_final: PreparedObjectIdentity,
+    reopened_content: PreparedFileEvidence,
+    visibility: PublicationVisibility,
+    whole_publication: WholePublicationAtomicity,
+    synchronization: PublicationSynchronization,
+}
+
+impl QualifiedExpectedIdentityReplacement {
+    pub(super) fn into_publication_parts(
+        self,
+    ) -> (
+        PreparedObjectIdentity,
+        PreparedObjectIdentity,
+        PreparedObjectIdentity,
+        PreparedFileEvidence,
+        PublicationVisibility,
+        WholePublicationAtomicity,
+        PublicationSynchronization,
+    ) {
+        (
+            self.expected_target,
+            self.displaced_target,
+            self.reopened_final,
+            self.reopened_content,
+            self.visibility,
+            self.whole_publication,
+            self.synchronization,
+        )
+    }
+}
+
+/// Outcome of one invocation of the expected-identity replacement seam.
+#[allow(dead_code)]
+pub(super) enum ExpectedIdentityReplacementOutcome {
+    QualifiedSuccess(QualifiedExpectedIdentityReplacement),
+    Unsupported { reason: String },
+    Drift { reason: String },
+    Ambiguous { reason: String },
+}
+
+/// Sealed capability-bound adapter contract.
+pub(super) trait ExpectedIdentityReplacementAdapter: sealed::Sealed {
+    fn attempt(
+        &self,
+        request: ExpectedIdentityReplacementRequest<'_>,
+    ) -> ExpectedIdentityReplacementOutcome;
+}
+
+/// Production adapter.  No platform replacement primitive is qualified in this slice.
+pub(super) struct ProductionExpectedIdentityReplacementAdapter;
+
+impl sealed::Sealed for ProductionExpectedIdentityReplacementAdapter {}
+
+impl ExpectedIdentityReplacementAdapter for ProductionExpectedIdentityReplacementAdapter {
+    fn attempt(
+        &self,
+        request: ExpectedIdentityReplacementRequest<'_>,
+    ) -> ExpectedIdentityReplacementOutcome {
+        let _ = (
+            request.target_parent,
+            request.target,
+            request.staging,
+            request.target_leaf,
+            request.staging_leaf,
+            request.target_parent_identity,
+            request.expected_target,
+            request.staging_identity,
+            request.staging_content,
+            request.volume,
+        );
+        ExpectedIdentityReplacementOutcome::Unsupported {
+            reason: String::from("expected-identity replacement primitive is not qualified"),
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub(super) enum TestQualifiedAdapterDrift {
+    ExpectedTarget,
+    DisplacedTarget,
+    ReopenedFinal,
+    ReopenedContent,
+    Visibility,
+    Atomicity,
+    Synchronization,
+}
+
+#[cfg(test)]
+/// Test-only adapter used to exercise the sealed adapter-to-journal evidence boundary.
+#[allow(dead_code)]
+pub(super) struct TestQualifiedExpectedIdentityReplacementAdapter {
+    pub(super) drift: Option<TestQualifiedAdapterDrift>,
+}
+
+#[cfg(test)]
+impl sealed::Sealed for TestQualifiedExpectedIdentityReplacementAdapter {}
+
+#[cfg(test)]
+impl ExpectedIdentityReplacementAdapter for TestQualifiedExpectedIdentityReplacementAdapter {
+    fn attempt(
+        &self,
+        request: ExpectedIdentityReplacementRequest<'_>,
+    ) -> ExpectedIdentityReplacementOutcome {
+        let mut qualified = QualifiedExpectedIdentityReplacement {
+            expected_target: request.expected_target.clone(),
+            displaced_target: request.expected_target.clone(),
+            reopened_final: request.staging_identity.clone(),
+            reopened_content: request.staging_content.clone(),
+            visibility: PublicationVisibility::VisibilityVerified,
+            whole_publication: WholePublicationAtomicity::WholePublicationNonAtomic,
+            synchronization: PublicationSynchronization::SyncUnsupportedOrUnverified,
+        };
+
+        match self.drift {
+            Some(TestQualifiedAdapterDrift::ExpectedTarget) => {
+                qualified.expected_target.len = qualified.expected_target.len.saturating_add(1);
+            }
+            Some(TestQualifiedAdapterDrift::DisplacedTarget) => {
+                qualified.displaced_target.len = qualified.displaced_target.len.saturating_add(1);
+            }
+            Some(TestQualifiedAdapterDrift::ReopenedFinal) => {
+                qualified.reopened_final.len = qualified.reopened_final.len.saturating_add(1);
+            }
+            Some(TestQualifiedAdapterDrift::ReopenedContent) => {
+                qualified.reopened_content = PreparedFileEvidence::ContentHash([9; 32]);
+            }
+            Some(TestQualifiedAdapterDrift::Visibility) => {
+                qualified.visibility = PublicationVisibility::VisibilityUnverified;
+            }
+            Some(TestQualifiedAdapterDrift::Atomicity) => {
+                qualified.whole_publication = WholePublicationAtomicity::WholePublicationAtomic;
+            }
+            Some(TestQualifiedAdapterDrift::Synchronization) => {
+                qualified.synchronization = PublicationSynchronization::PowerLossSynchronized;
+            }
+            None => {}
+        }
+
+        ExpectedIdentityReplacementOutcome::QualifiedSuccess(qualified)
+    }
+}
+
+#[cfg(test)]
+pub(super) fn test_qualified_success(
+    prepared: &super::operation_journal::PreparedWaveformRestore,
+    staged: &super::operation_journal::FilesystemStagedWaveformRestore,
+) -> QualifiedExpectedIdentityReplacement {
+    let super::operation_journal::FilesystemStagedParticipant::CopyValidated { staging, evidence } =
+        &staged.participant;
+    let expected_target = match &prepared.replacement {
+        super::operation_journal::ReplaceExpectedIdentity::Existing(identity) => identity.clone(),
+    };
+    QualifiedExpectedIdentityReplacement {
+        expected_target: expected_target.clone(),
+        displaced_target: expected_target,
+        reopened_final: staging.identity.clone(),
+        reopened_content: evidence.clone(),
+        visibility: PublicationVisibility::VisibilityVerified,
+        whole_publication: WholePublicationAtomicity::WholePublicationNonAtomic,
+        synchronization: PublicationSynchronization::SyncUnsupportedOrUnverified,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_adapter_is_fail_closed() {
+        let target_root = File::open(".").expect("current directory");
+        let target = target_root.try_clone().expect("target handle");
+        let staging = target_root.try_clone().expect("staging handle");
+        let root_identity = PreparedObjectIdentity {
+            stable_id: String::from("root"),
+            change_marker: None,
+            len: 0,
+        };
+        let target_identity = PreparedObjectIdentity {
+            stable_id: String::from("target"),
+            change_marker: None,
+            len: 0,
+        };
+        let request = ExpectedIdentityReplacementRequest {
+            target_parent: &target_root,
+            target: &target,
+            staging: &staging,
+            target_leaf: Path::new("target.wav"),
+            staging_leaf: Path::new("stage"),
+            target_parent_identity: &root_identity,
+            expected_target: &target_identity,
+            staging_identity: &target_identity,
+            staging_content: &PreparedFileEvidence::ContentHash([1; 32]),
+            volume: &VolumeIdentity { device: 1 },
+        };
+        assert!(matches!(
+            ProductionExpectedIdentityReplacementAdapter.attempt(request),
+            ExpectedIdentityReplacementOutcome::Unsupported { .. }
+        ));
+    }
+}

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -19,6 +19,10 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::capacity_gate::{DurableCapacityPlan, RejectedBeforeIntent, VolumeIdentity};
+use super::expected_identity_replacement::{
+    ExpectedIdentityReplacementAdapter, ExpectedIdentityReplacementOutcome,
+    ExpectedIdentityReplacementRequest, ProductionExpectedIdentityReplacementAdapter,
+};
 use super::publication::{FilesystemPublishedWaveformRestore, validate_publication_evidence};
 
 const CURRENT_SCHEMA_VERSION: u32 = 1;
@@ -490,6 +494,7 @@ pub(crate) enum PreparedOperationOutcome {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum FilesystemStageOutcome {
     FilesystemStaged(Uuid),
+    FilesystemPublished(Uuid),
     RetryPending { operation_id: Uuid, reason: String },
     AuditRequired { operation_id: Uuid, reason: String },
     JournalWriteFailed { operation_id: Uuid, reason: String },
@@ -1090,6 +1095,18 @@ fn clean_relative_path(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn single_clean_normal_leaf<'a>(label: &str, path: &'a Path) -> Result<&'a Path, String> {
+    clean_relative_path(path)?;
+    let mut components = path.components();
+    let Some(std::path::Component::Normal(component)) = components.next() else {
+        return Err(format!("{label} locator is not a single clean normal leaf"));
+    };
+    if components.next().is_some() || Path::new(component) != path {
+        return Err(format!("{label} locator is not a single clean normal leaf"));
+    }
+    Ok(path)
+}
+
 fn descriptor_identity(file: &File) -> Result<PreparedObjectIdentity, String> {
     let metadata = file.metadata().map_err(|error| error.to_string())?;
     let stable_id =
@@ -1295,6 +1312,30 @@ fn validate_identity(
     }
 }
 
+fn validate_root_identity(
+    label: &str,
+    expected: &PreparedObjectIdentity,
+    actual: &PreparedObjectIdentity,
+) -> Result<(), String> {
+    if expected.stable_id == actual.stable_id {
+        Ok(())
+    } else {
+        Err(format!("{label} identity changed since preparation"))
+    }
+}
+
+fn validate_volume_identity(
+    label: &str,
+    expected: &VolumeIdentity,
+    actual: &VolumeIdentity,
+) -> Result<(), String> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(format!("{label} volume identity changed since staging"))
+    }
+}
+
 fn validate_evidence(
     label: &str,
     expected: &PreparedFileEvidence,
@@ -1394,6 +1435,17 @@ struct ReacquiredPreparedRestore {
     backup: File,
 }
 
+struct ReacquiredStagedRestore {
+    target_parent: File,
+    target: File,
+    staging: File,
+    target_parent_identity: PreparedObjectIdentity,
+    target_identity: PreparedObjectIdentity,
+    staging_identity: PreparedObjectIdentity,
+    staging_content: PreparedFileEvidence,
+    volume: VolumeIdentity,
+}
+
 fn reacquire_prepared_restore(
     prepared: &PreparedWaveformRestore,
 ) -> Result<ReacquiredPreparedRestore, String> {
@@ -1451,6 +1503,83 @@ fn reacquire_prepared_restore(
         backup_root,
         target,
         backup,
+    })
+}
+
+fn reacquire_staged_restore(
+    prepared: &PreparedWaveformRestore,
+    staged: &FilesystemStagedWaveformRestore,
+    capacity_plan: &DurableCapacityPlan,
+) -> Result<ReacquiredStagedRestore, String> {
+    let FilesystemStagedParticipant::CopyValidated {
+        staging: expected_staging,
+        evidence: expected_staging_content,
+    } = &staged.participant;
+    validate_staged_checkpoint(prepared, staged)?;
+    let target_leaf =
+        single_clean_normal_leaf("target", &prepared.target.relative_path)?;
+    let staging_leaf =
+        single_clean_normal_leaf("staging", &prepared.staging.relative_path)?;
+    let [volume] = capacity_plan.volumes.as_slice() else {
+        return Err(String::from("capacity claim has unexpected volumes"));
+    };
+
+    let (target_root, target_root_capability) = open_root(&prepared.target_root.path)?;
+    validate_root_identity(
+        "target root",
+        &prepared.target_root.identity,
+        &target_root_capability.identity,
+    )?;
+    let target_parent = target_root
+        .try_clone()
+        .map_err(|error| format!("could not retain target parent capability: {error}"))?;
+    let target_display = prepared
+        .target_root
+        .path
+        .join(target_leaf);
+    let (target, target_identity) = open_leaf_relative(
+        &target_parent,
+        target_leaf,
+        &target_display,
+    )?;
+    validate_identity("target leaf", &prepared.target.identity, &target_identity)?;
+    validate_evidence(
+        "target leaf",
+        &prepared.evidence.target,
+        &prepared_file_evidence(&target),
+    )?;
+    let target_volume = super::capacity_gate::descriptor_capacity_facts(&target)
+        .map_err(|error| error.to_string())?
+        .identity;
+    validate_volume_identity("target", &volume.identity, &target_volume)?;
+
+    let staging_display = prepared
+        .target_root
+        .path
+        .join(staging_leaf);
+    let (staging, staging_identity) = open_staging_relative(
+        &target_parent,
+        staging_leaf,
+        &staging_display,
+    )?;
+    let staging_volume = super::capacity_gate::descriptor_capacity_facts(&staging)
+        .map_err(|error| error.to_string())?
+        .identity;
+    validate_volume_identity("staging", &volume.identity, &staging_volume)?;
+    validate_identity("staging", &expected_staging.identity, &staging_identity)?;
+    let staging_content = prepared_file_evidence(&staging);
+    validate_evidence("staging", expected_staging_content, &staging_content)?;
+    validate_staged_evidence(&prepared.evidence.backup, &staging_content)?;
+
+    Ok(ReacquiredStagedRestore {
+        target_parent,
+        target,
+        staging,
+        target_parent_identity: target_root_capability.identity,
+        target_identity,
+        staging_identity,
+        staging_content,
+        volume: volume.identity.clone(),
     })
 }
 
@@ -2001,6 +2130,141 @@ impl OperationJournalCoordinator {
         }
     }
 
+    /// Attempt publication of one already-staged restore through the sealed adapter seam.
+    ///
+    /// The production adapter is intentionally unsupported in this slice, so this method cannot
+    /// mutate the target namespace.  A test-only adapter exercises the same guarded evidence
+    /// path without standing in for a platform qualification.
+    pub(crate) fn attempt_publish_staged_waveform_restore(
+        &mut self,
+        operation_id: Uuid,
+    ) -> Result<FilesystemStageOutcome, JournalError> {
+        self.attempt_publish_staged_waveform_restore_with_adapter(
+            operation_id,
+            &ProductionExpectedIdentityReplacementAdapter,
+        )
+    }
+
+    fn attempt_publish_staged_waveform_restore_with_adapter<A>(
+        &mut self,
+        operation_id: Uuid,
+        adapter: &A,
+    ) -> Result<FilesystemStageOutcome, JournalError>
+    where
+        A: ExpectedIdentityReplacementAdapter,
+    {
+        let record = self
+            .store
+            .record(operation_id)
+            .ok_or(JournalError::NotFound(operation_id))?;
+        if record.phase != OperationPhase::FilesystemStaged {
+            return Err(JournalError::IllegalTransition {
+                operation_id,
+                from: record.phase,
+                to: OperationPhase::FilesystemPublished,
+            });
+        }
+        let prepared = record
+            .prepared
+            .clone()
+            .ok_or(JournalError::MissingPreparedEvidence(operation_id))?;
+        let staged = record
+            .staged
+            .clone()
+            .ok_or(JournalError::MissingPreparedEvidence(operation_id))?;
+        let capacity_plan = record
+            .capacity_plan
+            .clone()
+            .ok_or(JournalError::MissingPreparedEvidence(operation_id))?;
+
+        let reacquired = match reacquire_staged_restore(&prepared, &staged, &capacity_plan) {
+            Ok(reacquired) => reacquired,
+            Err(reason) => return self.attempt_retry_or_audit(operation_id, reason),
+        };
+        let request = ExpectedIdentityReplacementRequest {
+            target_parent: &reacquired.target_parent,
+            target: &reacquired.target,
+            staging: &reacquired.staging,
+            target_leaf: &prepared.target.relative_path,
+            staging_leaf: &prepared.staging.relative_path,
+            target_parent_identity: &reacquired.target_parent_identity,
+            expected_target: &reacquired.target_identity,
+            staging_identity: &reacquired.staging_identity,
+            staging_content: &reacquired.staging_content,
+            volume: &reacquired.volume,
+        };
+        match adapter.attempt(request) {
+            ExpectedIdentityReplacementOutcome::Unsupported { reason } => self
+                .update_attempt_disposition(
+                    operation_id,
+                    OperationDisposition::RetryPending,
+                    reason,
+                ),
+            ExpectedIdentityReplacementOutcome::Drift { reason }
+            | ExpectedIdentityReplacementOutcome::Ambiguous { reason } => self
+                .update_attempt_disposition(
+                    operation_id,
+                    OperationDisposition::AuditRequired,
+                    reason,
+                ),
+            ExpectedIdentityReplacementOutcome::QualifiedSuccess(qualified) => {
+                let published = super::publication::from_qualified_adapter_result(qualified);
+                if let Err(reason) = validate_publication_evidence(&prepared, &staged, &published) {
+                    return self.update_attempt_disposition(
+                        operation_id,
+                        OperationDisposition::AuditRequired,
+                        reason,
+                    );
+                }
+                match self.store.guarded_publish(operation_id, published) {
+                    Ok(()) => Ok(FilesystemStageOutcome::FilesystemPublished(operation_id)),
+                    Err(error) => Ok(FilesystemStageOutcome::JournalWriteFailed {
+                        operation_id,
+                        reason: error.to_string(),
+                    }),
+                }
+            }
+        }
+    }
+
+    fn update_attempt_disposition(
+        &mut self,
+        operation_id: Uuid,
+        disposition: OperationDisposition,
+        reason: String,
+    ) -> Result<FilesystemStageOutcome, JournalError> {
+        match self
+            .store
+            .update(operation_id, OperationPhase::FilesystemStaged, disposition)
+        {
+            Ok(()) => {
+                if disposition == OperationDisposition::RetryPending {
+                    Ok(FilesystemStageOutcome::RetryPending {
+                        operation_id,
+                        reason,
+                    })
+                } else {
+                    Ok(FilesystemStageOutcome::AuditRequired {
+                        operation_id,
+                        reason,
+                    })
+                }
+            }
+            Err(error) => Ok(FilesystemStageOutcome::JournalWriteFailed {
+                operation_id,
+                reason: error.to_string(),
+            }),
+        }
+    }
+
+    fn attempt_retry_or_audit(
+        &mut self,
+        operation_id: Uuid,
+        reason: String,
+    ) -> Result<FilesystemStageOutcome, JournalError> {
+        self.update_attempt_disposition(operation_id, OperationDisposition::AuditRequired, reason)
+    }
+
     /// Advance a staged waveform restore only with typed, validated publication evidence.
     /// This records evidence; it deliberately does not perform the publication primitive.
     pub(crate) fn guarded_publish(
@@ -2108,8 +2372,8 @@ impl OwnershipLock {
             use std::os::windows::fs::OpenOptionsExt;
             use std::os::windows::io::AsRawHandle;
             use windows::Win32::Storage::FileSystem::{
-                FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
-                LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
+                LockFileEx, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
+                LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
             };
             use windows::Win32::System::IO::OVERLAPPED;
 
@@ -2239,10 +2503,10 @@ fn atomic_durable_write(path: &Path, record: &OperationRecord) -> Result<(), Jou
 fn replace_file(temp_path: &Path, path: &Path) -> io::Result<()> {
     #[cfg(target_os = "windows")]
     {
-        use windows::Win32::Storage::FileSystem::{
-            MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
-        };
         use windows::core::PCWSTR;
+        use windows::Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        };
         fn wide(path: &Path) -> Vec<u16> {
             use std::os::windows::ffi::OsStrExt;
             path.as_os_str()
@@ -2616,6 +2880,173 @@ mod tests {
             Some(FilesystemStagedParticipant::CopyValidated { .. })
         ));
         assert_eq!(fs::read(&staging).unwrap(), fs::read(&backup).unwrap());
+    }
+
+    #[test]
+    fn production_publication_adapter_is_unsupported_without_namespace_mutation() {
+        let (journal_dir, _files, mut journal, id, backup, target, staging) =
+            prepared_restore_fixture();
+        journal
+            .stage_admitted_bounded_waveform_restore(id)
+            .expect("stage restore");
+        let target_before = fs::read(&target).unwrap();
+        let staging_before = fs::read(&staging).unwrap();
+        let names_before = fs::read_dir(target.parent().unwrap())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        let claims_before = journal.store.capacity_claims().clone();
+
+        assert!(matches!(
+            journal
+                .attempt_publish_staged_waveform_restore(id)
+                .expect("publication attempt"),
+            FilesystemStageOutcome::RetryPending { operation_id, .. } if operation_id == id
+        ));
+        let record = journal.record(id).unwrap();
+        assert_eq!(record.phase, OperationPhase::FilesystemStaged);
+        assert_eq!(record.disposition, OperationDisposition::RetryPending);
+        assert!(record.staged.is_some());
+        assert_eq!(journal.store.capacity_claims(), &claims_before);
+        assert_eq!(fs::read(&backup).unwrap(), vec![7_u8; 4097]);
+        assert_eq!(fs::read(&target).unwrap(), target_before);
+        assert_eq!(fs::read(&staging).unwrap(), staging_before);
+        assert_eq!(
+            fs::read_dir(target.parent().unwrap())
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name())
+                .collect::<Vec<_>>(),
+            names_before
+        );
+
+        drop(journal);
+        let reopened = OperationJournalCoordinator::open(journal_dir.path().to_path_buf()).unwrap();
+        let reopened_record = reopened.record(id).unwrap();
+        assert_eq!(reopened_record.phase, OperationPhase::FilesystemStaged);
+        assert_eq!(
+            reopened_record.disposition,
+            OperationDisposition::RetryPending
+        );
+        assert_eq!(reopened.store.capacity_claims(), &claims_before);
+    }
+
+    #[test]
+    fn nested_target_locator_is_rejected_before_qualified_adapter_and_preserves_recoverable_stage() {
+        let (journal_dir, _files, mut journal, id, _backup, target, staging) =
+            prepared_restore_fixture();
+        journal
+            .stage_admitted_bounded_waveform_restore(id)
+            .expect("stage restore");
+        let target_before = fs::read(&target).unwrap();
+        let staging_before = fs::read(&staging).unwrap();
+        let record = {
+            let record = journal.store.records.get_mut(&id).unwrap();
+            record.prepared.as_mut().unwrap().target.relative_path =
+                PathBuf::from("nested/target.wav");
+            record.clone()
+        };
+        let record_path = journal.store.record_path(id);
+        atomic_durable_write(&record_path, &record).unwrap();
+
+        let adapter = super::super::expected_identity_replacement::
+            TestQualifiedExpectedIdentityReplacementAdapter { drift: None };
+        assert!(matches!(
+            journal
+                .attempt_publish_staged_waveform_restore_with_adapter(id, &adapter)
+                .expect("nested target attempt"),
+            FilesystemStageOutcome::AuditRequired { operation_id, .. } if operation_id == id
+        ));
+
+        let record = journal.record(id).unwrap();
+        assert_eq!(record.phase, OperationPhase::FilesystemStaged);
+        assert_eq!(record.disposition, OperationDisposition::AuditRequired);
+        assert!(record.staged.is_some());
+        assert_eq!(fs::read(&target).unwrap(), target_before);
+        assert_eq!(fs::read(&staging).unwrap(), staging_before);
+
+        drop(journal);
+        let reopened = OperationJournalCoordinator::open(journal_dir.path().to_path_buf()).unwrap();
+        let reopened_record = reopened.record(id).unwrap();
+        assert_eq!(reopened_record.phase, OperationPhase::FilesystemStaged);
+        assert_eq!(reopened_record.disposition, OperationDisposition::AuditRequired);
+        assert!(reopened_record.staged.is_some());
+        assert_eq!(
+            reopened_record
+                .prepared
+                .as_ref()
+                .unwrap()
+                .target
+                .relative_path,
+            PathBuf::from("nested/target.wav")
+        );
+        assert_eq!(fs::read(&target).unwrap(), target_before);
+        assert_eq!(fs::read(&staging).unwrap(), staging_before);
+    }
+
+    #[test]
+    fn live_volume_identity_guard_rejects_mismatch() {
+        let expected = VolumeIdentity { device: 1 };
+        let actual = VolumeIdentity { device: 2 };
+        assert!(validate_volume_identity("target", &expected, &actual).is_err());
+        assert!(validate_volume_identity("target", &expected, &expected).is_ok());
+    }
+
+    #[test]
+    fn qualified_test_adapter_is_the_only_path_to_guarded_publication() {
+        let (journal_dir, _files, mut journal, id, _backup, target, staging) =
+            prepared_restore_fixture();
+        journal
+            .stage_admitted_bounded_waveform_restore(id)
+            .expect("stage restore");
+        let claims_before = journal.store.capacity_claims().clone();
+        let adapter = super::super::expected_identity_replacement::
+            TestQualifiedExpectedIdentityReplacementAdapter { drift: None };
+
+        assert_eq!(
+            journal
+                .attempt_publish_staged_waveform_restore_with_adapter(id, &adapter)
+                .expect("qualified publication attempt"),
+            FilesystemStageOutcome::FilesystemPublished(id)
+        );
+        let record = journal.record(id).unwrap();
+        assert_eq!(record.phase, OperationPhase::FilesystemPublished);
+        assert_eq!(record.disposition, OperationDisposition::None);
+        assert!(record.published.is_some());
+        assert_eq!(journal.store.capacity_claims(), &claims_before);
+        assert_eq!(fs::read(&target).unwrap(), vec![0_u8; 4097]);
+        assert_eq!(fs::read(&staging).unwrap(), vec![7_u8; 4097]);
+
+        drop(journal);
+        let reopened = OperationJournalCoordinator::open(journal_dir.path().to_path_buf()).unwrap();
+        let reopened_record = reopened.record(id).unwrap();
+        assert_eq!(reopened_record.phase, OperationPhase::FilesystemPublished);
+        assert!(reopened_record.published.is_some());
+        assert_eq!(reopened.store.capacity_claims(), &claims_before);
+    }
+
+    #[test]
+    fn target_drift_blocks_adapter_and_preserves_staged_restore() {
+        let (_journal_dir, _files, mut journal, id, _backup, target, staging) =
+            prepared_restore_fixture();
+        journal
+            .stage_admitted_bounded_waveform_restore(id)
+            .expect("stage restore");
+        let staging_before = fs::read(&staging).unwrap();
+        fs::write(&target, vec![9_u8; 4097]).unwrap();
+        let adapter = super::super::expected_identity_replacement::
+            TestQualifiedExpectedIdentityReplacementAdapter { drift: None };
+
+        assert!(matches!(
+            journal
+                .attempt_publish_staged_waveform_restore_with_adapter(id, &adapter)
+                .expect("drift attempt"),
+            FilesystemStageOutcome::AuditRequired { operation_id, .. } if operation_id == id
+        ));
+        let record = journal.record(id).unwrap();
+        assert_eq!(record.phase, OperationPhase::FilesystemStaged);
+        assert_eq!(record.disposition, OperationDisposition::AuditRequired);
+        assert_eq!(fs::read(&target).unwrap(), vec![9_u8; 4097]);
+        assert_eq!(fs::read(&staging).unwrap(), staging_before);
     }
 
     #[test]
@@ -3423,10 +3854,8 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(before, after);
-        assert!(
-            before
-                .iter()
-                .any(|(name, _)| name.to_string_lossy() == format!("{id}.json"))
-        );
+        assert!(before
+            .iter()
+            .any(|(name, _)| name.to_string_lossy() == format!("{id}.json")));
     }
 }

--- a/src/native_app/transaction_history/publication.rs
+++ b/src/native_app/transaction_history/publication.rs
@@ -6,6 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::expected_identity_replacement::QualifiedExpectedIdentityReplacement;
 use super::operation_journal::{
     FilesystemStagedParticipant, FilesystemStagedWaveformRestore, PreparedFileEvidence,
     PreparedObjectIdentity, PreparedWaveformRestore, ReplaceExpectedIdentity,
@@ -91,6 +92,37 @@ pub(crate) struct FilesystemPublishedWaveformRestore {
     visibility: PublicationVisibility,
     whole_publication: WholePublicationAtomicity,
     synchronization: PublicationSynchronization,
+}
+
+/// Construct publication evidence only from a sealed, qualified adapter result.
+pub(super) fn from_qualified_adapter_result(
+    qualified: QualifiedExpectedIdentityReplacement,
+) -> FilesystemPublishedWaveformRestore {
+    let (
+        expected_target,
+        displaced_target,
+        reopened_final,
+        reopened_content,
+        visibility,
+        whole_publication,
+        synchronization,
+    ) = qualified.into_publication_parts();
+    FilesystemPublishedWaveformRestore {
+        mode: FilesystemPublicationMode::NonAtomicCopyValidatePublish,
+        final_claim: FinalNamespaceClaim::ExpectedIdentityReplacement {
+            primitive: FinalClaimPrimitive::QualifiedExpectedIdentityReplacement,
+            result: FinalClaimResult::ExpectedIdentityReplaced,
+            expected_target,
+            displaced_target,
+        },
+        reopened_final: ReopenedFinalEvidence {
+            identity: reopened_final,
+            content: reopened_content,
+        },
+        visibility,
+        whole_publication,
+        synchronization,
+    }
 }
 
 /// Validate publication evidence without inferring anything from a pathname or touching the
@@ -230,26 +262,9 @@ pub(crate) fn test_publication_evidence(
     staged: &FilesystemStagedWaveformRestore,
     drift: Option<TestPublicationDrift>,
 ) -> FilesystemPublishedWaveformRestore {
-    let FilesystemStagedParticipant::CopyValidated { staging, evidence } = &staged.participant;
-    let expected_target = match &prepared.replacement {
-        ReplaceExpectedIdentity::Existing(identity) => identity.clone(),
-    };
-    let mut publication = FilesystemPublishedWaveformRestore {
-        mode: FilesystemPublicationMode::NonAtomicCopyValidatePublish,
-        final_claim: FinalNamespaceClaim::ExpectedIdentityReplacement {
-            primitive: FinalClaimPrimitive::QualifiedExpectedIdentityReplacement,
-            result: FinalClaimResult::ExpectedIdentityReplaced,
-            expected_target: expected_target.clone(),
-            displaced_target: expected_target,
-        },
-        reopened_final: ReopenedFinalEvidence {
-            identity: staging.identity.clone(),
-            content: evidence.clone(),
-        },
-        visibility: PublicationVisibility::VisibilityVerified,
-        whole_publication: WholePublicationAtomicity::WholePublicationNonAtomic,
-        synchronization: PublicationSynchronization::SyncUnsupportedOrUnverified,
-    };
+    let FilesystemStagedParticipant::CopyValidated { staging, .. } = &staged.participant;
+    let qualified = super::expected_identity_replacement::test_qualified_success(prepared, staged);
+    let mut publication = from_qualified_adapter_result(qualified);
 
     match drift {
         Some(TestPublicationDrift::UnqualifiedReplacement) => {


### PR DESCRIPTION
## Goal

Add the next bounded Wavecrate I/O target-alignment boundary after PR #1003: a sealed, capability-bound expected-identity replacement adapter seam for already-staged non-extracted waveform restores.

## Scope and non-goals

- Reacquire verified no-follow root, target-parent, target, and staging capabilities after durable `CopyValidated`.
- Validate clean single-leaf containment, expected identities/content, and live target/staging volume identities.
- Route production publication through an explicitly unsupported fail-closed adapter that leaves the target namespace unchanged and durably records `FilesystemStaged + RetryPending`.
- Keep qualified publication evidence opaque to sibling modules and admit it only through the existing guarded publication transition.
- Add nested-target, volume-guard, drift, retention, owner-flow, and compatibility regression coverage.

Non-goals: real macOS/Windows replacement primitives; rename/swap/pathname fallbacks; cleanup/rollback; source/global reconciliation; watcher/projection/readiness/reload work; schema or migration changes; extracted/folder operations; dependency, documentation, or Radiant changes.

## Definition of Done

- Unsafe or unsupported publication cannot mutate the final namespace.
- Target/staging/root drift or unproven containment/volume identity preserves evidence and leaves the operation recoverable with `AuditRequired`.
- Unsupported production execution retains the staged payload, capacity claim, journal record, operation identity, and in-flight history with `RetryPending`.
- Only an opaque adapter-produced qualified result can reach `FilesystemPublished`; publication does not complete history reconciliation.
- Existing legacy recovery, stale/duplicate completion fencing, and unrelated transaction behavior remain intact.

## Validation

- `RUSTFLAGS="-A unused-imports" cargo test -p wavecrate --lib native_app::transaction_history::operation_journal::tests --no-default-features -- --nocapture` — 37 passed
- `RUSTFLAGS="-A unused-imports" cargo test -p wavecrate --lib native_app::transaction_history::expected_identity_replacement::tests --no-default-features -- --nocapture` — 1 passed
- `RUSTFLAGS="-A unused-imports" cargo test -p wavecrate --lib native_app::transaction_history::publication::tests --no-default-features -- --nocapture` — 1 passed
- `RUSTFLAGS="-A unused-imports" cargo test -p wavecrate --lib native_app::app::state::journal::tests --no-default-features -- --nocapture` — 9 passed
- `RUSTFLAGS="-A unused-imports" cargo test -p wavecrate --lib native_app::tests::transactions --no-default-features -- --nocapture` — 23 passed
- `RUSTFLAGS="-A unused-imports" cargo check -p wavecrate --lib --locked --no-default-features` — passed
- `rustfmt --edition 2024 --check src/native_app/transaction_history/expected_identity_replacement.rs` — passed
- `git diff --check` — passed

Independent Terra review: APPROVE; no required findings.

## Known limitations

The production adapter intentionally does not perform final-file replacement. Platform-specific compare-by-identity replacement, crash semantics during that primitive, and subsequent source/global/projection reconciliation remain unqualified and deferred. Terra’s non-blocking observation is to add an injectable descriptor-facts test seam when a real platform adapter is introduced.

## Next architecture task

Design and qualify the macOS expected-identity replacement primitive through a verified directory capability, or revise the destructive-edit publication protocol if the platform cannot prove the required compare-by-identity semantics. Do not approximate it with swap-plus-check.

User approval is required before merge.