### PR TITLE
Persist expected-identity qualification evidence

### DIFF
--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -959,8 +959,10 @@ mod tests {
             .expect("prepare and stage result")
             .expect("prepare and stage")
         {
-            FilesystemStageOutcome::RetryPending { operation_id, .. } => operation_id,
-            other => panic!("expected retry-pending outcome, got {other:?}"),
+            FilesystemStageOutcome::PlatformQualificationRequired { operation_id, .. } => {
+                operation_id
+            }
+            other => panic!("expected platform-qualification outcome, got {other:?}"),
         };
         assert_eq!(
             std::fs::read(&target).expect("target after staging"),

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -1,7 +1,12 @@
 use super::gui_state_for_span_tests;
 use crate::native_app::app::{OperationJournalRestoreCompletion, OperationJournalRestoreError};
 use crate::native_app::sample_library::committed_file_mutations::PreparedCommittedFileMutationChange;
-use crate::native_app::transaction_history::operation_journal::FilesystemStageOutcome;
+use crate::native_app::transaction_history::operation_journal::{
+    FilesystemStageOutcome, ObservedFilesystemClassification, ReplacementCandidateAssessment,
+    ReplacementCandidatePrimitive, ReplacementMissingInvariant, ReplacementPlatformFamily,
+    ReplacementQualificationAssessment, ReplacementQualificationDecision,
+    ReplacementQualificationRetryCondition, VolumeIdentity,
+};
 use crate::native_app::transaction_history::{
     HistoryFileAction, HistoryFileIoDirection, HistoryFileIoOutput, HistoryFileIoResult,
 };
@@ -74,11 +79,29 @@ fn begin_owner_restore_for_tests(
         .expect("owner restore command")
 }
 
+fn platform_qualification_assessment_for_tests() -> ReplacementQualificationAssessment {
+    ReplacementQualificationAssessment {
+        platform_family: ReplacementPlatformFamily::Other,
+        observed_filesystem: ObservedFilesystemClassification::Unavailable,
+        volume: VolumeIdentity { device: 1 },
+        candidate: ReplacementCandidatePrimitive::NoPublicCandidate,
+        candidate_assessment: ReplacementCandidateAssessment::NoQualifiedCandidate,
+        missing_invariant: ReplacementMissingInvariant::AtomicExpectedTargetIdentityComparison,
+        decision: ReplacementQualificationDecision::PlatformQualificationRequired,
+        retry_condition:
+            ReplacementQualificationRetryCondition::PlatformBuildOrQualificationPolicyChange,
+    }
+}
+
 #[test]
 fn owner_staging_outcomes_retain_history_and_operation_identity() {
     let outcomes = [
         FilesystemStageOutcome::FilesystemStaged(Uuid::new_v4()),
         FilesystemStageOutcome::FilesystemPublished(Uuid::new_v4()),
+        FilesystemStageOutcome::PlatformQualificationRequired {
+            operation_id: Uuid::new_v4(),
+            assessment: platform_qualification_assessment_for_tests(),
+        },
         FilesystemStageOutcome::RetryPending {
             operation_id: Uuid::new_v4(),
             reason: String::from("staging collision"),
@@ -95,9 +118,14 @@ fn owner_staging_outcomes_retain_history_and_operation_identity() {
     for outcome in outcomes {
         let mut state = gui_state_for_span_tests();
         let command = begin_owner_restore_for_tests(&mut state);
+        let is_platform_qualification = matches!(
+            &outcome,
+            FilesystemStageOutcome::PlatformQualificationRequired { .. }
+        );
         let operation_id = match &outcome {
             FilesystemStageOutcome::FilesystemStaged(operation_id)
             | FilesystemStageOutcome::FilesystemPublished(operation_id)
+            | FilesystemStageOutcome::PlatformQualificationRequired { operation_id, .. }
             | FilesystemStageOutcome::RetryPending { operation_id, .. }
             | FilesystemStageOutcome::AuditRequired { operation_id, .. }
             | FilesystemStageOutcome::JournalWriteFailed { operation_id, .. } => *operation_id,
@@ -124,6 +152,18 @@ fn owner_staging_outcomes_retain_history_and_operation_identity() {
         assert!(!state.transactions.history.can_redo());
         assert_eq!(state.transactions.history_through_count, 0);
         assert!(state.ui.status.sample.contains(&operation_id.to_string()));
+        if is_platform_qualification {
+            assert!(state
+                .ui
+                .status
+                .sample
+                .contains("safe replacement unavailable on the current platform/build"));
+            assert!(state
+                .ui
+                .status
+                .sample
+                .contains("staged recovery data preserved"));
+        }
     }
 }
 

--- a/src/native_app/transaction_history/app_state.rs
+++ b/src/native_app/transaction_history/app_state.rs
@@ -559,6 +559,7 @@ fn operation_id_for_stage_outcome(outcome: &FilesystemStageOutcome) -> Uuid {
     match outcome {
         FilesystemStageOutcome::FilesystemStaged(operation_id)
         | FilesystemStageOutcome::FilesystemPublished(operation_id)
+        | FilesystemStageOutcome::PlatformQualificationRequired { operation_id, .. }
         | FilesystemStageOutcome::RetryPending { operation_id, .. }
         | FilesystemStageOutcome::AuditRequired { operation_id, .. }
         | FilesystemStageOutcome::JournalWriteFailed { operation_id, .. } => *operation_id,
@@ -592,6 +593,9 @@ fn owner_staging_status(
         ),
         FilesystemStageOutcome::FilesystemPublished(operation_id) => format!(
             "{verb} {label} published (operation {operation_id}); history completion is pending"
+        ),
+        FilesystemStageOutcome::PlatformQualificationRequired { operation_id, .. } => format!(
+            "{verb} {label}: safe replacement unavailable on the current platform/build (operation {operation_id}); staged recovery data preserved; retry requires platform/build or qualification-policy requalification"
         ),
         FilesystemStageOutcome::RetryPending {
             operation_id,

--- a/src/native_app/transaction_history/expected_identity_replacement.rs
+++ b/src/native_app/transaction_history/expected_identity_replacement.rs
@@ -6,6 +6,8 @@
 use std::fs::File;
 use std::path::Path;
 
+use serde::{Deserialize, Serialize};
+
 use super::capacity_gate::VolumeIdentity;
 use super::operation_journal::{PreparedFileEvidence, PreparedObjectIdentity};
 use super::publication::{
@@ -14,6 +16,127 @@ use super::publication::{
 
 mod sealed {
     pub trait Sealed {}
+}
+
+/// Stable platform family recorded with a replacement qualification assessment.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReplacementPlatformFamily {
+    Macos,
+    Windows,
+    Linux,
+    Other,
+}
+
+impl ReplacementPlatformFamily {
+    fn current() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            return Self::Macos;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            return Self::Windows;
+        }
+        #[cfg(target_os = "linux")]
+        {
+            return Self::Linux;
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+        {
+            Self::Other
+        }
+    }
+}
+
+/// Bounded filesystem relationship observed before the read-only assessment.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ObservedFilesystemClassification {
+    SameVolume,
+    DifferentVolume,
+    Unavailable,
+}
+
+/// Public candidate primitive considered by the current platform/build.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReplacementCandidatePrimitive {
+    MacosRenameAtxNpRenameExcl,
+    MacosRenameAtxNpRenameSwap,
+    NoPublicCandidate,
+}
+
+/// Semantic result of assessing a candidate without invoking it.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReplacementCandidateAssessment {
+    AbsentFinalOnly,
+    SwapWithoutExpectedTargetIdentityOperand,
+    NoQualifiedCandidate,
+}
+
+/// Stable invariant code explaining why expected-identity replacement is not qualified.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReplacementMissingInvariant {
+    AtomicExpectedTargetIdentityComparison,
+}
+
+/// Stable decision recorded for an unsupported expected-identity replacement assessment.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReplacementQualificationDecision {
+    PlatformQualificationRequired,
+}
+
+/// Stable condition under which a later attempt may reassess the platform boundary.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReplacementQualificationRetryCondition {
+    PlatformBuildOrQualificationPolicyChange,
+}
+
+/// Latest bounded evidence explaining an unsupported replacement assessment.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct ReplacementQualificationAssessment {
+    pub(crate) platform_family: ReplacementPlatformFamily,
+    pub(crate) observed_filesystem: ObservedFilesystemClassification,
+    pub(crate) volume: VolumeIdentity,
+    pub(crate) candidate: ReplacementCandidatePrimitive,
+    pub(crate) candidate_assessment: ReplacementCandidateAssessment,
+    pub(crate) missing_invariant: ReplacementMissingInvariant,
+    pub(crate) decision: ReplacementQualificationDecision,
+    pub(crate) retry_condition: ReplacementQualificationRetryCondition,
+}
+
+fn classify_candidate(
+    platform_family: ReplacementPlatformFamily,
+    observed_filesystem: ObservedFilesystemClassification,
+    volume: &VolumeIdentity,
+    candidate: ReplacementCandidatePrimitive,
+) -> ReplacementQualificationAssessment {
+    let candidate_assessment = match candidate {
+        ReplacementCandidatePrimitive::MacosRenameAtxNpRenameExcl => {
+            ReplacementCandidateAssessment::AbsentFinalOnly
+        }
+        ReplacementCandidatePrimitive::MacosRenameAtxNpRenameSwap => {
+            ReplacementCandidateAssessment::SwapWithoutExpectedTargetIdentityOperand
+        }
+        ReplacementCandidatePrimitive::NoPublicCandidate => {
+            ReplacementCandidateAssessment::NoQualifiedCandidate
+        }
+    };
+    ReplacementQualificationAssessment {
+        platform_family,
+        observed_filesystem,
+        volume: volume.clone(),
+        candidate,
+        candidate_assessment,
+        missing_invariant: ReplacementMissingInvariant::AtomicExpectedTargetIdentityComparison,
+        decision: ReplacementQualificationDecision::PlatformQualificationRequired,
+        retry_condition: ReplacementQualificationRetryCondition::PlatformBuildOrQualificationPolicyChange,
+    }
 }
 
 /// Handles and relative names supplied by the journal owner after all pre-attempt checks.
@@ -77,7 +200,9 @@ impl QualifiedExpectedIdentityReplacement {
 #[allow(dead_code)]
 pub(super) enum ExpectedIdentityReplacementOutcome {
     QualifiedSuccess(QualifiedExpectedIdentityReplacement),
-    Unsupported { reason: String },
+    PlatformQualificationRequired {
+        assessment: ReplacementQualificationAssessment,
+    },
     Drift { reason: String },
     Ambiguous { reason: String },
 }
@@ -90,7 +215,8 @@ pub(super) trait ExpectedIdentityReplacementAdapter: sealed::Sealed {
     ) -> ExpectedIdentityReplacementOutcome;
 }
 
-/// Production adapter.  No platform replacement primitive is qualified in this slice.
+/// Production adapter.  Assessment is read-only; no platform replacement primitive is qualified
+/// in this slice.
 pub(super) struct ProductionExpectedIdentityReplacementAdapter;
 
 impl sealed::Sealed for ProductionExpectedIdentityReplacementAdapter {}
@@ -100,6 +226,18 @@ impl ExpectedIdentityReplacementAdapter for ProductionExpectedIdentityReplacemen
         &self,
         request: ExpectedIdentityReplacementRequest<'_>,
     ) -> ExpectedIdentityReplacementOutcome {
+        let assessment = classify_candidate(
+            ReplacementPlatformFamily::current(),
+            // The journal has already validated the target, staging, and capacity facts against
+            // one descriptor-derived volume identity.  This is an observation, not a filesystem
+            // capability or qualification claim.
+            ObservedFilesystemClassification::SameVolume,
+            request.volume,
+            #[cfg(target_os = "macos")]
+            ReplacementCandidatePrimitive::MacosRenameAtxNpRenameSwap,
+            #[cfg(not(target_os = "macos"))]
+            ReplacementCandidatePrimitive::NoPublicCandidate,
+        );
         let _ = (
             request.target_parent,
             request.target,
@@ -110,12 +248,48 @@ impl ExpectedIdentityReplacementAdapter for ProductionExpectedIdentityReplacemen
             request.expected_target,
             request.staging_identity,
             request.staging_content,
-            request.volume,
         );
-        ExpectedIdentityReplacementOutcome::Unsupported {
-            reason: String::from("expected-identity replacement primitive is not qualified"),
-        }
+        ExpectedIdentityReplacementOutcome::PlatformQualificationRequired { assessment }
     }
+}
+
+#[cfg(test)]
+fn production_assessment_for_test(
+    filesystem: ObservedFilesystemClassification,
+    candidate: ReplacementCandidatePrimitive,
+) -> ReplacementQualificationAssessment {
+    classify_candidate(
+        ReplacementPlatformFamily::current(),
+        filesystem,
+        &VolumeIdentity { device: 1 },
+        candidate,
+    )
+}
+
+#[cfg(test)]
+fn assert_unsupported_assessment(
+    assessment: &ReplacementQualificationAssessment,
+) {
+    assert_eq!(
+        assessment.missing_invariant,
+        ReplacementMissingInvariant::AtomicExpectedTargetIdentityComparison
+    );
+    assert_eq!(
+        assessment.decision,
+        ReplacementQualificationDecision::PlatformQualificationRequired
+    );
+    assert_eq!(
+        assessment.retry_condition,
+        ReplacementQualificationRetryCondition::PlatformBuildOrQualificationPolicyChange
+    );
+}
+
+#[cfg(test)]
+fn candidate_assessment(
+    candidate: ReplacementCandidatePrimitive,
+) -> ReplacementCandidateAssessment {
+    production_assessment_for_test(ObservedFilesystemClassification::SameVolume, candidate)
+        .candidate_assessment
 }
 
 #[cfg(test)]
@@ -238,9 +412,65 @@ mod tests {
             staging_content: &PreparedFileEvidence::ContentHash([1; 32]),
             volume: &VolumeIdentity { device: 1 },
         };
+        let ExpectedIdentityReplacementOutcome::PlatformQualificationRequired { assessment } =
+            ProductionExpectedIdentityReplacementAdapter.attempt(request)
+        else {
+            panic!("production assessment must remain qualification-required");
+        };
+        assert_unsupported_assessment(&assessment);
+        assert_eq!(assessment.volume, VolumeIdentity { device: 1 });
+    }
+
+    #[test]
+    fn candidate_classification_keeps_exclusive_and_swap_semantics_distinct() {
+        assert_eq!(
+            candidate_assessment(ReplacementCandidatePrimitive::MacosRenameAtxNpRenameExcl),
+            ReplacementCandidateAssessment::AbsentFinalOnly
+        );
+        assert_eq!(
+            candidate_assessment(ReplacementCandidatePrimitive::MacosRenameAtxNpRenameSwap),
+            ReplacementCandidateAssessment::SwapWithoutExpectedTargetIdentityOperand
+        );
+    }
+
+    #[test]
+    fn filesystem_classification_does_not_qualify_a_candidate() {
+        let baseline = production_assessment_for_test(
+            ObservedFilesystemClassification::SameVolume,
+            ReplacementCandidatePrimitive::MacosRenameAtxNpRenameSwap,
+        );
+        for filesystem in [
+            ObservedFilesystemClassification::DifferentVolume,
+            ObservedFilesystemClassification::Unavailable,
+        ] {
+            let assessment = production_assessment_for_test(
+                filesystem,
+                ReplacementCandidatePrimitive::MacosRenameAtxNpRenameSwap,
+            );
+            assert_eq!(assessment.candidate, baseline.candidate);
+            assert_eq!(
+                assessment.candidate_assessment,
+                baseline.candidate_assessment
+            );
+            assert_eq!(assessment.missing_invariant, baseline.missing_invariant);
+            assert_eq!(assessment.decision, baseline.decision);
+            assert_eq!(assessment.retry_condition, baseline.retry_condition);
+        }
+    }
+
+    #[test]
+    fn qualification_required_assessment_cannot_construct_qualified_success() {
+        let assessment = production_assessment_for_test(
+            ObservedFilesystemClassification::SameVolume,
+            ReplacementCandidatePrimitive::MacosRenameAtxNpRenameSwap,
+        );
+        assert_unsupported_assessment(&assessment);
+        let outcome = ExpectedIdentityReplacementOutcome::PlatformQualificationRequired {
+            assessment,
+        };
         assert!(matches!(
-            ProductionExpectedIdentityReplacementAdapter.attempt(request),
-            ExpectedIdentityReplacementOutcome::Unsupported { .. }
+            outcome,
+            ExpectedIdentityReplacementOutcome::PlatformQualificationRequired { .. }
         ));
     }
 }

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -18,10 +18,18 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::capacity_gate::{DurableCapacityPlan, RejectedBeforeIntent, VolumeIdentity};
+use super::capacity_gate::{DurableCapacityPlan, RejectedBeforeIntent};
+pub(crate) use super::capacity_gate::VolumeIdentity;
 use super::expected_identity_replacement::{
     ExpectedIdentityReplacementAdapter, ExpectedIdentityReplacementOutcome,
     ExpectedIdentityReplacementRequest, ProductionExpectedIdentityReplacementAdapter,
+};
+pub(crate) use super::expected_identity_replacement::ReplacementQualificationAssessment;
+#[cfg(test)]
+pub(crate) use super::expected_identity_replacement::{
+    ObservedFilesystemClassification, ReplacementCandidateAssessment,
+    ReplacementCandidatePrimitive, ReplacementMissingInvariant, ReplacementPlatformFamily,
+    ReplacementQualificationDecision, ReplacementQualificationRetryCondition,
 };
 use super::publication::{FilesystemPublishedWaveformRestore, validate_publication_evidence};
 
@@ -333,6 +341,10 @@ pub(crate) struct OperationRecord {
     /// Typed filesystem publication evidence. Legacy records do not contain this checkpoint.
     #[serde(default)]
     pub(crate) published: Option<FilesystemPublishedWaveformRestore>,
+    /// Latest bounded assessment explaining why expected-identity replacement is not qualified.
+    /// Legacy schema-v1 records do not contain this field.
+    #[serde(default)]
+    pub(crate) replacement_qualification: Option<ReplacementQualificationAssessment>,
     /// Creation timestamp in Unix milliseconds.
     pub(crate) created_unix_ms: i64,
     /// Last update timestamp in Unix milliseconds.
@@ -362,6 +374,7 @@ impl OperationRecord {
             prepared: None,
             staged: None,
             published: None,
+            replacement_qualification: None,
             created_unix_ms: now,
             updated_unix_ms: now,
         }
@@ -398,6 +411,9 @@ impl OperationRecord {
         updated.phase = OperationPhase::FilesystemPublished;
         updated.disposition = OperationDisposition::None;
         updated.published = Some(published);
+        // A qualified publication supersedes any prior unsupported assessment.  Keeping both
+        // would make the durable record contradict its terminal filesystem evidence.
+        updated.replacement_qualification = None;
         updated.updated_unix_ms = unix_millis();
         updated
     }
@@ -495,6 +511,10 @@ pub(crate) enum PreparedOperationOutcome {
 pub(crate) enum FilesystemStageOutcome {
     FilesystemStaged(Uuid),
     FilesystemPublished(Uuid),
+    PlatformQualificationRequired {
+        operation_id: Uuid,
+        assessment: ReplacementQualificationAssessment,
+    },
     RetryPending { operation_id: Uuid, reason: String },
     AuditRequired { operation_id: Uuid, reason: String },
     JournalWriteFailed { operation_id: Uuid, reason: String },
@@ -622,6 +642,43 @@ impl OperationJournalStore {
         phase: OperationPhase,
         disposition: OperationDisposition,
     ) -> Result<(), JournalError> {
+        self.update_with_optional_replacement_qualification(
+            operation_id,
+            phase,
+            disposition,
+            None,
+        )
+    }
+
+    /// Durably replace one staged record with its latest platform qualification assessment.
+    fn update_with_replacement_qualification(
+        &mut self,
+        operation_id: Uuid,
+        assessment: ReplacementQualificationAssessment,
+    ) -> Result<(), JournalError> {
+        self.update_with_optional_replacement_qualification(
+            operation_id,
+            OperationPhase::FilesystemStaged,
+            OperationDisposition::RetryPending,
+            Some(assessment),
+        )
+    }
+
+    fn update_with_optional_replacement_qualification(
+        &mut self,
+        operation_id: Uuid,
+        phase: OperationPhase,
+        disposition: OperationDisposition,
+        replacement_qualification: Option<ReplacementQualificationAssessment>,
+    ) -> Result<(), JournalError> {
+        if replacement_qualification.is_some() && phase != OperationPhase::FilesystemStaged {
+            return Err(JournalError::InvalidPublicationEvidence {
+                operation_id,
+                reason: String::from(
+                    "replacement qualification evidence requires the filesystem-staged phase",
+                ),
+            });
+        }
         let current = self
             .records
             .get(&operation_id)
@@ -684,7 +741,16 @@ impl OperationJournalStore {
                 }
             })?;
         }
-        let updated = current.with_update(phase, disposition);
+        let mut updated = current.with_update(phase, disposition);
+        if let Some(assessment) = replacement_qualification {
+            if current.phase == phase
+                && current.disposition == disposition
+                && current.replacement_qualification.as_ref() == Some(&assessment)
+            {
+                return Ok(());
+            }
+            updated.replacement_qualification = Some(assessment);
+        }
         let path = self.record_path(operation_id);
         atomic_durable_write(&path, &updated)?;
         self.records.insert(operation_id, updated);
@@ -940,6 +1006,13 @@ impl OperationJournalStore {
                 });
                 continue;
             }
+            if validate_replacement_qualification_value(&value).is_err() {
+                self.recovery.malformed_count += 1;
+                self.recovery.attention_required = true;
+                self.retained
+                    .push(RetainedRecord::Malformed { path, bytes });
+                continue;
+            }
             match serde_json::from_value::<OperationRecord>(value) {
                 Ok(record) => {
                     let filename_id = path
@@ -1046,6 +1119,44 @@ impl OperationJournalStore {
         self.rebuild_capacity_claims();
         Ok(())
     }
+}
+
+fn validate_replacement_qualification_value(value: &Value) -> Result<(), &'static str> {
+    let Some(qualification) = value.get("replacement_qualification") else {
+        return Ok(());
+    };
+    let Some(qualification) = qualification.as_object() else {
+        return if qualification.is_null() {
+            Ok(())
+        } else {
+            Err("replacement qualification must be an object or null")
+        };
+    };
+    if qualification.keys().any(|key| {
+        !matches!(
+            key.as_str(),
+            "platform_family"
+                | "observed_filesystem"
+                | "volume"
+                | "candidate"
+                | "candidate_assessment"
+                | "missing_invariant"
+                | "decision"
+                | "retry_condition"
+        )
+    }) {
+        return Err("replacement qualification contains an unknown field");
+    }
+    let Some(volume) = qualification.get("volume") else {
+        return Ok(());
+    };
+    let Some(volume) = volume.as_object() else {
+        return Err("replacement qualification volume must be an object");
+    };
+    if volume.keys().any(|key| key != "device") {
+        return Err("replacement qualification volume contains an unknown field");
+    }
+    Ok(())
 }
 
 fn validate_capacity_plan_option(
@@ -2194,12 +2305,9 @@ impl OperationJournalCoordinator {
             volume: &reacquired.volume,
         };
         match adapter.attempt(request) {
-            ExpectedIdentityReplacementOutcome::Unsupported { reason } => self
-                .update_attempt_disposition(
-                    operation_id,
-                    OperationDisposition::RetryPending,
-                    reason,
-                ),
+            ExpectedIdentityReplacementOutcome::PlatformQualificationRequired { assessment } => {
+                self.update_platform_qualification(operation_id, assessment)
+            }
             ExpectedIdentityReplacementOutcome::Drift { reason }
             | ExpectedIdentityReplacementOutcome::Ambiguous { reason } => self
                 .update_attempt_disposition(
@@ -2224,6 +2332,26 @@ impl OperationJournalCoordinator {
                     }),
                 }
             }
+        }
+    }
+
+    fn update_platform_qualification(
+        &mut self,
+        operation_id: Uuid,
+        assessment: ReplacementQualificationAssessment,
+    ) -> Result<FilesystemStageOutcome, JournalError> {
+        match self
+            .store
+            .update_with_replacement_qualification(operation_id, assessment.clone())
+        {
+            Ok(()) => Ok(FilesystemStageOutcome::PlatformQualificationRequired {
+                operation_id,
+                assessment,
+            }),
+            Err(error) => Ok(FilesystemStageOutcome::JournalWriteFailed {
+                operation_id,
+                reason: error.to_string(),
+            }),
         }
     }
 
@@ -2897,16 +3025,36 @@ mod tests {
             .collect::<Vec<_>>();
         let claims_before = journal.store.capacity_claims().clone();
 
-        assert!(matches!(
-            journal
-                .attempt_publish_staged_waveform_restore(id)
-                .expect("publication attempt"),
-            FilesystemStageOutcome::RetryPending { operation_id, .. } if operation_id == id
-        ));
+        let outcome = journal
+            .attempt_publish_staged_waveform_restore(id)
+            .expect("publication attempt");
+        let assessment = match &outcome {
+            FilesystemStageOutcome::PlatformQualificationRequired {
+                operation_id,
+                assessment,
+            } if *operation_id == id => assessment.clone(),
+            other => panic!("expected platform qualification, got {other:?}"),
+        };
+        assert_eq!(
+            assessment.missing_invariant,
+            super::super::expected_identity_replacement::ReplacementMissingInvariant::AtomicExpectedTargetIdentityComparison
+        );
+        assert_eq!(
+            assessment.retry_condition,
+            super::super::expected_identity_replacement::ReplacementQualificationRetryCondition::PlatformBuildOrQualificationPolicyChange
+        );
         let record = journal.record(id).unwrap();
         assert_eq!(record.phase, OperationPhase::FilesystemStaged);
         assert_eq!(record.disposition, OperationDisposition::RetryPending);
-        assert!(record.staged.is_some());
+        assert_eq!(record.replacement_qualification.as_ref(), Some(&assessment));
+        assert!(matches!(
+            record.staged.as_ref().map(|staged| &staged.participant),
+            Some(FilesystemStagedParticipant::CopyValidated { .. })
+        ));
+        assert_eq!(
+            record.prepared.as_ref().unwrap().target.relative_path,
+            PathBuf::from("target.wav")
+        );
         assert_eq!(journal.store.capacity_claims(), &claims_before);
         assert_eq!(fs::read(&backup).unwrap(), vec![7_u8; 4097]);
         assert_eq!(fs::read(&target).unwrap(), target_before);
@@ -2927,7 +3075,45 @@ mod tests {
             reopened_record.disposition,
             OperationDisposition::RetryPending
         );
+        assert_eq!(
+            reopened_record.replacement_qualification.as_ref(),
+            Some(&assessment)
+        );
+        assert!(matches!(
+            reopened_record
+                .staged
+                .as_ref()
+                .map(|staged| &staged.participant),
+            Some(FilesystemStagedParticipant::CopyValidated { .. })
+        ));
+        assert_eq!(
+            reopened_record
+                .prepared
+                .as_ref()
+                .unwrap()
+                .target
+                .relative_path,
+            PathBuf::from("target.wav")
+        );
         assert_eq!(reopened.store.capacity_claims(), &claims_before);
+    }
+
+    #[test]
+    fn repeated_platform_qualification_assessment_is_idempotent() {
+        let (_journal_dir, _files, mut journal, id, _backup, _target, _staging) =
+            prepared_restore_fixture();
+        journal
+            .stage_admitted_bounded_waveform_restore(id)
+            .expect("stage restore");
+        let first = journal
+            .attempt_publish_staged_waveform_restore(id)
+            .expect("first qualification assessment");
+        let first_record = journal.record(id).unwrap().clone();
+        let second = journal
+            .attempt_publish_staged_waveform_restore(id)
+            .expect("repeated qualification assessment");
+        assert_eq!(second, first);
+        assert_eq!(journal.record(id), Some(&first_record));
     }
 
     #[test]
@@ -2999,6 +3185,19 @@ mod tests {
             .stage_admitted_bounded_waveform_restore(id)
             .expect("stage restore");
         let claims_before = journal.store.capacity_claims().clone();
+        let qualification = journal
+            .attempt_publish_staged_waveform_restore(id)
+            .expect("unsupported production assessment");
+        assert!(matches!(
+            qualification,
+            FilesystemStageOutcome::PlatformQualificationRequired { operation_id, .. }
+                if operation_id == id
+        ));
+        assert!(journal
+            .record(id)
+            .unwrap()
+            .replacement_qualification
+            .is_some());
         let adapter = super::super::expected_identity_replacement::
             TestQualifiedExpectedIdentityReplacementAdapter { drift: None };
 
@@ -3011,6 +3210,7 @@ mod tests {
         let record = journal.record(id).unwrap();
         assert_eq!(record.phase, OperationPhase::FilesystemPublished);
         assert_eq!(record.disposition, OperationDisposition::None);
+        assert!(record.replacement_qualification.is_none());
         assert!(record.published.is_some());
         assert_eq!(journal.store.capacity_claims(), &claims_before);
         assert_eq!(fs::read(&target).unwrap(), vec![0_u8; 4097]);
@@ -3614,6 +3814,116 @@ mod tests {
         assert!(reopened_record.prepared.is_none());
         assert_eq!(reopened.store.capacity_claims(), &claims_before);
         assert_eq!(fs::read(&staging).unwrap(), staging_bytes);
+    }
+
+    #[test]
+    fn schema_v1_record_without_replacement_qualification_reopens_unchanged() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let record = OperationRecord::new(intent(), serde_json::json!({"legacy": true}));
+        let operation_id = record.operation_id;
+        let path = dir.path().join(format!("{operation_id}.json"));
+        let mut value = serde_json::to_value(&record).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("replacement_qualification")
+            .expect("current record has optional qualification field");
+        let bytes = serde_json::to_vec(&value).unwrap();
+        fs::write(&path, &bytes).unwrap();
+
+        let journal = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+        let reopened = journal.record(operation_id).expect("legacy record reopens");
+        assert_eq!(reopened.operation_id, operation_id);
+        assert_eq!(reopened.payload, serde_json::json!({"legacy": true}));
+        assert_eq!(reopened.phase, OperationPhase::IntentDurable);
+        assert_eq!(reopened.disposition, OperationDisposition::None);
+        assert!(reopened.replacement_qualification.is_none());
+        assert_eq!(journal.recovery_summary().malformed_count, 0);
+        assert_eq!(fs::read(path).unwrap(), bytes);
+    }
+
+    fn assert_malformed_qualification_recovery(
+        journal: &OperationJournalCoordinator,
+        operation_id: Uuid,
+        path: &Path,
+        bytes: &[u8],
+    ) {
+        let summary = journal.recovery_summary();
+        assert_eq!(summary.malformed_count, 1);
+        assert!(summary.attention_required);
+        assert!(journal.record(operation_id).is_none());
+        assert!(journal.store.capacity_blocked());
+        assert_eq!(fs::read(path).unwrap(), bytes);
+    }
+
+    #[test]
+    fn unknown_replacement_qualification_field_is_retained_fail_closed() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let record = OperationRecord::new(intent(), Value::Null);
+        let operation_id = record.operation_id;
+        let path = dir.path().join(format!("{operation_id}.json"));
+        let mut value = serde_json::to_value(&record).unwrap();
+        value.as_object_mut().unwrap().insert(
+            String::from("replacement_qualification"),
+            serde_json::json!({
+                "platform_family": "linux",
+                "observed_filesystem": "same_volume",
+                "volume": {"device": 1},
+                "candidate": "no_public_candidate",
+                "candidate_assessment": "no_qualified_candidate",
+                "missing_invariant": "atomic_expected_target_identity_comparison",
+                "decision": "platform_qualification_required",
+                "retry_condition": "platform_build_or_qualification_policy_change",
+                "future_evidence": true
+            }),
+        );
+        let bytes = serde_json::to_vec(&value).unwrap();
+        fs::write(&path, &bytes).unwrap();
+
+        {
+            let journal = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+            assert_malformed_qualification_recovery(&journal, operation_id, &path, &bytes);
+        }
+        let reopened = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+        assert_malformed_qualification_recovery(&reopened, operation_id, &path, &bytes);
+        drop(reopened);
+        assert_eq!(fs::read(path).unwrap(), bytes);
+    }
+
+    #[test]
+    fn unknown_replacement_qualification_volume_field_is_retained_fail_closed() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let record = OperationRecord::new(intent(), Value::Null);
+        let operation_id = record.operation_id;
+        let path = dir.path().join(format!("{operation_id}.json"));
+        let mut value = serde_json::to_value(&record).unwrap();
+        value.as_object_mut().unwrap().insert(
+            String::from("replacement_qualification"),
+            serde_json::json!({
+                "platform_family": "linux",
+                "observed_filesystem": "same_volume",
+                "volume": {"device": 1, "future_volume_evidence": true},
+                "candidate": "no_public_candidate",
+                "candidate_assessment": "no_qualified_candidate",
+                "missing_invariant": "atomic_expected_target_identity_comparison",
+                "decision": "platform_qualification_required",
+                "retry_condition": "platform_build_or_qualification_policy_change"
+            }),
+        );
+        let bytes = serde_json::to_vec(&value).unwrap();
+        fs::write(&path, &bytes).unwrap();
+
+        {
+            let journal = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+            assert_malformed_qualification_recovery(&journal, operation_id, &path, &bytes);
+        }
+        let reopened = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
+        assert_malformed_qualification_recovery(&reopened, operation_id, &path, &bytes);
+        drop(reopened);
+        assert_eq!(fs::read(path).unwrap(), bytes);
     }
 
     #[test]


### PR DESCRIPTION
## Goal

Persist a typed, bounded, nonterminal qualification result when expected-identity filesystem replacement is unavailable, so staged recovery remains durable and restartable instead of collapsing to an opaque retry reason.

## Scope and non-goals

- Add serializable replacement qualification evidence for platform family, observed filesystem classification, volume identity, candidate primitive, candidate assessment, missing invariant, decision, and retry condition.
- Add the PlatformQualificationRequired runtime outcome while retaining the compatible RetryPending journal disposition.
- Persist the latest assessment atomically with the staged phase and retry disposition, preserving prepared, CopyValidated staging, capacity, target, and staging evidence.
- Preserve old schema-v1 records without the optional field and retain malformed or unknown qualification evidence fail-closed with original bytes.
- Update owner status text and clear contradictory qualification evidence after qualified test publication.
- Keep production assessment read-only and fail closed. No expected-identity replacement primitive, namespace mutation, database migration, absent-final qualification, or native app acceptance is included.

## Definition of Done

- Unsupported production assessment returns a typed nonterminal outcome and durable evidence survives reopen.
- Repeated identical assessments are idempotent; changed assessments replace only the bounded latest field.
- macOS candidate classification distinguishes absent-final RENAME_EXCL from RENAME_SWAP without an expected-target identity operand.
- Unknown direct or nested qualification fields are retained as malformed and block admission without rewriting original records.
- The sealed test-only qualified adapter remains the only publication path.

## Validation

- cargo test --locked transaction_history::operation_journal — 41 passed
- cargo test --locked transaction_history::expected_identity_replacement — 4 passed
- cargo test --locked owner_staging_outcomes_retain_history_and_operation_identity — 1 passed
- cargo check --locked — passed
- git diff --check — passed
- Independent Terra review — APPROVE
- cargo fmt --all -- --check remains affected by known repository-wide baseline formatting drift in unrelated existing files; no new whitespace errors are present.

## Known limitations

The production expected-identity replacement primitive is intentionally not qualified or implemented. Native macOS, APFS-wide, race, crash, power-loss, sync, removable-media, and real-app acceptance remain future work.

## Next task

Separately qualify the absent-final macOS/APFS no-replace path using capability-relative containment, reopen/content verification, and synchronization downgrade rules.

User approval is required before merge.