### PR TITLE
Add read-only absent-final recovery classifier

### DIFF
--- a/src/native_app/transaction_history.rs
+++ b/src/native_app/transaction_history.rs
@@ -1,5 +1,6 @@
-mod app_state;
 mod absent_final_no_replace;
+mod absent_final_recovery;
+mod app_state;
 mod capacity_gate;
 mod context;
 mod expected_identity_replacement;
@@ -11,6 +12,7 @@ pub(in crate::native_app) mod operation_journal;
 pub(in crate::native_app) mod publication;
 mod summary;
 
+pub(in crate::native_app) use absent_final_recovery::AbsentFinalRecoveryClassification;
 pub(in crate::native_app) use capacity_gate::RejectedBeforeIntent;
 pub(in crate::native_app) use capacity_gate::open_no_follow_path;
 pub(in crate::native_app) use context::TransactionContext;

--- a/src/native_app/transaction_history/absent_final_no_replace.rs
+++ b/src/native_app/transaction_history/absent_final_no_replace.rs
@@ -80,6 +80,27 @@ fn is_single_clean_normal_leaf(path: &Path) -> bool {
     !component.as_encoded_bytes().contains(&0)
 }
 
+/// Compare an observed object with durable identity while allowing a namespace operation to
+/// refresh the change marker. Recovery uses this predicate before exact content matching.
+pub(super) fn stable_id_and_length_matches(
+    actual: &PreparedObjectIdentity,
+    expected: &PreparedObjectIdentity,
+) -> bool {
+    actual.stable_id == expected.stable_id && actual.len == expected.len
+}
+
+/// Compare only exact content evidence. Metadata-only and unverifiable evidence never qualifies.
+pub(super) fn exact_content_evidence_matches(
+    expected: &PreparedFileEvidence,
+    actual: &PreparedFileEvidence,
+) -> bool {
+    matches!(
+        (expected, actual),
+        (PreparedFileEvidence::ContentHash(expected), PreparedFileEvidence::ContentHash(actual))
+            if expected == actual
+    )
+}
+
 /// Collision observed while claiming the absent final name.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum AbsentFinalNoReplaceCollision {
@@ -310,13 +331,13 @@ pub(super) fn test_mutating_attempt(
             );
         }
     };
-    if !same_reopened_identity(&reopened_identity, request.expected_staging) {
+    if !stable_id_and_length_matches(&reopened_identity, request.expected_staging) {
         return AbsentFinalNoReplaceOutcome::DriftOrVerificationFailure(
             AbsentFinalNoReplaceFailure::ReopenedIdentityDrift,
         );
     }
     let reopened_content = prepared_file_evidence(&reopened_final);
-    if !content_evidence_matches(request.expected_content, &reopened_content) {
+    if !exact_content_evidence_matches(request.expected_content, &reopened_content) {
         return AbsentFinalNoReplaceOutcome::DriftOrVerificationFailure(
             AbsentFinalNoReplaceFailure::ReopenedContentDrift,
         );
@@ -329,16 +350,6 @@ pub(super) fn test_mutating_attempt(
         visibility: PublicationVisibility::VisibilityVerified,
         synchronization: PublicationSynchronization::SyncUnsupportedOrUnverified,
     })
-}
-
-#[cfg(all(target_os = "macos", test))]
-fn same_reopened_identity(
-    actual: &PreparedObjectIdentity,
-    expected: &PreparedObjectIdentity,
-) -> bool {
-    // A namespace claim can update ctime/change_marker while preserving the object.  Stable
-    // filesystem identity plus length, followed by content hashing below, is the ownership proof.
-    actual.stable_id == expected.stable_id && actual.len == expected.len
 }
 
 #[cfg(all(target_os = "macos", test))]
@@ -369,7 +380,7 @@ fn verify_staging(
         return Err(AbsentFinalNoReplaceFailure::StagingIdentityDrift);
     }
     let content = prepared_file_evidence(request.staging);
-    if !content_evidence_matches(request.expected_content, &content) {
+    if !exact_content_evidence_matches(request.expected_content, &content) {
         return Err(AbsentFinalNoReplaceFailure::StagingContentDrift);
     }
 
@@ -388,7 +399,7 @@ fn verify_staging(
         request.staging_leaf,
     )
     .map_err(|_| AbsentFinalNoReplaceFailure::StagingIdentityDrift)?;
-    if !content_evidence_matches(
+    if !exact_content_evidence_matches(
         request.expected_content,
         &prepared_file_evidence(&relative_staging),
     ) {
@@ -464,18 +475,6 @@ fn rename_directory_relative(parent: &File, source: &Path, destination: &Path) -
         )
     };
     if result == 0 { Ok(()) } else { Err(()) }
-}
-
-#[cfg(all(target_os = "macos", test))]
-fn content_evidence_matches(
-    expected: &PreparedFileEvidence,
-    actual: &PreparedFileEvidence,
-) -> bool {
-    matches!(
-        (expected, actual),
-        (PreparedFileEvidence::ContentHash(expected), PreparedFileEvidence::ContentHash(actual))
-            if expected == actual
-    )
 }
 
 #[cfg(test)]

--- a/src/native_app/transaction_history/absent_final_recovery.rs
+++ b/src/native_app/transaction_history/absent_final_recovery.rs
@@ -1,0 +1,752 @@
+//! Read-only recovery classification for schema-v2 absent-final staging records.
+//!
+//! The classifier reacquires the prepared target-parent capability and observes both leaves
+//! relative to that descriptor. It never claims publication, ownership, or pathname continuity;
+//! all returned values are evidence-only and contain no open handles or mutation capabilities.
+
+#![allow(dead_code)]
+
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::path::Path;
+
+use super::absent_final_no_replace::{
+    exact_content_evidence_matches, stable_id_and_length_matches,
+};
+use super::operation_journal::{
+    FilesystemStagedParticipant, FilesystemStagedWaveformRestore, PreparedAbsentFinalNoReplace,
+};
+#[cfg(unix)]
+use super::operation_journal::{
+    PreparedFileEvidence, PreparedObjectIdentity, descriptor_identity, open_root,
+    prepared_file_evidence,
+};
+
+/// Whether the durable staging locator is present while a final collision is observed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CollisionStagingState {
+    Present,
+    Missing,
+}
+
+/// A typed reason why live namespace evidence is not safe to interpret as a match or collision.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AbsentFinalRecoveryAmbiguity {
+    TargetParentReacquisitionFailed,
+    TargetParentIdentityChanged,
+    StagingEntryNotRegular,
+    StagingIdentityUnavailable,
+    StagingIdentityDrift,
+    StagingContentUnavailable,
+    StagingContentDrift,
+    FinalEntryNotRegular,
+    FinalIdentityUnavailable,
+    FinalIdentityLengthDrift,
+    FinalContentUnavailable,
+    FinalContentDrift,
+    StagingInspectionRaceOrFailure,
+    FinalInspectionRaceOrFailure,
+    UnsupportedDescriptorRelativeInspection,
+}
+
+/// Read-only classification of one eligible schema-v2 absent-final recovery observation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AbsentFinalRecoveryClassification {
+    StagingPresentFinalAbsent,
+    StagingMissingFinalMatches,
+    BothPresent,
+    NeitherPresent,
+    Collision { staging: CollisionStagingState },
+    IdentityAmbiguous(AbsentFinalRecoveryAmbiguity),
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+enum LeafInspectionError {
+    NotRegular,
+    IdentityUnavailable,
+    ContentUnavailable,
+    RaceOrFailure,
+}
+
+#[cfg(unix)]
+enum LeafObservation {
+    Missing,
+    Present {
+        identity: PreparedObjectIdentity,
+        content: PreparedFileEvidence,
+    },
+}
+
+/// Classify one already-validated absent-final staging checkpoint without any filesystem or
+/// journal mutation. The coordinator performs the schema/phase/evidence eligibility checks
+/// before delegating here.
+pub(super) fn classify_absent_final_recovery(
+    prepared: &PreparedAbsentFinalNoReplace,
+    staged: &FilesystemStagedWaveformRestore,
+) -> AbsentFinalRecoveryClassification {
+    #[cfg(unix)]
+    {
+        return classify_unix(prepared, staged);
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (prepared, staged);
+        AbsentFinalRecoveryClassification::IdentityAmbiguous(
+            AbsentFinalRecoveryAmbiguity::UnsupportedDescriptorRelativeInspection,
+        )
+    }
+}
+
+#[cfg(unix)]
+fn classify_unix(
+    prepared: &PreparedAbsentFinalNoReplace,
+    staged: &FilesystemStagedWaveformRestore,
+) -> AbsentFinalRecoveryClassification {
+    let FilesystemStagedParticipant::CopyValidated {
+        staging: expected_staging,
+        evidence: expected_content,
+    } = &staged.participant;
+
+    let (target_parent, reacquired_parent) = match open_root(&prepared.target_parent.path) {
+        Ok(value) => value,
+        Err(_) => {
+            return AbsentFinalRecoveryClassification::IdentityAmbiguous(
+                AbsentFinalRecoveryAmbiguity::TargetParentReacquisitionFailed,
+            );
+        }
+    };
+    if reacquired_parent.identity.stable_id != prepared.target_parent.identity.stable_id {
+        return AbsentFinalRecoveryClassification::IdentityAmbiguous(
+            AbsentFinalRecoveryAmbiguity::TargetParentIdentityChanged,
+        );
+    }
+
+    let staging = match inspect_leaf(&target_parent, &prepared.staging.relative_path) {
+        Ok(observation) => observation,
+        Err(error) => {
+            return AbsentFinalRecoveryClassification::IdentityAmbiguous(staging_ambiguity(error));
+        }
+    };
+    let staging_present = match &staging {
+        LeafObservation::Missing => false,
+        LeafObservation::Present { identity, content } => {
+            if !stable_id_and_length_matches(identity, &expected_staging.identity) {
+                return AbsentFinalRecoveryClassification::IdentityAmbiguous(
+                    AbsentFinalRecoveryAmbiguity::StagingIdentityDrift,
+                );
+            }
+            if !exact_content_evidence_matches(expected_content, content) {
+                return AbsentFinalRecoveryClassification::IdentityAmbiguous(
+                    AbsentFinalRecoveryAmbiguity::StagingContentDrift,
+                );
+            }
+            true
+        }
+    };
+
+    let final_observation = match inspect_leaf(&target_parent, &prepared.final_leaf) {
+        Ok(observation) => observation,
+        Err(error) => {
+            return AbsentFinalRecoveryClassification::IdentityAmbiguous(final_ambiguity(error));
+        }
+    };
+    match final_observation {
+        LeafObservation::Missing if staging_present => {
+            AbsentFinalRecoveryClassification::StagingPresentFinalAbsent
+        }
+        LeafObservation::Missing => AbsentFinalRecoveryClassification::NeitherPresent,
+        LeafObservation::Present { identity, content } => {
+            if identity.stable_id != expected_staging.identity.stable_id {
+                return AbsentFinalRecoveryClassification::Collision {
+                    staging: if staging_present {
+                        CollisionStagingState::Present
+                    } else {
+                        CollisionStagingState::Missing
+                    },
+                };
+            }
+            if !stable_id_and_length_matches(&identity, &expected_staging.identity) {
+                return AbsentFinalRecoveryClassification::IdentityAmbiguous(
+                    AbsentFinalRecoveryAmbiguity::FinalIdentityLengthDrift,
+                );
+            }
+            if !exact_content_evidence_matches(expected_content, &content) {
+                return AbsentFinalRecoveryClassification::IdentityAmbiguous(
+                    AbsentFinalRecoveryAmbiguity::FinalContentDrift,
+                );
+            }
+            if staging_present {
+                AbsentFinalRecoveryClassification::BothPresent
+            } else {
+                AbsentFinalRecoveryClassification::StagingMissingFinalMatches
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn inspect_leaf(root: &File, relative: &Path) -> Result<LeafObservation, LeafInspectionError> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let mut components = relative.components();
+    let Some(std::path::Component::Normal(component)) = components.next() else {
+        return Err(LeafInspectionError::RaceOrFailure);
+    };
+    if components.next().is_some() || Path::new(component) != relative {
+        return Err(LeafInspectionError::RaceOrFailure);
+    }
+    let name = CString::new(component.as_encoded_bytes())
+        .map_err(|_| LeafInspectionError::RaceOrFailure)?;
+
+    let mut metadata = std::mem::MaybeUninit::<libc::stat>::zeroed();
+    let result = unsafe {
+        libc::fstatat(
+            root.as_raw_fd(),
+            name.as_ptr(),
+            metadata.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result != 0 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ENOENT) {
+            return Ok(LeafObservation::Missing);
+        }
+        return Err(LeafInspectionError::RaceOrFailure);
+    }
+    let metadata = unsafe { metadata.assume_init() };
+    if metadata.st_mode & libc::S_IFMT != libc::S_IFREG {
+        return Err(LeafInspectionError::NotRegular);
+    }
+
+    let fd = unsafe {
+        libc::openat(
+            root.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+        )
+    };
+    if fd < 0 {
+        return Err(LeafInspectionError::RaceOrFailure);
+    }
+    let file = unsafe { File::from_raw_fd(fd) };
+    let before =
+        descriptor_identity(&file).map_err(|_| LeafInspectionError::IdentityUnavailable)?;
+    let content = prepared_file_evidence(&file);
+    let after = descriptor_identity(&file).map_err(|_| LeafInspectionError::IdentityUnavailable)?;
+    if !stable_id_and_length_matches(&before, &after) {
+        return Err(LeafInspectionError::RaceOrFailure);
+    }
+    if !matches!(content, PreparedFileEvidence::ContentHash(_)) {
+        return Err(LeafInspectionError::ContentUnavailable);
+    }
+    Ok(LeafObservation::Present {
+        identity: after,
+        content,
+    })
+}
+
+#[cfg(unix)]
+fn staging_ambiguity(error: LeafInspectionError) -> AbsentFinalRecoveryAmbiguity {
+    match error {
+        LeafInspectionError::NotRegular => AbsentFinalRecoveryAmbiguity::StagingEntryNotRegular,
+        LeafInspectionError::IdentityUnavailable => {
+            AbsentFinalRecoveryAmbiguity::StagingIdentityUnavailable
+        }
+        LeafInspectionError::ContentUnavailable => {
+            AbsentFinalRecoveryAmbiguity::StagingContentUnavailable
+        }
+        LeafInspectionError::RaceOrFailure => {
+            AbsentFinalRecoveryAmbiguity::StagingInspectionRaceOrFailure
+        }
+    }
+}
+
+#[cfg(unix)]
+fn final_ambiguity(error: LeafInspectionError) -> AbsentFinalRecoveryAmbiguity {
+    match error {
+        LeafInspectionError::NotRegular => AbsentFinalRecoveryAmbiguity::FinalEntryNotRegular,
+        LeafInspectionError::IdentityUnavailable => {
+            AbsentFinalRecoveryAmbiguity::FinalIdentityUnavailable
+        }
+        LeafInspectionError::ContentUnavailable => {
+            AbsentFinalRecoveryAmbiguity::FinalContentUnavailable
+        }
+        LeafInspectionError::RaceOrFailure => {
+            AbsentFinalRecoveryAmbiguity::FinalInspectionRaceOrFailure
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::native_app::transaction_history::capacity_gate::{
+        CapacityAllocationClass, DurableCapacityPlan, DurableVolumeCapacity,
+        PROTECTED_FREE_SPACE_FLOOR, VolumeIdentity,
+    };
+    use crate::native_app::transaction_history::operation_journal::{
+        AbsentFinalObservation, FilesystemStagedParticipant, FilesystemStagedWaveformRestore,
+        OperationActor, OperationIntent, OperationJournalCoordinator, OperationKind,
+        OperationPhase, PreparedAbsentFinalNoReplace, PreparedFileEvidence, PreparedLeafLocator,
+        PreparedRestoreDirection, PreparedRootCapability, PreparedStagingLocator,
+        descriptor_identity, prepared_file_evidence,
+    };
+    use std::ffi::CString;
+    use std::fs::{self, File};
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::symlink;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    const STAGING_LEAF: &str = "staging.wav";
+    const FINAL_LEAF: &str = "final.wav";
+    const STAGING_BYTES: &[u8] = b"durable staged waveform";
+
+    struct Fixture {
+        _directory: TempDir,
+        target_parent_path: PathBuf,
+        prepared: PreparedAbsentFinalNoReplace,
+        staged: FilesystemStagedWaveformRestore,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let directory = tempfile::tempdir().expect("fixture directory");
+            let base = directory
+                .path()
+                .canonicalize()
+                .expect("canonical fixture directory");
+            let target_parent_path = base.join("target-parent");
+            fs::create_dir(&target_parent_path).expect("target parent");
+            let staging_path = target_parent_path.join(STAGING_LEAF);
+            fs::write(&staging_path, STAGING_BYTES).expect("staging bytes");
+
+            let target_parent = File::open(&target_parent_path).expect("target parent handle");
+            let target_parent_identity =
+                descriptor_identity(&target_parent).expect("target parent identity");
+            let staging = File::open(&staging_path).expect("staging handle");
+            let staging_identity = descriptor_identity(&staging).expect("staging identity");
+            let evidence = prepared_file_evidence(&staging);
+            assert!(matches!(evidence, PreparedFileEvidence::ContentHash(_)));
+            let target_parent = PreparedRootCapability {
+                path: target_parent_path.clone(),
+                identity: target_parent_identity,
+            };
+            let prepared = PreparedAbsentFinalNoReplace {
+                direction: PreparedRestoreDirection::Undo,
+                source_id: String::from("absent-final-recovery-fixture"),
+                source_root: target_parent.clone(),
+                target_parent,
+                final_leaf: PathBuf::from(FINAL_LEAF),
+                staging: PreparedStagingLocator {
+                    relative_path: PathBuf::from(STAGING_LEAF),
+                    absent: true,
+                },
+                final_observation: AbsentFinalObservation::ObservedAbsent,
+                copy_validated_evidence: evidence.clone(),
+            };
+            let staged = FilesystemStagedWaveformRestore {
+                participant: FilesystemStagedParticipant::CopyValidated {
+                    staging: PreparedLeafLocator {
+                        relative_path: PathBuf::from(STAGING_LEAF),
+                        identity: staging_identity,
+                    },
+                    evidence,
+                },
+            };
+            Self {
+                _directory: directory,
+                target_parent_path,
+                prepared,
+                staged,
+            }
+        }
+
+        fn staging_path(&self) -> PathBuf {
+            self.target_parent_path.join(STAGING_LEAF)
+        }
+
+        fn final_path(&self) -> PathBuf {
+            self.target_parent_path.join(FINAL_LEAF)
+        }
+
+        fn classify(&self) -> AbsentFinalRecoveryClassification {
+            classify_absent_final_recovery(&self.prepared, &self.staged)
+        }
+
+        fn set_staged_change_marker(&mut self, marker: &str) {
+            let FilesystemStagedParticipant::CopyValidated { staging, .. } =
+                &mut self.staged.participant;
+            staging.identity.change_marker = Some(String::from(marker));
+        }
+
+        fn replace_parent(&self) -> PathBuf {
+            let moved = self
+                .target_parent_path
+                .parent()
+                .expect("fixture parent")
+                .join("moved-target-parent");
+            fs::rename(&self.target_parent_path, &moved).expect("move target parent");
+            fs::create_dir(&self.target_parent_path).expect("replacement target parent");
+            moved
+        }
+
+        fn remove_parent_contents(&self) {
+            let _ = fs::remove_file(self.staging_path());
+            let _ = fs::remove_file(self.final_path());
+        }
+    }
+
+    fn assert_ambiguous(fixture: &Fixture, expected: AbsentFinalRecoveryAmbiguity) {
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::IdentityAmbiguous(expected)
+        );
+    }
+
+    #[test]
+    fn presence_matrix_classifies_staging_and_final_without_mutation() {
+        let fixture = Fixture::new();
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::StagingPresentFinalAbsent
+        );
+        assert!(fixture.staging_path().is_file());
+        assert!(!fixture.final_path().exists());
+
+        let fixture = Fixture::new();
+        fs::hard_link(fixture.staging_path(), fixture.final_path()).expect("hard link final");
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::BothPresent
+        );
+        assert!(fixture.staging_path().is_file());
+        assert!(fixture.final_path().is_file());
+
+        let fixture = Fixture::new();
+        fs::rename(fixture.staging_path(), fixture.final_path()).expect("rename staging to final");
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::StagingMissingFinalMatches
+        );
+        assert!(!fixture.staging_path().exists());
+        assert!(fixture.final_path().is_file());
+
+        let fixture = Fixture::new();
+        fs::remove_file(fixture.staging_path()).expect("remove staging");
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::NeitherPresent
+        );
+    }
+
+    #[test]
+    fn staging_and_final_change_marker_drift_does_not_change_matching_identity() {
+        let mut fixture = Fixture::new();
+        fixture.set_staged_change_marker("stale-change-marker");
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::StagingPresentFinalAbsent
+        );
+
+        let fixture = Fixture::new();
+        fs::rename(fixture.staging_path(), fixture.final_path()).expect("rename staging to final");
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::StagingMissingFinalMatches
+        );
+    }
+
+    #[test]
+    fn different_final_identity_is_a_collision_with_staging_presence() {
+        let fixture = Fixture::new();
+        fs::write(fixture.final_path(), b"foreign final object").expect("foreign final");
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::Collision {
+                staging: CollisionStagingState::Present,
+            }
+        );
+
+        let fixture = Fixture::new();
+        fs::write(fixture.final_path(), STAGING_BYTES).expect("same bytes, new final object");
+        assert_ne!(
+            descriptor_identity(&File::open(fixture.final_path()).expect("foreign final handle"))
+                .expect("foreign final identity")
+                .stable_id,
+            match &fixture.staged.participant {
+                FilesystemStagedParticipant::CopyValidated { staging, .. } => {
+                    staging.identity.stable_id.clone()
+                }
+            }
+        );
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::Collision {
+                staging: CollisionStagingState::Present,
+            }
+        );
+    }
+
+    #[test]
+    fn different_final_identity_is_a_collision_after_staging_disappears() {
+        let fixture = Fixture::new();
+        fs::remove_file(fixture.staging_path()).expect("remove staging");
+        fs::write(fixture.final_path(), b"foreign final object").expect("foreign final");
+        assert_eq!(
+            fixture.classify(),
+            AbsentFinalRecoveryClassification::Collision {
+                staging: CollisionStagingState::Missing,
+            }
+        );
+    }
+
+    #[test]
+    fn replaced_staging_and_changed_same_identity_final_are_ambiguous() {
+        let fixture = Fixture::new();
+        fs::remove_file(fixture.staging_path()).expect("remove staging");
+        fs::write(fixture.staging_path(), STAGING_BYTES).expect("replacement staging");
+        assert_ambiguous(&fixture, AbsentFinalRecoveryAmbiguity::StagingIdentityDrift);
+
+        let fixture = Fixture::new();
+        fs::rename(fixture.staging_path(), fixture.final_path()).expect("rename staging to final");
+        fs::write(fixture.final_path(), vec![b'x'; STAGING_BYTES.len()])
+            .expect("change final content in place");
+        assert_ambiguous(&fixture, AbsentFinalRecoveryAmbiguity::FinalContentDrift);
+    }
+
+    #[test]
+    fn replaced_missing_and_symlink_parent_are_ambiguous() {
+        let fixture = Fixture::new();
+        let moved = fixture.replace_parent();
+        assert_ambiguous(
+            &fixture,
+            AbsentFinalRecoveryAmbiguity::TargetParentIdentityChanged,
+        );
+        assert!(moved.is_dir());
+
+        let fixture = Fixture::new();
+        fixture.remove_parent_contents();
+        fs::remove_dir(&fixture.target_parent_path).expect("remove target parent");
+        assert_ambiguous(
+            &fixture,
+            AbsentFinalRecoveryAmbiguity::TargetParentReacquisitionFailed,
+        );
+
+        let fixture = Fixture::new();
+        let moved = fixture.replace_parent();
+        let replacement = fixture
+            .target_parent_path
+            .parent()
+            .expect("fixture parent")
+            .join("symlink-target-parent");
+        fs::create_dir(&replacement).expect("symlink target parent");
+        fs::remove_dir(&fixture.target_parent_path).expect("remove replacement directory");
+        symlink(&replacement, &fixture.target_parent_path).expect("symlink target parent");
+        assert_ambiguous(
+            &fixture,
+            AbsentFinalRecoveryAmbiguity::TargetParentReacquisitionFailed,
+        );
+        assert!(moved.is_dir());
+    }
+
+    #[test]
+    fn symlink_and_special_final_are_ambiguous_without_following_or_blocking() {
+        let fixture = Fixture::new();
+        let foreign = fixture
+            .target_parent_path
+            .parent()
+            .expect("fixture parent")
+            .join("foreign-target");
+        fs::write(&foreign, b"foreign").expect("foreign target");
+        symlink(&foreign, fixture.final_path()).expect("symlink final");
+        assert_ambiguous(&fixture, AbsentFinalRecoveryAmbiguity::FinalEntryNotRegular);
+
+        let fixture = Fixture::new();
+        let name = CString::new(fixture.final_path().as_os_str().as_bytes())
+            .expect("fifo path without NUL");
+        assert_eq!(unsafe { libc::mkfifo(name.as_ptr(), 0o600) }, 0);
+        assert_ambiguous(&fixture, AbsentFinalRecoveryAmbiguity::FinalEntryNotRegular);
+    }
+
+    #[test]
+    fn coordinator_rejects_v1_and_wrong_phase_records() {
+        let v1_directory = tempfile::tempdir().expect("v1 journal directory");
+        let mut v1_journal = OperationJournalCoordinator::open(v1_directory.path().to_path_buf())
+            .expect("open journal");
+        let v1 = v1_journal
+            .admit(
+                OperationIntent {
+                    actor: OperationActor::User,
+                    kind: OperationKind::FileHistory,
+                    label: String::from("v1"),
+                },
+                serde_json::json!({"schema": 1}),
+            )
+            .expect("admit v1 record");
+        assert!(matches!(
+            v1_journal.classify_schema_v2_absent_final_recovery(v1),
+            Err(crate::native_app::transaction_history::operation_journal::JournalError::InvalidPublicationEvidence { .. })
+        ));
+        drop(v1_journal);
+
+        let directory = tempfile::tempdir().expect("v2 journal directory");
+        let fixture = Fixture::new();
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open v2 journal");
+        let v2 = journal
+            .admit_schema_v2_absent_final_for_test(
+                OperationIntent {
+                    actor: OperationActor::User,
+                    kind: OperationKind::FileHistory,
+                    label: String::from("wrong phase"),
+                },
+                serde_json::json!({"schema": 2}),
+                fixture.prepared,
+                fixture.staged,
+                valid_capacity_plan(),
+            )
+            .expect("admit v2 record");
+        journal
+            .update(
+                v2,
+                OperationPhase::Terminal,
+                crate::native_app::transaction_history::operation_journal::OperationDisposition::CancelledBeforePublish,
+            )
+            .expect("cancel before publish");
+        assert!(matches!(
+            journal.classify_schema_v2_absent_final_recovery(v2),
+            Err(crate::native_app::transaction_history::operation_journal::JournalError::InvalidPublicationEvidence { .. })
+        ));
+    }
+
+    #[test]
+    fn journal_restart_and_classification_are_byte_and_state_read_only() {
+        let directory = tempfile::tempdir().expect("journal directory");
+        let fixture = Fixture::new();
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open journal");
+        let operation_id = journal
+            .admit_schema_v2_absent_final_for_test(
+                test_intent(),
+                serde_json::json!({"schema": 2, "fixture": true}),
+                fixture.prepared.clone(),
+                fixture.staged.clone(),
+                valid_capacity_plan(),
+            )
+            .expect("admit absent-final record");
+        let record_path = journal.record_path_for_test(operation_id);
+        let bytes_before = fs::read(&record_path).expect("record bytes before classification");
+        let record_before = journal
+            .record(operation_id)
+            .cloned()
+            .expect("record before");
+        let capacity_before = journal.capacity_claims_for_test();
+
+        assert_eq!(
+            journal
+                .classify_schema_v2_absent_final_recovery(operation_id)
+                .expect("first classification"),
+            AbsentFinalRecoveryClassification::StagingPresentFinalAbsent
+        );
+        assert_eq!(
+            journal
+                .classify_schema_v2_absent_final_recovery(operation_id)
+                .expect("repeat classification"),
+            AbsentFinalRecoveryClassification::StagingPresentFinalAbsent
+        );
+        assert_eq!(
+            fs::read(&record_path).expect("record bytes after classification"),
+            bytes_before
+        );
+        assert_eq!(journal.record(operation_id), Some(&record_before));
+        assert_eq!(journal.capacity_claims_for_test(), capacity_before);
+        drop(journal);
+
+        let reopened = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("reopen journal");
+        assert_eq!(reopened.record(operation_id), Some(&record_before));
+        assert_eq!(
+            reopened
+                .classify_schema_v2_absent_final_recovery(operation_id)
+                .expect("restart classification"),
+            AbsentFinalRecoveryClassification::StagingPresentFinalAbsent
+        );
+        assert_eq!(
+            fs::read(&record_path).expect("record bytes after restart"),
+            bytes_before
+        );
+        assert_eq!(reopened.capacity_claims_for_test(), capacity_before);
+    }
+
+    #[test]
+    fn malformed_copy_evidence_is_rejected_before_live_inspection() {
+        let directory = tempfile::tempdir().expect("journal directory");
+        let fixture = Fixture::new();
+        let mut prepared = fixture.prepared.clone();
+        prepared.copy_validated_evidence = PreparedFileEvidence::Metadata {
+            len: STAGING_BYTES.len() as u64,
+            modified_ns: None,
+            is_dir: false,
+        };
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open journal");
+        let result = journal.admit_schema_v2_absent_final_for_test(
+            test_intent(),
+            serde_json::json!({"schema": 2}),
+            prepared,
+            fixture.staged.clone(),
+            valid_capacity_plan(),
+        );
+        assert!(matches!(
+            result,
+            Err(
+                crate::native_app::transaction_history::operation_journal::JournalError::Write { .. }
+            )
+        ));
+
+        let mut staged = fixture.staged.clone();
+        let FilesystemStagedParticipant::CopyValidated { staging, .. } = &mut staged.participant;
+        staging.identity.stable_id.clear();
+        let result = journal.admit_schema_v2_absent_final_for_test(
+            test_intent(),
+            serde_json::json!({"schema": 2}),
+            fixture.prepared,
+            staged,
+            valid_capacity_plan(),
+        );
+        assert!(matches!(
+            result,
+            Err(
+                crate::native_app::transaction_history::operation_journal::JournalError::Write { .. }
+            )
+        ));
+        assert_eq!(journal.recovery_summary().record_count, 0);
+    }
+
+    fn test_intent() -> OperationIntent {
+        OperationIntent {
+            actor: OperationActor::User,
+            kind: OperationKind::FileHistory,
+            label: String::from("absent-final recovery"),
+        }
+    }
+
+    fn valid_capacity_plan() -> DurableCapacityPlan {
+        DurableCapacityPlan {
+            volumes: vec![DurableVolumeCapacity {
+                identity: VolumeIdentity { device: 77 },
+                allocation_unit: 4096,
+                allocation_class: CapacityAllocationClass::DestinationStaging,
+                logical_bytes: 4096,
+                allocated_bytes: 4096,
+                protected_free_bytes: PROTECTED_FREE_SPACE_FLOOR,
+            }],
+        }
+    }
+}

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -18,6 +18,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use uuid::Uuid;
 
+use super::AbsentFinalRecoveryClassification;
+use super::absent_final_recovery::classify_absent_final_recovery;
 pub(crate) use super::capacity_gate::VolumeIdentity;
 use super::capacity_gate::{DurableCapacityPlan, RejectedBeforeIntent};
 pub(crate) use super::expected_identity_replacement::ReplacementQualificationAssessment;
@@ -1201,6 +1203,18 @@ fn validate_prepared_contract(prepared: &PreparedTargetContract) -> Result<(), S
     let PreparedTargetContract::AbsentFinalNoReplace(prepared) = prepared else {
         return Ok(());
     };
+    if !prepared.source_root.path.is_absolute()
+        || prepared.source_root.identity.stable_id.is_empty()
+    {
+        return Err(String::from(
+            "absent-final source-root capability is not an absolute, identified root",
+        ));
+    }
+    if !prepared.target_parent.path.is_absolute() {
+        return Err(String::from(
+            "absent-final target-parent capability path must be absolute",
+        ));
+    }
     if prepared.target_parent.identity.stable_id.is_empty() {
         return Err(String::from(
             "absent-final target-parent capability identity is empty",
@@ -2102,7 +2116,7 @@ pub(super) fn descriptor_identity(file: &File) -> Result<PreparedObjectIdentity,
     })
 }
 
-fn open_root(path: &Path) -> Result<(File, PreparedRootCapability), String> {
+pub(super) fn open_root(path: &Path) -> Result<(File, PreparedRootCapability), String> {
     let file =
         super::capacity_gate::open_no_follow_path(path).map_err(|error| error.to_string())?;
     if !file.metadata().map_err(|error| error.to_string())?.is_dir() {
@@ -2817,6 +2831,67 @@ impl OperationJournalCoordinator {
         self.store.recovery_summary()
     }
 
+    /// Classify one eligible schema-v2 absent-final record by reacquiring and inspecting its
+    /// target-parent capability. This method is observation-only: it never updates the record,
+    /// writes journal bytes, changes disposition, or alters capacity claims.
+    pub(crate) fn classify_schema_v2_absent_final_recovery(
+        &self,
+        operation_id: Uuid,
+    ) -> Result<AbsentFinalRecoveryClassification, JournalError> {
+        let record = self
+            .store
+            .record(operation_id)
+            .ok_or(JournalError::NotFound(operation_id))?;
+        if record.schema_version != SCHEMA_V2 {
+            return Err(JournalError::InvalidPublicationEvidence {
+                operation_id,
+                reason: String::from("absent-final recovery requires schema-v2"),
+            });
+        }
+        if record.phase != OperationPhase::FilesystemStaged {
+            return Err(JournalError::InvalidPublicationEvidence {
+                operation_id,
+                reason: String::from("absent-final recovery requires the filesystem-staged phase"),
+            });
+        }
+        validate_schema_v2_phase_evidence_record(record).map_err(|reason| {
+            JournalError::InvalidPublicationEvidence {
+                operation_id,
+                reason,
+            }
+        })?;
+        let prepared = record
+            .prepared
+            .as_ref()
+            .ok_or(JournalError::MissingPreparedEvidence(operation_id))?;
+        let PreparedTargetContract::AbsentFinalNoReplace(prepared) = prepared else {
+            return Err(JournalError::InvalidPublicationEvidence {
+                operation_id,
+                reason: String::from(
+                    "absent-final recovery requires absent-final preparation evidence",
+                ),
+            });
+        };
+        let staged = record
+            .staged
+            .as_ref()
+            .ok_or(JournalError::MissingPreparedEvidence(operation_id))?;
+        validate_prepared_contract(&PreparedTargetContract::AbsentFinalNoReplace(
+            prepared.clone(),
+        ))
+        .map_err(|reason| JournalError::InvalidPublicationEvidence {
+            operation_id,
+            reason,
+        })?;
+        validate_absent_final_staged_checkpoint(prepared, staged).map_err(|reason| {
+            JournalError::InvalidPublicationEvidence {
+                operation_id,
+                reason,
+            }
+        })?;
+        Ok(classify_absent_final_recovery(prepared, staged))
+    }
+
     /// Admit an intent durably and return its stable operation ID.
     #[cfg(test)]
     pub(crate) fn admit(
@@ -2833,7 +2908,7 @@ impl OperationJournalCoordinator {
     /// Explicit test-only constructor for the schema-v2 absent-final contract. Production
     /// waveform-restore admission remains on `OperationRecord::new`, which is schema-v1.
     #[cfg(test)]
-    fn admit_schema_v2_absent_final_for_test(
+    pub(super) fn admit_schema_v2_absent_final_for_test(
         &mut self,
         intent: OperationIntent,
         payload: Value,
@@ -2867,6 +2942,16 @@ impl OperationJournalCoordinator {
         })?;
         self.store.admit_capacity(record)?;
         Ok(operation_id)
+    }
+
+    #[cfg(test)]
+    pub(super) fn record_path_for_test(&self, operation_id: Uuid) -> PathBuf {
+        self.store.record_path(operation_id)
+    }
+
+    #[cfg(test)]
+    pub(super) fn capacity_claims_for_test(&self) -> BTreeMap<VolumeIdentity, u64> {
+        self.store.capacity_claims.clone()
     }
 
     /// Admit exactly one bounded waveform restore after owner-thread capacity discovery.
@@ -6472,5 +6557,53 @@ mod tests {
         assert_eq!(record.disposition, OperationDisposition::AuditRequired);
         assert_eq!(record.staged.as_ref(), Some(&staged));
         assert!(record.published.is_none());
+    }
+
+    #[test]
+    fn absent_final_recovery_rejects_schema_v2_existing_target_contract() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let mut journal =
+            OperationJournalCoordinator::open(directory.path().to_path_buf()).unwrap();
+        let (prepared, staged, capacity_plan) = absent_final_v2_fixture();
+        let FilesystemStagedParticipant::CopyValidated { staging, evidence } =
+            staged.participant.clone();
+        let identity = staging.identity.clone();
+        let existing = PreparedWaveformRestore {
+            direction: prepared.direction,
+            source_id: prepared.source_id.clone(),
+            source_root: prepared.source_root.clone(),
+            target_root: prepared.target_parent.clone(),
+            target: PreparedLeafLocator {
+                relative_path: prepared.final_leaf.clone(),
+                identity: identity.clone(),
+            },
+            backup_root: prepared.target_parent.clone(),
+            backup: PreparedLeafLocator {
+                relative_path: prepared.staging.relative_path.clone(),
+                identity: identity.clone(),
+            },
+            replacement: ReplaceExpectedIdentity::Existing(identity),
+            staging: prepared.staging.clone(),
+            evidence: PreparedRestoreEvidence {
+                target: PreparedFileEvidence::Missing,
+                backup: evidence,
+            },
+        };
+        let mut record = OperationRecord::new_v2_absent_final_with_capacity_plan(
+            intent(),
+            serde_json::json!({"schema": 2}),
+            prepared,
+            staged,
+            capacity_plan,
+        );
+        let operation_id = record.operation_id;
+        record.prepared = Some(PreparedTargetContract::ExistingExpectedIdentity(existing));
+        journal.store.admit_capacity(record).unwrap();
+
+        assert!(matches!(
+            journal.classify_schema_v2_absent_final_recovery(operation_id),
+            Err(JournalError::InvalidPublicationEvidence { .. })
+        ));
     }
 }


### PR DESCRIPTION
## Goal

Advance Wavecrate toward docs/IO_ARCHITECTURE_TARGET.md by making eligible schema-v2 absent-final staging records safely inspectable after a crash-window restart without claiming ownership or mutating durable state.

## Scope and non-goals

This slice adds a descriptor-relative, no-follow recovery classifier for schema-v2 AbsentFinalNoReplace records in FilesystemStaged with valid prepared and CopyValidated evidence. It covers staging/final presence, exact identity and content matching, collisions, and conservative ambiguity.

It does not adopt or publish files, rename/link/unlink/remove paths, write journals, change phases or capacity claims, infer pathname continuity, enable production schema-v2 admission, add owner/startup wiring, or change database/source behavior.

## Definition of Done

- Reacquire the durable target-parent capability and inspect one clean leaf at a time without following symlinks.
- Return typed classifications for the complete presence, collision, drift, race, and unsupported-platform matrix.
- Reject ineligible schema, phase, contract, and evidence before live inspection.
- Preserve existing no-replace qualification semantics through shared identity/content predicates.
- Prove restart and repeated classification are byte/state/capacity read-only.
- Keep the next adoption contract explicitly deferred.

## Validation

- Isolated clean Radiant patch focused classifier tests: 10 passed.
- Isolated operation-journal tests: 67 passed.
- Isolated absent-final no-replace tests: 12 passed.
- Isolated publication tests: 2 passed.
- Isolated cargo check: passed.
- Changed-file rustfmt check and git diff check: passed.
- Workspace cargo fmt still reports only known unrelated pre-existing diffs outside this slice.

## Known limitations

The classifier is observation-only and has no production caller; production schema-v2 absent-final admission remains disabled. Non-Unix builds fail closed and were not cross-compiled in this validation. The next bounded task is an idempotent adoption contract for StagingMissingFinalMatches; production mutation remains deferred.

User approval is required before merge. The user has explicitly approved this merge workflow.