### PR TITLE
Add capability-bound absent-final adoption guard

### DIFF
--- a/src/native_app/transaction_history/absent_final_no_replace.rs
+++ b/src/native_app/transaction_history/absent_final_no_replace.rs
@@ -37,6 +37,146 @@ pub(super) struct AbsentFinalNoReplaceRequest<'a> {
     expected_content: &'a PreparedFileEvidence,
 }
 
+/// A read-only request to qualify an already-present final through a retained parent capability.
+///
+/// The request borrows the capability and carries only durable identity/content expectations. It
+/// contains no pathname outside the clean final leaf and grants no namespace mutation authority.
+pub(super) struct AbsentFinalAdoptionRequest<'a> {
+    target_parent: &'a File,
+    final_leaf: &'a Path,
+    expected_target_parent: &'a PreparedObjectIdentity,
+    expected_final_stable_id: &'a str,
+    expected_final_len: u64,
+    expected_final_content: &'a [u8; 32],
+}
+
+impl<'a> AbsentFinalAdoptionRequest<'a> {
+    pub(super) fn try_new(
+        target_parent: &'a File,
+        final_leaf: &'a Path,
+        expected_target_parent: &'a PreparedObjectIdentity,
+        expected_final_stable_id: &'a str,
+        expected_final_len: u64,
+        expected_final_content: &'a [u8; 32],
+    ) -> Result<Self, AbsentFinalNoReplaceRequestError> {
+        if !is_single_clean_normal_leaf(final_leaf) {
+            return Err(AbsentFinalNoReplaceRequestError::TargetLeafNotSingleCleanNormal);
+        }
+        if expected_final_stable_id.is_empty() {
+            return Err(AbsentFinalNoReplaceRequestError::TargetLeafNotSingleCleanNormal);
+        }
+        Ok(Self {
+            target_parent,
+            final_leaf,
+            expected_target_parent,
+            expected_final_stable_id,
+            expected_final_len,
+            expected_final_content,
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum AbsentFinalAdoptionOutcome {
+    Qualified(QualifiedAbsentFinalAdoption),
+    ParentIdentityDrift,
+    FinalMissing,
+    FinalIdentityDrift,
+    FinalContentDrift,
+    UnsupportedPlatform,
+    VerificationFailed,
+}
+
+/// Transient evidence from one descriptor-relative adoption qualification.
+/// It intentionally contains no path or open handle.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct QualifiedAbsentFinalAdoption {
+    pub(super) target_parent: PreparedObjectIdentity,
+    pub(super) final_object: PreparedObjectIdentity,
+    pub(super) final_content: PreparedFileEvidence,
+}
+
+pub(super) trait AbsentFinalAdoptionAdapter: sealed::Sealed {
+    fn qualify(&self, request: AbsentFinalAdoptionRequest<'_>) -> AbsentFinalAdoptionOutcome;
+}
+
+pub(super) struct ProductionAbsentFinalAdoptionAdapter;
+
+impl sealed::Sealed for ProductionAbsentFinalAdoptionAdapter {}
+
+impl AbsentFinalAdoptionAdapter for ProductionAbsentFinalAdoptionAdapter {
+    fn qualify(&self, request: AbsentFinalAdoptionRequest<'_>) -> AbsentFinalAdoptionOutcome {
+        #[cfg(unix)]
+        {
+            return qualify_unix_absent_final_adoption(request);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = request;
+            AbsentFinalAdoptionOutcome::UnsupportedPlatform
+        }
+    }
+}
+
+#[cfg(unix)]
+fn qualify_unix_absent_final_adoption(
+    request: AbsentFinalAdoptionRequest<'_>,
+) -> AbsentFinalAdoptionOutcome {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let parent = match super::operation_journal::descriptor_identity(request.target_parent) {
+        Ok(identity) if identity.stable_id == request.expected_target_parent.stable_id => identity,
+        Ok(_) => return AbsentFinalAdoptionOutcome::ParentIdentityDrift,
+        Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+    };
+    let name = match CString::new(request.final_leaf.as_os_str().as_encoded_bytes()) {
+        Ok(name) => name,
+        Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+    };
+    let fd = unsafe {
+        libc::openat(
+            request.target_parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+        )
+    };
+    if fd < 0 {
+        return match std::io::Error::last_os_error().kind() {
+            std::io::ErrorKind::NotFound => AbsentFinalAdoptionOutcome::FinalMissing,
+            _ => AbsentFinalAdoptionOutcome::VerificationFailed,
+        };
+    }
+    let final_file = unsafe { File::from_raw_fd(fd) };
+    let metadata = match final_file.metadata() {
+        Ok(metadata) if metadata.is_file() => metadata,
+        Ok(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+        Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+    };
+    let final_object = match super::operation_journal::descriptor_identity(&final_file) {
+        Ok(identity) => identity,
+        Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+    };
+    if final_object.stable_id != request.expected_final_stable_id
+        || final_object.len != request.expected_final_len
+        || metadata.len() != request.expected_final_len
+    {
+        return AbsentFinalAdoptionOutcome::FinalIdentityDrift;
+    }
+    let final_content = super::operation_journal::prepared_file_evidence(&final_file);
+    if !matches!(
+        final_content,
+        PreparedFileEvidence::ContentHash(hash) if &hash == request.expected_final_content
+    ) {
+        return AbsentFinalAdoptionOutcome::FinalContentDrift;
+    }
+    AbsentFinalAdoptionOutcome::Qualified(QualifiedAbsentFinalAdoption {
+        target_parent: parent,
+        final_object,
+        final_content,
+    })
+}
+
 impl<'a> AbsentFinalNoReplaceRequest<'a> {
     /// Build a request after validating both namespace leaves without touching the filesystem.
     pub(super) fn try_new(
@@ -877,6 +1017,122 @@ mod tests {
         ));
         assert_not_qualified(&outcome);
         assert!(!fixture.target_path().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn adoption_qualifies_final_after_staging_to_final_rename() {
+        let fixture = Fixture::new();
+        fs::rename(fixture.staging_path(), fixture.target_path()).expect("stage final");
+        let final_file = File::open(fixture.target_path()).expect("final file");
+        let final_identity = descriptor_identity(&final_file).expect("final identity");
+        let request = AbsentFinalAdoptionRequest::try_new(
+            &fixture.target_parent,
+            Path::new(TARGET_LEAF),
+            &fixture.target_parent_identity,
+            &final_identity.stable_id,
+            final_identity.len,
+            match &fixture.expected_content {
+                PreparedFileEvidence::ContentHash(hash) => hash,
+                _ => panic!("fixture must have exact content"),
+            },
+        )
+        .expect("valid adoption request");
+        let outcome = ProductionAbsentFinalAdoptionAdapter.qualify(request);
+        assert!(matches!(outcome, AbsentFinalAdoptionOutcome::Qualified(_)));
+        assert!(!fixture.staging_path().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn adoption_missing_final_and_replacement_fail_closed() {
+        let fixture = Fixture::new();
+        let hash = match &fixture.expected_content {
+            PreparedFileEvidence::ContentHash(hash) => hash,
+            _ => panic!("fixture must have exact content"),
+        };
+        let request = AbsentFinalAdoptionRequest::try_new(
+            &fixture.target_parent,
+            Path::new(TARGET_LEAF),
+            &fixture.target_parent_identity,
+            &fixture.expected_staging.stable_id,
+            fixture.expected_staging.len,
+            hash,
+        )
+        .expect("valid adoption request");
+        assert_eq!(
+            ProductionAbsentFinalAdoptionAdapter.qualify(request),
+            AbsentFinalAdoptionOutcome::FinalMissing
+        );
+        fs::write(fixture.target_path(), b"replacement").expect("replacement final");
+        let request = AbsentFinalAdoptionRequest::try_new(
+            &fixture.target_parent,
+            Path::new(TARGET_LEAF),
+            &fixture.target_parent_identity,
+            &fixture.expected_staging.stable_id,
+            fixture.expected_staging.len,
+            hash,
+        )
+        .expect("valid adoption request");
+        assert!(matches!(
+            ProductionAbsentFinalAdoptionAdapter.qualify(request),
+            AbsentFinalAdoptionOutcome::FinalIdentityDrift
+                | AbsentFinalAdoptionOutcome::FinalContentDrift
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn adoption_rejects_parent_identity_and_final_symlink() {
+        let fixture = Fixture::new();
+        let hash = match &fixture.expected_content {
+            PreparedFileEvidence::ContentHash(hash) => hash,
+            _ => panic!("fixture must have exact content"),
+        };
+        let mut wrong_parent = fixture.target_parent_identity.clone();
+        wrong_parent.stable_id = String::from("wrong-parent");
+        let request = AbsentFinalAdoptionRequest::try_new(
+            &fixture.target_parent,
+            Path::new(TARGET_LEAF),
+            &wrong_parent,
+            &fixture.expected_staging.stable_id,
+            fixture.expected_staging.len,
+            hash,
+        )
+        .expect("valid adoption request");
+        assert_eq!(
+            ProductionAbsentFinalAdoptionAdapter.qualify(request),
+            AbsentFinalAdoptionOutcome::ParentIdentityDrift
+        );
+        std::os::unix::fs::symlink(fixture.staging_path(), fixture.target_path())
+            .expect("symlink final");
+        let request = AbsentFinalAdoptionRequest::try_new(
+            &fixture.target_parent,
+            Path::new(TARGET_LEAF),
+            &fixture.target_parent_identity,
+            &fixture.expected_staging.stable_id,
+            fixture.expected_staging.len,
+            hash,
+        )
+        .expect("valid adoption request");
+        assert_eq!(
+            ProductionAbsentFinalAdoptionAdapter.qualify(request),
+            AbsentFinalAdoptionOutcome::VerificationFailed
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn adoption_parent_reacquisition_rejects_symlink_path() {
+        let fixture = Fixture::new();
+        let alias = fixture
+            .target_parent_path
+            .parent()
+            .expect("fixture parent")
+            .join("target-parent-alias");
+        std::os::unix::fs::symlink(&fixture.target_parent_path, &alias)
+            .expect("symlink target parent");
+        assert!(super::super::operation_journal::open_root(&alias).is_err());
     }
 
     #[cfg(all(target_os = "macos", test))]

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -19,6 +19,10 @@ use serde_json::{Map, Value};
 use uuid::Uuid;
 
 use super::AbsentFinalRecoveryClassification;
+use super::absent_final_no_replace::{
+    AbsentFinalAdoptionAdapter, AbsentFinalAdoptionOutcome, AbsentFinalNoReplaceRequestError,
+    ProductionAbsentFinalAdoptionAdapter,
+};
 use super::absent_final_recovery::inspect_absent_final_recovery;
 pub(crate) use super::capacity_gate::VolumeIdentity;
 use super::capacity_gate::{DurableCapacityPlan, RejectedBeforeIntent};
@@ -3485,6 +3489,121 @@ impl OperationJournalCoordinator {
         Ok(AbsentFinalRecoveryClassification::StagingMissingFinalMatches)
     }
 
+    /// Qualify an already-present absent-final entry through a freshly reacquired, identity-checked
+    /// target-parent capability. This is observation-only: it never writes the journal, changes
+    /// phase/timestamps/capacity, or mutates the filesystem.
+    pub(crate) fn qualify_schema_v2_absent_final_adoption(
+        &self,
+        operation_id: Uuid,
+    ) -> Result<AbsentFinalAdoptionOutcome, JournalError> {
+        let inspection = self
+            .inspect_schema_v2_absent_final_recovery(operation_id)
+            .map_err(|error| match error {
+                JournalError::NotFound(_) => error,
+                error => JournalError::InvalidRecoveryObservation {
+                    operation_id,
+                    reason: format!("invalid durable absent-final adoption precondition: {error}"),
+                },
+            })?;
+        if !matches!(
+            inspection.classification,
+            AbsentFinalRecoveryClassification::StagingMissingFinalMatches
+        ) {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: format!(
+                    "absent-final adoption requires StagingMissingFinalMatches, got {:?}",
+                    inspection.classification
+                ),
+            });
+        }
+        let record = self
+            .store
+            .record(operation_id)
+            .ok_or(JournalError::NotFound(operation_id))?;
+        let Some(observation) = record.absent_final_recovery_observation.as_ref() else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final adoption requires a recovery observation"),
+            });
+        };
+        let Some(proof) = record.absent_final_transaction_owned_proof.as_ref() else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final adoption requires transaction-owned proof"),
+            });
+        };
+        if proof.target_parent_stable_id != observation.target_parent_stable_id
+            || proof.final_stable_id != observation.final_stable_id
+            || proof.final_len != observation.final_len
+            || proof.final_content != observation.final_content
+        {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final adoption proof conflicts with observation"),
+            });
+        }
+        let Some(PreparedTargetContract::AbsentFinalNoReplace(prepared)) = record.prepared.as_ref()
+        else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final adoption requires absent-final preparation"),
+            });
+        };
+        let PreparedFileEvidence::ContentHash(expected_content) = &proof.final_content else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final adoption requires exact content proof"),
+            });
+        };
+        let (target_parent, target_capability) =
+            open_root(&prepared.target_parent.path).map_err(|reason| {
+                JournalError::InvalidRecoveryObservation {
+                    operation_id,
+                    reason: format!("could not reacquire target-parent capability: {reason}"),
+                }
+            })?;
+        if target_capability.identity.stable_id != proof.target_parent_stable_id {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("reacquired target-parent identity conflicts with proof"),
+            });
+        }
+        let request = super::absent_final_no_replace::AbsentFinalAdoptionRequest::try_new(
+            &target_parent,
+            &prepared.final_leaf,
+            &target_capability.identity,
+            &proof.final_stable_id,
+            proof.final_len,
+            expected_content,
+        )
+        .map_err(|error| JournalError::InvalidRecoveryObservation {
+            operation_id,
+            reason: match error {
+                AbsentFinalNoReplaceRequestError::TargetLeafNotSingleCleanNormal => {
+                    String::from("absent-final adoption final leaf is not clean")
+                }
+                AbsentFinalNoReplaceRequestError::StagingLeafNotSingleCleanNormal => {
+                    String::from("absent-final adoption staging leaf is not applicable")
+                }
+            },
+        })?;
+        let outcome = ProductionAbsentFinalAdoptionAdapter.qualify(request);
+        if let AbsentFinalAdoptionOutcome::Qualified(qualified) = &outcome {
+            if qualified.target_parent != target_capability.identity
+                || qualified.final_object.stable_id != proof.final_stable_id
+                || qualified.final_object.len != proof.final_len
+                || qualified.final_content != proof.final_content
+            {
+                return Err(JournalError::InvalidRecoveryObservation {
+                    operation_id,
+                    reason: String::from("qualified absent-final evidence conflicts with proof"),
+                });
+            }
+        }
+        Ok(outcome)
+    }
+
     /// Admit an intent durably and return its stable operation ID.
     #[cfg(test)]
     pub(crate) fn admit(
@@ -4461,6 +4580,56 @@ mod tests {
             )
             .expect("admit schema-v2 absent-final fixture");
         (operation_id, prepared, staged)
+    }
+
+    #[cfg(unix)]
+    fn admit_real_absent_final_v2_fixture(
+        journal: &mut OperationJournalCoordinator,
+        directory: &tempfile::TempDir,
+    ) -> (Uuid, PathBuf, PathBuf) {
+        let target_parent_path = directory.path().join("target-parent");
+        fs::create_dir(&target_parent_path).expect("real target parent");
+        let staging_path = target_parent_path.join("staging.wav");
+        let final_path = target_parent_path.join("final.wav");
+        fs::write(&staging_path, b"real staged bytes").expect("real staging bytes");
+        let (target_parent, target_parent_capability) =
+            open_root(&target_parent_path).expect("real target parent capability");
+        let staging = File::open(&staging_path).expect("real staging file");
+        let staging_identity = descriptor_identity(&staging).expect("real staging identity");
+        let evidence = prepared_file_evidence(&staging);
+        let prepared = PreparedAbsentFinalNoReplace {
+            direction: PreparedRestoreDirection::Undo,
+            source_id: String::from("real-v2-fixture-source"),
+            source_root: target_parent_capability.clone(),
+            target_parent: target_parent_capability,
+            final_leaf: PathBuf::from("final.wav"),
+            staging: PreparedStagingLocator {
+                relative_path: PathBuf::from("staging.wav"),
+                absent: true,
+            },
+            final_observation: AbsentFinalObservation::ObservedAbsent,
+            copy_validated_evidence: evidence.clone(),
+        };
+        let staged = FilesystemStagedWaveformRestore {
+            participant: FilesystemStagedParticipant::CopyValidated {
+                staging: PreparedLeafLocator {
+                    relative_path: PathBuf::from("staging.wav"),
+                    identity: staging_identity,
+                },
+                evidence,
+            },
+        };
+        let operation_id = journal
+            .admit_schema_v2_absent_final_for_test(
+                intent(),
+                serde_json::json!({"schema": 2}),
+                prepared,
+                staged,
+                valid_capacity_plan(),
+            )
+            .expect("admit real schema-v2 absent-final fixture");
+        drop(target_parent);
+        (operation_id, final_path, staging_path)
     }
 
     fn invalid_v2_admission_record() -> OperationRecord {
@@ -6868,6 +7037,171 @@ mod tests {
         );
         assert_eq!(old_v2.recovery_summary().malformed_count, 0);
         assert_eq!(fs::read(&path).unwrap(), old_v2_bytes);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schema_v2_absent_final_adoption_qualification_is_exact_and_observation_only() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let directory = fixture_directory();
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open real fixture journal");
+        let (operation_id, final_path, staging_path) =
+            admit_real_absent_final_v2_fixture(&mut journal, &directory);
+        fs::rename(&staging_path, &final_path).expect("staging to final rename");
+        journal
+            .record_schema_v2_absent_final_recovery_observation(operation_id)
+            .expect("record exact recovery observation");
+        journal
+            .record_schema_v2_absent_final_transaction_owned_proof(operation_id)
+            .expect("record exact transaction-owned proof");
+
+        let record_before = journal.record(operation_id).unwrap().clone();
+        let proof = record_before
+            .absent_final_transaction_owned_proof
+            .clone()
+            .expect("durable transaction-owned proof");
+        let path = journal.store.record_path(operation_id);
+        let bytes_before = fs::read(&path).expect("journal bytes before qualification");
+        let claims_before = journal.store.capacity_claims().clone();
+        let final_bytes_before = fs::read(&final_path).expect("final bytes before qualification");
+        assert!(!staging_path.exists());
+
+        let outcome = journal
+            .qualify_schema_v2_absent_final_adoption(operation_id)
+            .expect("qualify real absent-final adoption");
+        let AbsentFinalAdoptionOutcome::Qualified(qualified) = outcome else {
+            panic!("expected qualified adoption outcome");
+        };
+        assert_eq!(
+            qualified.target_parent.stable_id,
+            proof.target_parent_stable_id
+        );
+        assert_eq!(qualified.final_object.stable_id, proof.final_stable_id);
+        assert_eq!(qualified.final_object.len, proof.final_len);
+        assert_eq!(qualified.final_content, proof.final_content);
+        assert_eq!(journal.record(operation_id), Some(&record_before));
+        assert_eq!(fs::read(&path).unwrap(), bytes_before);
+        assert_eq!(journal.store.capacity_claims(), &claims_before);
+        assert_eq!(fs::read(&final_path).unwrap(), final_bytes_before);
+        assert!(!staging_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schema_v2_absent_final_adoption_missing_evidence_is_immutable() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        for record_proof in [false, true] {
+            let directory = fixture_directory();
+            let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+                .expect("open real fixture journal");
+            let (operation_id, final_path, staging_path) =
+                admit_real_absent_final_v2_fixture(&mut journal, &directory);
+            fs::rename(&staging_path, &final_path).expect("staging to final rename");
+            journal
+                .record_schema_v2_absent_final_recovery_observation(operation_id)
+                .expect("record exact recovery observation");
+            if !record_proof {
+                let record = journal.record(operation_id).unwrap().clone();
+                let path = journal.store.record_path(operation_id);
+                let bytes_before = fs::read(&path).unwrap();
+                let claims_before = journal.store.capacity_claims().clone();
+                let final_bytes_before = fs::read(&final_path).unwrap();
+                let error = journal
+                    .qualify_schema_v2_absent_final_adoption(operation_id)
+                    .unwrap_err();
+                assert!(matches!(
+                    error,
+                    JournalError::InvalidRecoveryObservation { .. }
+                ));
+                assert_eq!(journal.record(operation_id), Some(&record));
+                assert_eq!(fs::read(&path).unwrap(), bytes_before);
+                assert_eq!(journal.store.capacity_claims(), &claims_before);
+                assert_eq!(fs::read(&final_path).unwrap(), final_bytes_before);
+                assert!(!staging_path.exists());
+                continue;
+            }
+            journal
+                .record_schema_v2_absent_final_transaction_owned_proof(operation_id)
+                .expect("record exact transaction-owned proof");
+            let mut invalid = journal.record(operation_id).unwrap().clone();
+            invalid.absent_final_recovery_observation = None;
+            journal.store.records.insert(operation_id, invalid.clone());
+            let path = journal.store.record_path(operation_id);
+            let bytes_before = fs::read(&path).unwrap();
+            let claims_before = journal.store.capacity_claims().clone();
+            let final_bytes_before = fs::read(&final_path).unwrap();
+            let error = journal
+                .qualify_schema_v2_absent_final_adoption(operation_id)
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                JournalError::InvalidRecoveryObservation { .. }
+            ));
+            assert_eq!(journal.record(operation_id), Some(&invalid));
+            assert_eq!(fs::read(&path).unwrap(), bytes_before);
+            assert_eq!(journal.store.capacity_claims(), &claims_before);
+            assert_eq!(fs::read(&final_path).unwrap(), final_bytes_before);
+            assert!(!staging_path.exists());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schema_v2_absent_final_adoption_stale_final_and_parent_are_immutable() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        for replace_parent in [false, true] {
+            let directory = fixture_directory();
+            let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+                .expect("open real fixture journal");
+            let (operation_id, final_path, staging_path) =
+                admit_real_absent_final_v2_fixture(&mut journal, &directory);
+            fs::rename(&staging_path, &final_path).expect("staging to final rename");
+            journal
+                .record_schema_v2_absent_final_recovery_observation(operation_id)
+                .expect("record exact recovery observation");
+            journal
+                .record_schema_v2_absent_final_transaction_owned_proof(operation_id)
+                .expect("record exact transaction-owned proof");
+            let path = journal.store.record_path(operation_id);
+            let record_before = journal.record(operation_id).unwrap().clone();
+            let bytes_before = fs::read(&path).unwrap();
+            let claims_before = journal.store.capacity_claims().clone();
+
+            let final_bytes_before = if replace_parent {
+                let target_parent = final_path.parent().unwrap().to_path_buf();
+                let moved_parent = target_parent.with_file_name("moved-target-parent");
+                fs::rename(&target_parent, &moved_parent).expect("move target parent");
+                fs::create_dir(&target_parent).expect("replacement target parent");
+                let moved_final = moved_parent.join("final.wav");
+                fs::read(moved_final).expect("moved final bytes")
+            } else {
+                fs::write(&final_path, b"stale replacement bytes").expect("replace final");
+                fs::read(&final_path).expect("stale final bytes")
+            };
+            let error = journal
+                .qualify_schema_v2_absent_final_adoption(operation_id)
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                JournalError::InvalidRecoveryObservation { .. }
+            ));
+            assert_eq!(journal.record(operation_id), Some(&record_before));
+            assert_eq!(fs::read(&path).unwrap(), bytes_before);
+            assert_eq!(journal.store.capacity_claims(), &claims_before);
+            if replace_parent {
+                let moved_final = final_path
+                    .parent()
+                    .unwrap()
+                    .with_file_name("moved-target-parent")
+                    .join("final.wav");
+                assert_eq!(fs::read(moved_final).unwrap(), final_bytes_before);
+                assert!(!final_path.exists());
+            } else {
+                assert_eq!(fs::read(&final_path).unwrap(), final_bytes_before);
+            }
+            assert!(!staging_path.exists());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Goal

Add the capability-bound, read-only adoption guard that consumes the durable schema-v2 transaction-owned proof from PR #1011.

## Scope and non-goals

- Add a sealed absent-final adoption request and transient qualified evidence.
- Reopen the final only relative to a retained no-follow target-parent descriptor and verify live parent identity, final identity/length, and exact content hash.
- Add a coordinator read-only qualification method requiring valid schema-v2 staged evidence, recovery observation, and transaction-owned proof.
- Preserve journal bytes, phase, timestamps, capacity claims, and filesystem state during qualification.
- Do not change `publication.rs`, the existing no-replace mutation adapter, production absent-final workflow, or any namespace mutation.

## Definition of Done

- Stored locators are used only to reacquire a live target-parent capability; no pathname fallback is used.
- Non-Unix and ambiguous/missing/drifted entries fail closed.
- Successful transient evidence contains no pathname or open handle and exactly matches the durable transaction-owned proof.
- Coordinator success and all failure paths are observation-only.
- Regression coverage covers success, missing/replaced/symlink final and parent, missing proof/observation, and journal/record/timestamp/capacity/filesystem immutability.
- Terra security/capability review approves the complete diff with no required findings.

## Validation

- `rustfmt --edition 2024 --check` on changed files
- `git diff --check`
- Isolated `cargo test --locked` with clean Radiant archive:
  - `transaction_history::absent_final_no_replace`: 16 passed
  - `transaction_history::absent_final_recovery`: 17 passed
  - `transaction_history::operation_journal`: 75 passed
  - `transaction_history::publication`: 2 passed
- Isolated full `cargo check --locked`: passed
- Terra specialist review: `APPROVE`

## Known limitations

This is a transient read-only qualification seam; it does not persist adoption evidence or advance `FilesystemPublished`. Non-Unix behavior is fail-closed and was not cross-platform compiled in this macOS validation. Concurrent post-return filesystem changes require the later publication/ownership guard.

## Next task

Add the durable publication/adoption evidence guard that consumes this qualified result without claiming an unverified final-name primitive, then continue source/database reconciliation.

User approval is required before merge.