### PR TITLE
Separate live adoption authority from journal

### DIFF
--- a/src/native_app/transaction_history/absent_final_no_replace.rs
+++ b/src/native_app/transaction_history/absent_final_no_replace.rs
@@ -8,11 +8,14 @@
 #![allow(dead_code)]
 
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-use super::operation_journal::{PreparedFileEvidence, PreparedObjectIdentity};
+use super::operation_journal::{
+    AbsentFinalAdoptionGuardRequest, PreparedFileEvidence, PreparedObjectIdentity,
+};
 use super::publication::{PublicationSynchronization, PublicationVisibility};
 
 mod sealed {
@@ -76,9 +79,42 @@ impl<'a> AbsentFinalAdoptionRequest<'a> {
     }
 }
 
+impl AbsentFinalAdoptionGuardRequest {
+    pub(super) fn try_new(
+        operation_id: Uuid,
+        target_parent_path: PathBuf,
+        final_leaf: PathBuf,
+        expected_target_parent_stable_id: String,
+        expected_final_stable_id: String,
+        expected_final_len: u64,
+        expected_final_content: [u8; 32],
+    ) -> Result<Self, AbsentFinalNoReplaceRequestError> {
+        if !is_single_clean_normal_leaf(&final_leaf) {
+            return Err(AbsentFinalNoReplaceRequestError::TargetLeafNotSingleCleanNormal);
+        }
+        if expected_target_parent_stable_id.is_empty() || expected_final_stable_id.is_empty() {
+            return Err(AbsentFinalNoReplaceRequestError::TargetLeafNotSingleCleanNormal);
+        }
+        Ok(Self {
+            operation_id,
+            target_parent_path,
+            final_leaf,
+            expected_target_parent_stable_id,
+            expected_final_stable_id,
+            expected_final_len,
+            expected_final_content,
+        })
+    }
+
+    pub(super) fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum AbsentFinalAdoptionOutcome {
     Qualified(QualifiedAbsentFinalAdoption),
+    OperationIdDrift,
     ParentIdentityDrift,
     FinalMissing,
     FinalIdentityDrift,
@@ -94,6 +130,45 @@ pub(crate) struct QualifiedAbsentFinalAdoption {
     pub(super) target_parent: PreparedObjectIdentity,
     pub(super) final_object: PreparedObjectIdentity,
     pub(super) final_content: PreparedFileEvidence,
+}
+
+/// A retained, read-only capability for a qualified absent-final adoption.
+///
+/// This deliberately has no serialization, comparison, or clone boundary. The retained
+/// descriptors, clean leaf, and exact content hash are the authority for a later binding check;
+/// the configured root pathname is not retained or consulted.
+pub(super) struct QualifiedAbsentFinalAdoptionGuard {
+    operation_id: Uuid,
+    target_parent: File,
+    final_object: File,
+    final_leaf: PathBuf,
+    target_parent_identity: PreparedObjectIdentity,
+    final_identity: PreparedObjectIdentity,
+    final_content: [u8; 32],
+}
+
+impl QualifiedAbsentFinalAdoptionGuard {
+    pub(super) fn revalidate_binding(
+        &self,
+        current_operation_id: Uuid,
+    ) -> Result<(), AbsentFinalAdoptionOutcome> {
+        #[cfg(unix)]
+        {
+            if self.operation_id != current_operation_id {
+                return Err(AbsentFinalAdoptionOutcome::OperationIdDrift);
+            }
+            return revalidate_unix_absent_final_adoption_guard(self);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (self, current_operation_id);
+            Err(AbsentFinalAdoptionOutcome::UnsupportedPlatform)
+        }
+    }
+
+    pub(super) fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
 }
 
 pub(super) trait AbsentFinalAdoptionAdapter: sealed::Sealed {
@@ -118,63 +193,188 @@ impl AbsentFinalAdoptionAdapter for ProductionAbsentFinalAdoptionAdapter {
     }
 }
 
+impl ProductionAbsentFinalAdoptionAdapter {
+    /// Acquire a retained, operation-bound guard through the live target-parent capability.
+    ///
+    /// This is the file-operation owner boundary: the journal request contains only durable
+    /// locators and expectations, while this adapter reacquires descriptors and verifies live
+    /// identity and exact content before retaining either descriptor.
+    pub(super) fn acquire_guard(
+        &self,
+        request: AbsentFinalAdoptionGuardRequest,
+    ) -> Result<QualifiedAbsentFinalAdoptionGuard, AbsentFinalAdoptionOutcome> {
+        #[cfg(unix)]
+        {
+            return acquire_unix_absent_final_adoption_guard(request);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = request;
+            Err(AbsentFinalAdoptionOutcome::UnsupportedPlatform)
+        }
+    }
+}
+
 #[cfg(unix)]
-fn qualify_unix_absent_final_adoption(
-    request: AbsentFinalAdoptionRequest<'_>,
-) -> AbsentFinalAdoptionOutcome {
+fn open_final_relative(
+    target_parent: &File,
+    final_leaf: &Path,
+) -> Result<File, AbsentFinalAdoptionOutcome> {
     use std::ffi::CString;
     use std::os::fd::{AsRawFd, FromRawFd};
 
-    let parent = match super::operation_journal::descriptor_identity(request.target_parent) {
-        Ok(identity) if identity.stable_id == request.expected_target_parent.stable_id => identity,
-        Ok(_) => return AbsentFinalAdoptionOutcome::ParentIdentityDrift,
-        Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
-    };
-    let name = match CString::new(request.final_leaf.as_os_str().as_encoded_bytes()) {
-        Ok(name) => name,
-        Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
-    };
+    let name = CString::new(final_leaf.as_os_str().as_encoded_bytes())
+        .map_err(|_| AbsentFinalAdoptionOutcome::VerificationFailed)?;
     let fd = unsafe {
         libc::openat(
-            request.target_parent.as_raw_fd(),
+            target_parent.as_raw_fd(),
             name.as_ptr(),
             libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
         )
     };
     if fd < 0 {
         return match std::io::Error::last_os_error().kind() {
-            std::io::ErrorKind::NotFound => AbsentFinalAdoptionOutcome::FinalMissing,
-            _ => AbsentFinalAdoptionOutcome::VerificationFailed,
+            std::io::ErrorKind::NotFound => Err(AbsentFinalAdoptionOutcome::FinalMissing),
+            _ => Err(AbsentFinalAdoptionOutcome::VerificationFailed),
         };
     }
-    let final_file = unsafe { File::from_raw_fd(fd) };
-    let metadata = match final_file.metadata() {
-        Ok(metadata) if metadata.is_file() => metadata,
-        Ok(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
-        Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn observe_final(
+    final_file: &File,
+) -> Result<(PreparedObjectIdentity, [u8; 32]), AbsentFinalAdoptionOutcome> {
+    let metadata = final_file
+        .metadata()
+        .map_err(|_| AbsentFinalAdoptionOutcome::VerificationFailed)?;
+    if !metadata.is_file() {
+        return Err(AbsentFinalAdoptionOutcome::VerificationFailed);
+    }
+    let identity = super::operation_journal::descriptor_identity(final_file)
+        .map_err(|_| AbsentFinalAdoptionOutcome::VerificationFailed)?;
+    let content = super::operation_journal::prepared_file_evidence(final_file);
+    let PreparedFileEvidence::ContentHash(hash) = content else {
+        return Err(AbsentFinalAdoptionOutcome::FinalContentDrift);
     };
-    let final_object = match super::operation_journal::descriptor_identity(&final_file) {
-        Ok(identity) => identity,
-        Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+
+    let after_identity = super::operation_journal::descriptor_identity(final_file)
+        .map_err(|_| AbsentFinalAdoptionOutcome::VerificationFailed)?;
+    if after_identity.stable_id != identity.stable_id || after_identity.len != identity.len {
+        return Err(AbsentFinalAdoptionOutcome::FinalIdentityDrift);
+    }
+    Ok((after_identity, hash))
+}
+
+#[cfg(unix)]
+fn qualify_unix_absent_final_adoption(
+    request: AbsentFinalAdoptionRequest<'_>,
+) -> AbsentFinalAdoptionOutcome {
+    let target_parent_identity =
+        match super::operation_journal::descriptor_identity(request.target_parent) {
+            Ok(identity) if identity.stable_id == request.expected_target_parent.stable_id => {
+                identity
+            }
+            Ok(_) => return AbsentFinalAdoptionOutcome::ParentIdentityDrift,
+            Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+        };
+    let final_object = match open_final_relative(request.target_parent, request.final_leaf) {
+        Ok(file) => file,
+        Err(outcome) => return outcome,
     };
-    if final_object.stable_id != request.expected_final_stable_id
-        || final_object.len != request.expected_final_len
-        || metadata.len() != request.expected_final_len
+    let (final_identity, final_content) = match observe_final(&final_object) {
+        Ok(observation) => observation,
+        Err(outcome) => return outcome,
+    };
+    if final_identity.stable_id != request.expected_final_stable_id
+        || final_identity.len != request.expected_final_len
     {
         return AbsentFinalAdoptionOutcome::FinalIdentityDrift;
     }
-    let final_content = super::operation_journal::prepared_file_evidence(&final_file);
-    if !matches!(
-        final_content,
-        PreparedFileEvidence::ContentHash(hash) if &hash == request.expected_final_content
-    ) {
+    if &final_content != request.expected_final_content {
         return AbsentFinalAdoptionOutcome::FinalContentDrift;
     }
     AbsentFinalAdoptionOutcome::Qualified(QualifiedAbsentFinalAdoption {
-        target_parent: parent,
+        target_parent: target_parent_identity,
+        final_object: final_identity,
+        final_content: PreparedFileEvidence::ContentHash(final_content),
+    })
+}
+
+#[cfg(unix)]
+fn acquire_unix_absent_final_adoption_guard(
+    request: AbsentFinalAdoptionGuardRequest,
+) -> Result<QualifiedAbsentFinalAdoptionGuard, AbsentFinalAdoptionOutcome> {
+    let (target_parent, target_capability) =
+        super::operation_journal::open_root(&request.target_parent_path)
+            .map_err(|_| AbsentFinalAdoptionOutcome::VerificationFailed)?;
+    if target_capability.identity.stable_id != request.expected_target_parent_stable_id {
+        return Err(AbsentFinalAdoptionOutcome::ParentIdentityDrift);
+    }
+    let final_request = AbsentFinalAdoptionRequest::try_new(
+        &target_parent,
+        &request.final_leaf,
+        &target_capability.identity,
+        &request.expected_final_stable_id,
+        request.expected_final_len,
+        &request.expected_final_content,
+    )
+    .map_err(|_| AbsentFinalAdoptionOutcome::VerificationFailed)?;
+    let final_object = open_final_relative(&target_parent, &request.final_leaf)?;
+    let (final_identity, final_content) = observe_final(&final_object)?;
+    if final_identity.stable_id != final_request.expected_final_stable_id
+        || final_identity.len != final_request.expected_final_len
+    {
+        return Err(AbsentFinalAdoptionOutcome::FinalIdentityDrift);
+    }
+    if final_content != request.expected_final_content {
+        return Err(AbsentFinalAdoptionOutcome::FinalContentDrift);
+    }
+    Ok(QualifiedAbsentFinalAdoptionGuard {
+        operation_id: request.operation_id,
+        target_parent,
         final_object,
+        final_leaf: request.final_leaf,
+        target_parent_identity: target_capability.identity,
+        final_identity,
         final_content,
     })
+}
+
+#[cfg(unix)]
+fn revalidate_unix_absent_final_adoption_guard(
+    guard: &QualifiedAbsentFinalAdoptionGuard,
+) -> Result<(), AbsentFinalAdoptionOutcome> {
+    let target_parent_identity =
+        super::operation_journal::descriptor_identity(&guard.target_parent)
+            .map_err(|_| AbsentFinalAdoptionOutcome::VerificationFailed)?;
+    if target_parent_identity.stable_id != guard.target_parent_identity.stable_id {
+        return Err(AbsentFinalAdoptionOutcome::ParentIdentityDrift);
+    }
+
+    let (retained_identity, retained_content) = observe_final(&guard.final_object)?;
+    if retained_identity.stable_id != guard.final_identity.stable_id
+        || retained_identity.len != guard.final_identity.len
+    {
+        return Err(AbsentFinalAdoptionOutcome::FinalIdentityDrift);
+    }
+    if retained_content != guard.final_content {
+        return Err(AbsentFinalAdoptionOutcome::FinalContentDrift);
+    }
+
+    let final_object = open_final_relative(&guard.target_parent, &guard.final_leaf)?;
+    let (final_identity, final_content) = observe_final(&final_object)?;
+    if final_identity.stable_id != guard.final_identity.stable_id
+        || final_identity.len != guard.final_identity.len
+        || final_identity.stable_id != retained_identity.stable_id
+        || final_identity.len != retained_identity.len
+    {
+        return Err(AbsentFinalAdoptionOutcome::FinalIdentityDrift);
+    }
+    if final_content != guard.final_content || final_content != retained_content {
+        return Err(AbsentFinalAdoptionOutcome::FinalContentDrift);
+    }
+    Ok(())
 }
 
 impl<'a> AbsentFinalNoReplaceRequest<'a> {

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -313,6 +313,21 @@ pub(crate) struct AbsentFinalAdoptionEvidence {
     pub(crate) final_content: PreparedFileEvidence,
 }
 
+/// An owned, non-authoritative handoff from durable journal evidence to the file-operation owner.
+///
+/// This request contains only a path locator, a clean final leaf, and exact durable expectations.
+/// It owns no descriptor, does not inspect the filesystem, and cannot establish that the locator
+/// currently names the expected objects.
+pub(crate) struct AbsentFinalAdoptionGuardRequest {
+    pub(super) operation_id: Uuid,
+    pub(super) target_parent_path: PathBuf,
+    pub(super) final_leaf: PathBuf,
+    pub(super) expected_target_parent_stable_id: String,
+    pub(super) expected_final_stable_id: String,
+    pub(super) expected_final_len: u64,
+    pub(super) expected_final_content: [u8; 32],
+}
+
 /// Tagged runtime preparation contract used to select the publication guard.
 ///
 /// Schema-v1 records adapt only to `ExistingExpectedIdentity`.  The absent-final variant is
@@ -3806,6 +3821,143 @@ impl OperationJournalCoordinator {
         Ok(outcome)
     }
 
+    /// Build an owned, non-authoritative handoff for a durably qualified absent-final adoption.
+    /// This method validates only the in-memory durable record. It never inspects or opens the
+    /// filesystem, writes the journal, changes phase/timestamps or capacity, or exposes a handle.
+    pub(crate) fn prepare_schema_v2_absent_final_adoption_guard_request(
+        &self,
+        operation_id: Uuid,
+    ) -> Result<AbsentFinalAdoptionGuardRequest, JournalError> {
+        let record = self
+            .store
+            .record(operation_id)
+            .ok_or(JournalError::NotFound(operation_id))?;
+        if record.operation_id != operation_id {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final guard operation identity does not match record"),
+            });
+        }
+        if record.schema_version != SCHEMA_V2 {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final guard requires schema-v2"),
+            });
+        }
+        if record.phase != OperationPhase::FilesystemStaged {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final guard requires the filesystem-staged phase"),
+            });
+        }
+        validate_schema_v2_phase_evidence_record(record).map_err(|reason| {
+            JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: format!("invalid durable absent-final guard record: {reason}"),
+            }
+        })?;
+        let Some(PreparedTargetContract::AbsentFinalNoReplace(prepared)) = record.prepared.as_ref()
+        else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final guard requires absent-final preparation"),
+            });
+        };
+        let Some(staged) = record.staged.as_ref() else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final guard requires staged evidence"),
+            });
+        };
+        validate_prepared_contract(&PreparedTargetContract::AbsentFinalNoReplace(
+            prepared.clone(),
+        ))
+        .map_err(|reason| JournalError::InvalidRecoveryObservation {
+            operation_id,
+            reason,
+        })?;
+        validate_absent_final_staged_checkpoint(prepared, staged).map_err(|reason| {
+            JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason,
+            }
+        })?;
+        let FilesystemStagedParticipant::CopyValidated { staging, evidence } = &staged.participant;
+        let Some(observation) = record.absent_final_recovery_observation.as_ref() else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final guard requires a recovery observation"),
+            });
+        };
+        let Some(proof) = record.absent_final_transaction_owned_proof.as_ref() else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final guard requires transaction-owned proof"),
+            });
+        };
+        let Some(adoption) = record.absent_final_adoption_evidence.as_ref() else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final guard requires durable adoption evidence"),
+            });
+        };
+        if proof.target_parent_stable_id != observation.target_parent_stable_id
+            || proof.final_stable_id != observation.final_stable_id
+            || proof.final_len != observation.final_len
+            || proof.final_content != observation.final_content
+            || adoption.target_parent_stable_id != proof.target_parent_stable_id
+            || adoption.final_stable_id != proof.final_stable_id
+            || adoption.final_len != proof.final_len
+            || adoption.final_content != proof.final_content
+        {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from(
+                    "absent-final guard durable or live evidence does not cross-match",
+                ),
+            });
+        }
+        let PreparedFileEvidence::ContentHash(expected_content) = &adoption.final_content else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final guard requires exact content evidence"),
+            });
+        };
+        if prepared.target_parent.identity.stable_id != adoption.target_parent_stable_id
+            || staging.identity.stable_id != adoption.final_stable_id
+            || staging.identity.len != adoption.final_len
+            || prepared.copy_validated_evidence != adoption.final_content
+            || evidence != &adoption.final_content
+        {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from(
+                    "absent-final guard evidence does not match prepared or staged contract",
+                ),
+            });
+        }
+        AbsentFinalAdoptionGuardRequest::try_new(
+            operation_id,
+            prepared.target_parent.path.clone(),
+            prepared.final_leaf.clone(),
+            adoption.target_parent_stable_id.clone(),
+            adoption.final_stable_id.clone(),
+            adoption.final_len,
+            *expected_content,
+        )
+        .map_err(|error| JournalError::InvalidRecoveryObservation {
+            operation_id,
+            reason: match error {
+                AbsentFinalNoReplaceRequestError::TargetLeafNotSingleCleanNormal => {
+                    String::from("absent-final guard final leaf is not clean")
+                }
+                AbsentFinalNoReplaceRequestError::StagingLeafNotSingleCleanNormal => {
+                    String::from("absent-final guard staging leaf is not applicable")
+                }
+            },
+        })
+    }
+
     /// Requalify an already-present transaction-owned final and durably retain only the exact
     /// capability-bound adoption evidence. This keeps the operation filesystem-staged and never
     /// performs publication or filesystem mutation.
@@ -4888,6 +5040,26 @@ mod tests {
             )
             .expect("admit real schema-v2 absent-final fixture");
         drop(target_parent);
+        (operation_id, final_path, staging_path)
+    }
+
+    #[cfg(unix)]
+    fn admit_real_absent_final_v2_adoption_fixture(
+        journal: &mut OperationJournalCoordinator,
+        directory: &tempfile::TempDir,
+    ) -> (Uuid, PathBuf, PathBuf) {
+        let (operation_id, final_path, staging_path) =
+            admit_real_absent_final_v2_fixture(journal, directory);
+        fs::rename(&staging_path, &final_path).expect("staging to final rename");
+        journal
+            .record_schema_v2_absent_final_recovery_observation(operation_id)
+            .expect("record exact recovery observation");
+        journal
+            .record_schema_v2_absent_final_transaction_owned_proof(operation_id)
+            .expect("record exact transaction-owned proof");
+        journal
+            .record_schema_v2_absent_final_adoption_evidence(operation_id)
+            .expect("record exact adoption evidence");
         (operation_id, final_path, staging_path)
     }
 
@@ -7543,6 +7715,207 @@ mod tests {
         assert_eq!(journal.store.capacity_claims(), &claims_before);
         assert_eq!(fs::read(&final_path).unwrap(), final_bytes_before);
         assert!(!staging_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schema_v2_absent_final_adoption_guard_request_is_filesystem_free() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let directory = fixture_directory();
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open real fixture journal");
+        let (operation_id, final_path, staging_path) =
+            admit_real_absent_final_v2_adoption_fixture(&mut journal, &directory);
+
+        let record_before = journal.record(operation_id).unwrap().clone();
+        let path = journal.store.record_path(operation_id);
+        let bytes_before = fs::read(&path).expect("journal bytes before request construction");
+        let claims_before = journal.store.capacity_claims().clone();
+        fs::remove_file(&final_path).expect("remove final before request construction");
+
+        let request = journal
+            .prepare_schema_v2_absent_final_adoption_guard_request(operation_id)
+            .expect("durable request construction must not inspect the final");
+
+        assert_eq!(request.operation_id, operation_id);
+        assert_eq!(request.target_parent_path, final_path.parent().unwrap());
+        assert_eq!(request.final_leaf, PathBuf::from("final.wav"));
+        assert_eq!(journal.record(operation_id), Some(&record_before));
+        assert_eq!(fs::read(&path).unwrap(), bytes_before);
+        assert_eq!(journal.store.capacity_claims(), &claims_before);
+        assert!(!staging_path.exists());
+        assert!(!final_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schema_v2_absent_final_adoption_guard_request_rejects_missing_or_mismatched_evidence() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        {
+            let directory = fixture_directory();
+            let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+                .expect("open real fixture journal");
+            let (operation_id, final_path, staging_path) =
+                admit_real_absent_final_v2_fixture(&mut journal, &directory);
+            fs::rename(&staging_path, &final_path).expect("staging to final rename");
+            journal
+                .record_schema_v2_absent_final_recovery_observation(operation_id)
+                .expect("record exact recovery observation");
+            journal
+                .record_schema_v2_absent_final_transaction_owned_proof(operation_id)
+                .expect("record exact transaction-owned proof");
+
+            let record_before = journal.record(operation_id).unwrap().clone();
+            let path = journal.store.record_path(operation_id);
+            let bytes_before = fs::read(&path).expect("journal bytes before missing evidence");
+            let claims_before = journal.store.capacity_claims().clone();
+            let final_bytes_before = fs::read(&final_path).expect("final bytes before rejection");
+            let error = journal
+                .prepare_schema_v2_absent_final_adoption_guard_request(operation_id)
+                .err()
+                .expect("missing adoption evidence must reject guard request");
+
+            assert!(matches!(
+                error,
+                JournalError::InvalidRecoveryObservation { .. }
+            ));
+            assert_eq!(journal.record(operation_id), Some(&record_before));
+            assert_eq!(fs::read(&path).unwrap(), bytes_before);
+            assert_eq!(journal.store.capacity_claims(), &claims_before);
+            assert_eq!(fs::read(&final_path).unwrap(), final_bytes_before);
+        }
+
+        let directory = fixture_directory();
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open real fixture journal");
+        let (operation_id, final_path, staging_path) =
+            admit_real_absent_final_v2_adoption_fixture(&mut journal, &directory);
+        let mut invalid = journal.record(operation_id).unwrap().clone();
+        invalid
+            .absent_final_adoption_evidence
+            .as_mut()
+            .expect("durable adoption evidence")
+            .final_len += 1;
+        journal.store.records.insert(operation_id, invalid.clone());
+        let path = journal.store.record_path(operation_id);
+        let bytes_before = fs::read(&path).expect("journal bytes before mismatched evidence");
+        let claims_before = journal.store.capacity_claims().clone();
+        let final_bytes_before = fs::read(&final_path).expect("final bytes before rejection");
+        let error = journal
+            .prepare_schema_v2_absent_final_adoption_guard_request(operation_id)
+            .err()
+            .expect("mismatched adoption evidence must reject guard request");
+
+        assert!(matches!(
+            error,
+            JournalError::InvalidRecoveryObservation { .. }
+        ));
+        assert_eq!(journal.record(operation_id), Some(&invalid));
+        assert_eq!(fs::read(&path).unwrap(), bytes_before);
+        assert_eq!(journal.store.capacity_claims(), &claims_before);
+        assert_eq!(fs::read(&final_path).unwrap(), final_bytes_before);
+        assert!(!staging_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schema_v2_absent_final_adoption_guard_is_adapter_bound_immutable_and_operation_fenced() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let directory = fixture_directory();
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open real fixture journal");
+        let (operation_id, final_path, staging_path) =
+            admit_real_absent_final_v2_adoption_fixture(&mut journal, &directory);
+
+        let record_before = journal.record(operation_id).unwrap().clone();
+        let path = journal.store.record_path(operation_id);
+        let bytes_before = fs::read(&path).expect("journal bytes before guard acquisition");
+        let claims_before = journal.store.capacity_claims().clone();
+        let final_bytes_before =
+            fs::read(&final_path).expect("final bytes before guard acquisition");
+        let request = journal
+            .prepare_schema_v2_absent_final_adoption_guard_request(operation_id)
+            .expect("prepare durable adoption guard request");
+        let guard = ProductionAbsentFinalAdoptionAdapter
+            .acquire_guard(request)
+            .expect("file-operation adapter acquires guard");
+
+        assert_eq!(guard.operation_id(), operation_id);
+        assert_eq!(
+            guard.revalidate_binding(Uuid::new_v4()),
+            Err(AbsentFinalAdoptionOutcome::OperationIdDrift)
+        );
+        assert!(guard.revalidate_binding(operation_id).is_ok());
+        assert_eq!(journal.record(operation_id), Some(&record_before));
+        assert_eq!(fs::read(&path).unwrap(), bytes_before);
+        assert_eq!(journal.store.capacity_claims(), &claims_before);
+        assert_eq!(fs::read(&final_path).unwrap(), final_bytes_before);
+        assert!(!staging_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schema_v2_absent_final_adoption_guard_acquisition_rejects_root_drift() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let directory = fixture_directory();
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open real fixture journal");
+        let (operation_id, final_path, staging_path) =
+            admit_real_absent_final_v2_adoption_fixture(&mut journal, &directory);
+        let request = journal
+            .prepare_schema_v2_absent_final_adoption_guard_request(operation_id)
+            .expect("prepare durable adoption guard request");
+        let target_parent = final_path.parent().unwrap().to_path_buf();
+        let moved_parent = target_parent.with_file_name("moved-target-parent");
+        fs::rename(&target_parent, &moved_parent).expect("move target parent");
+        fs::create_dir(&target_parent).expect("replacement target parent");
+
+        let Err(outcome) = ProductionAbsentFinalAdoptionAdapter.acquire_guard(request) else {
+            panic!("replaced root path must not acquire a guard");
+        };
+        assert_eq!(outcome, AbsentFinalAdoptionOutcome::ParentIdentityDrift);
+        assert_eq!(
+            fs::read(moved_parent.join("final.wav")).unwrap(),
+            b"real staged bytes"
+        );
+        assert!(!final_path.exists());
+        assert!(!staging_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schema_v2_absent_final_adoption_guard_revalidates_retained_parent_and_final() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let directory = fixture_directory();
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open real fixture journal");
+        let (operation_id, final_path, staging_path) =
+            admit_real_absent_final_v2_adoption_fixture(&mut journal, &directory);
+        let request = journal
+            .prepare_schema_v2_absent_final_adoption_guard_request(operation_id)
+            .expect("prepare durable adoption guard request");
+        let guard = ProductionAbsentFinalAdoptionAdapter
+            .acquire_guard(request)
+            .expect("file-operation adapter acquires guard");
+        let target_parent = final_path.parent().unwrap().to_path_buf();
+        let moved_parent = target_parent.with_file_name("moved-target-parent");
+        fs::rename(&target_parent, &moved_parent).expect("move target parent");
+        fs::create_dir(&target_parent).expect("replacement target parent");
+
+        assert!(guard.revalidate_binding(operation_id).is_ok());
+        assert_eq!(
+            fs::read(moved_parent.join("final.wav")).unwrap(),
+            b"real staged bytes"
+        );
+        assert!(!final_path.exists());
+        assert!(!staging_path.exists());
+
+        fs::write(moved_parent.join("final.wav"), b"real staged byte!")
+            .expect("change retained final content");
+        assert_eq!(
+            guard.revalidate_binding(operation_id),
+            Err(AbsentFinalAdoptionOutcome::FinalContentDrift)
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Goal
Align the absent-final recovery handoff with the target ownership model: durable journal evidence produces a non-authoritative request, while the file-operation adapter owns live descriptor reacquisition and retained capability verification.

## Scope and non-goals
- Add an owned, operation-bound `AbsentFinalAdoptionGuardRequest` containing only locator and exact durable expectations.
- Keep journal-side request construction filesystem-free and strictly cross-validate schema-v2 durable evidence.
- Move live target-parent/final acquisition, no-follow verification, descriptor retention, operation fencing, and binding revalidation behind the sealed absent-final adapter.
- Preserve the opaque guard boundary; it cannot be cloned, serialized, or converted into publication evidence.
- No production schema-v2 admission or caller, journal schema change, phase advancement, publication, database work, app-state wiring, or filesystem mutation.

## Definition of Done
- The coordinator never returns or retains a live filesystem descriptor for this handoff.
- The adapter alone reacquires the parent capability, verifies the final identity/length/exact hash, retains both descriptors, and fails closed on missing/replaced/symlink/non-file/content/parent drift.
- Revalidation remains bound to the retained parent and retained final object, with operation-ID fencing and root-path substitution coverage.
- Missing or mismatched durable evidence is rejected without filesystem access or journal/capacity mutation.
- Schema-v1 and existing journal/publication compatibility remain unchanged.

## Validation
- `cargo test --locked ... transaction_history::absent_final_no_replace` — 16 passed.
- `cargo test --locked ... transaction_history::operation_journal` — 84 passed.
- `cargo test --locked ... transaction_history::absent_final_recovery` — 17 passed.
- `cargo test --locked ... transaction_history::publication` — 2 passed.
- `rustfmt --edition 2024 --check` on both changed files — passed.
- `git diff --check` — passed.
- `cargo check --locked --all-targets` with isolated target `/private/tmp/wavecrate-live-adoption-target` and Radiant archive `/private/tmp/wavecrate-journal-radiant.KTJELI` — passed.
- `cargo check --locked --target x86_64-pc-windows-msvc --lib` was attempted; the installed target is present, but the host lacks the MSVC/C header toolchain (`assert.h`, `stdlib.h`), so no Windows Rust diagnostics were obtainable.

## Known limitations and next task
This remains a schema-v2/test-only owner handoff; it does not activate production recovery or publication. The broader production file-operation owner route still needs to be wired before schema-v2 recovery is enabled. The next I/O slice can split the existing recovery observation/proof/adoption execution into the same typed owner request/result/persistence boundary, then later add an honest adoption-to-publication transition.

## Review
Sol resolved the ownership escalation. Terra specialist review: APPROVE, no required findings.

User approval is required before merge.