### PR TITLE
Move absent-final recovery behind owner adapters

### DIFF
--- a/src/native_app/transaction_history/absent_final_no_replace.rs
+++ b/src/native_app/transaction_history/absent_final_no_replace.rs
@@ -53,6 +53,65 @@ pub(super) struct AbsentFinalAdoptionRequest<'a> {
     expected_final_content: &'a [u8; 32],
 }
 
+/// An owned, non-authoritative request for live adoption qualification.
+///
+/// The journal constructs this from durable preparation, recovery observation, and transaction-
+/// owned proof. The adapter reacquires the target-parent capability and revalidates the final;
+/// this request carries no borrowed descriptor.
+pub(super) struct AbsentFinalAdoptionQualificationRequest {
+    pub(super) operation_id: Uuid,
+    pub(super) target_parent_path: PathBuf,
+    pub(super) final_leaf: PathBuf,
+    pub(super) expected_target_parent_stable_id: String,
+    pub(super) expected_final_stable_id: String,
+    pub(super) expected_final_len: u64,
+    pub(super) expected_final_content: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum AbsentFinalAdoptionQualificationRequestError {
+    TargetParentPathNotAbsolute,
+    FinalLeafNotSingleCleanNormal,
+    TargetParentIdentityEmpty,
+    FinalIdentityEmpty,
+}
+
+impl AbsentFinalAdoptionQualificationRequest {
+    pub(super) fn try_new(
+        operation_id: Uuid,
+        target_parent_path: PathBuf,
+        final_leaf: PathBuf,
+        expected_target_parent_stable_id: String,
+        expected_final_stable_id: String,
+        expected_final_len: u64,
+        expected_final_content: [u8; 32],
+    ) -> Result<Self, AbsentFinalAdoptionQualificationRequestError> {
+        if !target_parent_path.is_absolute() {
+            return Err(AbsentFinalAdoptionQualificationRequestError::TargetParentPathNotAbsolute);
+        }
+        if !is_single_clean_normal_leaf(&final_leaf) {
+            return Err(
+                AbsentFinalAdoptionQualificationRequestError::FinalLeafNotSingleCleanNormal,
+            );
+        }
+        if expected_target_parent_stable_id.is_empty() {
+            return Err(AbsentFinalAdoptionQualificationRequestError::TargetParentIdentityEmpty);
+        }
+        if expected_final_stable_id.is_empty() {
+            return Err(AbsentFinalAdoptionQualificationRequestError::FinalIdentityEmpty);
+        }
+        Ok(Self {
+            operation_id,
+            target_parent_path,
+            final_leaf,
+            expected_target_parent_stable_id,
+            expected_final_stable_id,
+            expected_final_len,
+            expected_final_content,
+        })
+    }
+}
+
 impl<'a> AbsentFinalAdoptionRequest<'a> {
     pub(super) fn try_new(
         target_parent: &'a File,
@@ -132,6 +191,20 @@ pub(crate) struct QualifiedAbsentFinalAdoption {
     pub(super) final_content: PreparedFileEvidence,
 }
 
+/// Operation-fenced evidence returned by the physical file owner after live adoption
+/// qualification. It contains no retained handle or mutation capability.
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct AbsentFinalAdoptionQualificationResult {
+    pub(super) operation_id: Uuid,
+    pub(super) outcome: AbsentFinalAdoptionOutcome,
+}
+
+impl AbsentFinalAdoptionQualificationResult {
+    pub(super) fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+}
+
 /// A retained, read-only capability for a qualified absent-final adoption.
 ///
 /// This deliberately has no serialization, comparison, or clone boundary. The retained
@@ -173,6 +246,10 @@ impl QualifiedAbsentFinalAdoptionGuard {
 
 pub(super) trait AbsentFinalAdoptionAdapter: sealed::Sealed {
     fn qualify(&self, request: AbsentFinalAdoptionRequest<'_>) -> AbsentFinalAdoptionOutcome;
+    fn qualify_owned(
+        &self,
+        request: AbsentFinalAdoptionQualificationRequest,
+    ) -> AbsentFinalAdoptionQualificationResult;
 }
 
 pub(super) struct ProductionAbsentFinalAdoptionAdapter;
@@ -189,6 +266,24 @@ impl AbsentFinalAdoptionAdapter for ProductionAbsentFinalAdoptionAdapter {
         {
             let _ = request;
             AbsentFinalAdoptionOutcome::UnsupportedPlatform
+        }
+    }
+
+    fn qualify_owned(
+        &self,
+        request: AbsentFinalAdoptionQualificationRequest,
+    ) -> AbsentFinalAdoptionQualificationResult {
+        let operation_id = request.operation_id;
+        #[cfg(unix)]
+        let outcome = qualify_unix_owned_absent_final_adoption(&request);
+        #[cfg(not(unix))]
+        let outcome = {
+            let _ = request;
+            AbsentFinalAdoptionOutcome::UnsupportedPlatform
+        };
+        AbsentFinalAdoptionQualificationResult {
+            operation_id,
+            outcome,
         }
     }
 }
@@ -299,6 +394,32 @@ fn qualify_unix_absent_final_adoption(
         final_object: final_identity,
         final_content: PreparedFileEvidence::ContentHash(final_content),
     })
+}
+
+#[cfg(unix)]
+fn qualify_unix_owned_absent_final_adoption(
+    request: &AbsentFinalAdoptionQualificationRequest,
+) -> AbsentFinalAdoptionOutcome {
+    let (target_parent, target_capability) =
+        match super::operation_journal::open_root(&request.target_parent_path) {
+            Ok(value) => value,
+            Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+        };
+    if target_capability.identity.stable_id != request.expected_target_parent_stable_id {
+        return AbsentFinalAdoptionOutcome::ParentIdentityDrift;
+    }
+    let borrowed_request = match AbsentFinalAdoptionRequest::try_new(
+        &target_parent,
+        &request.final_leaf,
+        &target_capability.identity,
+        &request.expected_final_stable_id,
+        request.expected_final_len,
+        &request.expected_final_content,
+    ) {
+        Ok(request) => request,
+        Err(_) => return AbsentFinalAdoptionOutcome::VerificationFailed,
+    };
+    qualify_unix_absent_final_adoption(borrowed_request)
 }
 
 #[cfg(unix)]
@@ -1241,6 +1362,64 @@ mod tests {
         let outcome = ProductionAbsentFinalAdoptionAdapter.qualify(request);
         assert!(matches!(outcome, AbsentFinalAdoptionOutcome::Qualified(_)));
         assert!(!fixture.staging_path().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owned_adoption_qualification_reacquires_and_returns_operation_bound_evidence() {
+        let fixture = Fixture::new();
+        fs::rename(fixture.staging_path(), fixture.target_path()).expect("stage final");
+        let final_file = File::open(fixture.target_path()).expect("final file");
+        let final_identity = descriptor_identity(&final_file).expect("final identity");
+        let expected_content = match &fixture.expected_content {
+            PreparedFileEvidence::ContentHash(hash) => *hash,
+            _ => panic!("fixture must have exact content"),
+        };
+        let operation_id = Uuid::new_v4();
+        let request = AbsentFinalAdoptionQualificationRequest::try_new(
+            operation_id,
+            fixture.target_parent_path.clone(),
+            PathBuf::from(TARGET_LEAF),
+            fixture.target_parent_identity.stable_id.clone(),
+            final_identity.stable_id,
+            final_identity.len,
+            expected_content,
+        )
+        .expect("owned adoption request");
+        let result = ProductionAbsentFinalAdoptionAdapter.qualify_owned(request);
+
+        assert_eq!(result.operation_id(), operation_id);
+        assert!(matches!(
+            result.outcome,
+            AbsentFinalAdoptionOutcome::Qualified(_)
+        ));
+        assert!(!fixture.staging_path().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owned_adoption_qualification_request_does_not_claim_missing_final() {
+        let fixture = Fixture::new();
+        let expected_content = match &fixture.expected_content {
+            PreparedFileEvidence::ContentHash(hash) => *hash,
+            _ => panic!("fixture must have exact content"),
+        };
+        let operation_id = Uuid::new_v4();
+        let request = AbsentFinalAdoptionQualificationRequest::try_new(
+            operation_id,
+            fixture.target_parent_path.clone(),
+            PathBuf::from(TARGET_LEAF),
+            fixture.target_parent_identity.stable_id.clone(),
+            fixture.expected_staging.stable_id.clone(),
+            fixture.expected_staging.len,
+            expected_content,
+        )
+        .expect("owned adoption request without live inspection");
+        let result = ProductionAbsentFinalAdoptionAdapter.qualify_owned(request);
+
+        assert_eq!(result.operation_id(), operation_id);
+        assert_eq!(result.outcome, AbsentFinalAdoptionOutcome::FinalMissing);
+        assert!(!fixture.target_path().exists());
     }
 
     #[cfg(unix)]

--- a/src/native_app/transaction_history/absent_final_recovery.rs
+++ b/src/native_app/transaction_history/absent_final_recovery.rs
@@ -8,21 +8,93 @@
 
 #[cfg(unix)]
 use std::fs::File;
-#[cfg(unix)]
 use std::path::Path;
+use std::path::PathBuf;
+use uuid::Uuid;
 
 use super::absent_final_no_replace::{
     exact_content_evidence_matches, stable_id_and_length_matches,
 };
 use super::operation_journal::{
     AbsentFinalRecoveryObservation, FilesystemStagedParticipant, FilesystemStagedWaveformRestore,
-    PreparedAbsentFinalNoReplace,
+    PreparedAbsentFinalNoReplace, PreparedFileEvidence, PreparedObjectIdentity,
 };
 #[cfg(unix)]
-use super::operation_journal::{
-    PreparedFileEvidence, PreparedObjectIdentity, descriptor_identity, open_root,
-    prepared_file_evidence,
-};
+use super::operation_journal::{descriptor_identity, open_root, prepared_file_evidence};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A request for the physical file owner to inspect one durable absent-final checkpoint.
+///
+/// The request owns only durable locators and expectations. It deliberately contains no open
+/// descriptor, filesystem capability, or mutation authority; the production adapter reacquires
+/// those capabilities before interpreting the locators.
+pub(super) struct AbsentFinalRecoveryRequest {
+    pub(super) operation_id: Uuid,
+    pub(super) target_parent_path: PathBuf,
+    pub(super) expected_target_parent: PreparedObjectIdentity,
+    pub(super) staging_leaf: PathBuf,
+    pub(super) final_leaf: PathBuf,
+    pub(super) expected_staging: PreparedObjectIdentity,
+    pub(super) expected_content: PreparedFileEvidence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum AbsentFinalRecoveryRequestError {
+    TargetParentPathNotAbsolute,
+    TargetParentIdentityEmpty,
+    StagingLeafNotSingleCleanNormal,
+    FinalLeafNotSingleCleanNormal,
+    StagingAndFinalLeafEqual,
+    StagingIdentityEmpty,
+    StagingContentNotExact,
+}
+
+impl AbsentFinalRecoveryRequest {
+    /// Construct an owned recovery request without touching the filesystem.
+    pub(super) fn try_new(
+        operation_id: Uuid,
+        target_parent_path: PathBuf,
+        expected_target_parent: PreparedObjectIdentity,
+        staging_leaf: PathBuf,
+        final_leaf: PathBuf,
+        expected_staging: PreparedObjectIdentity,
+        expected_content: PreparedFileEvidence,
+    ) -> Result<Self, AbsentFinalRecoveryRequestError> {
+        if !target_parent_path.is_absolute() {
+            return Err(AbsentFinalRecoveryRequestError::TargetParentPathNotAbsolute);
+        }
+        if expected_target_parent.stable_id.is_empty() {
+            return Err(AbsentFinalRecoveryRequestError::TargetParentIdentityEmpty);
+        }
+        if !is_single_clean_normal_leaf(&staging_leaf) {
+            return Err(AbsentFinalRecoveryRequestError::StagingLeafNotSingleCleanNormal);
+        }
+        if !is_single_clean_normal_leaf(&final_leaf) {
+            return Err(AbsentFinalRecoveryRequestError::FinalLeafNotSingleCleanNormal);
+        }
+        if staging_leaf == final_leaf {
+            return Err(AbsentFinalRecoveryRequestError::StagingAndFinalLeafEqual);
+        }
+        if expected_staging.stable_id.is_empty() {
+            return Err(AbsentFinalRecoveryRequestError::StagingIdentityEmpty);
+        }
+        if !matches!(&expected_content, PreparedFileEvidence::ContentHash(_)) {
+            return Err(AbsentFinalRecoveryRequestError::StagingContentNotExact);
+        }
+        Ok(Self {
+            operation_id,
+            target_parent_path,
+            expected_target_parent,
+            staging_leaf,
+            final_leaf,
+            expected_staging,
+            expected_content,
+        })
+    }
+}
 
 /// Whether the durable staging locator is present while a final collision is observed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -68,6 +140,51 @@ pub(super) struct AbsentFinalRecoveryInspection {
     pub(super) observation: Option<AbsentFinalRecoveryObservation>,
 }
 
+/// Operation-fenced evidence returned by the physical file owner.
+///
+/// The result contains no descriptors or mutation capabilities. A caller must correlate the
+/// operation ID before interpreting or persisting the evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct AbsentFinalRecoveryResult {
+    pub(super) operation_id: Uuid,
+    pub(super) classification: AbsentFinalRecoveryClassification,
+    pub(super) observation: Option<AbsentFinalRecoveryObservation>,
+}
+
+impl AbsentFinalRecoveryResult {
+    pub(super) fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+}
+
+pub(super) trait AbsentFinalRecoveryAdapter: sealed::Sealed {
+    fn inspect(&self, request: AbsentFinalRecoveryRequest) -> AbsentFinalRecoveryResult;
+}
+
+pub(super) struct ProductionAbsentFinalRecoveryAdapter;
+
+impl sealed::Sealed for ProductionAbsentFinalRecoveryAdapter {}
+
+impl AbsentFinalRecoveryAdapter for ProductionAbsentFinalRecoveryAdapter {
+    fn inspect(&self, request: AbsentFinalRecoveryRequest) -> AbsentFinalRecoveryResult {
+        let operation_id = request.operation_id;
+        #[cfg(unix)]
+        let inspection = inspect_unix(&request);
+        #[cfg(not(unix))]
+        let inspection = {
+            let _ = request;
+            inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
+                AbsentFinalRecoveryAmbiguity::UnsupportedDescriptorRelativeInspection,
+            ))
+        };
+        AbsentFinalRecoveryResult {
+            operation_id,
+            classification: inspection.classification,
+            observation: inspection.observation,
+        }
+    }
+}
+
 #[cfg(unix)]
 #[derive(Debug)]
 enum LeafInspectionError {
@@ -102,34 +219,24 @@ pub(super) fn inspect_absent_final_recovery(
     prepared: &PreparedAbsentFinalNoReplace,
     staged: &FilesystemStagedWaveformRestore,
 ) -> AbsentFinalRecoveryInspection {
-    #[cfg(unix)]
-    {
-        return classify_unix(prepared, staged);
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = (prepared, staged);
-        AbsentFinalRecoveryInspection {
-            classification: AbsentFinalRecoveryClassification::IdentityAmbiguous(
-                AbsentFinalRecoveryAmbiguity::UnsupportedDescriptorRelativeInspection,
-            ),
-            observation: None,
+    let request = match request_from_prepared(Uuid::nil(), prepared, staged) {
+        Ok(request) => request,
+        Err(_) => {
+            return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
+                AbsentFinalRecoveryAmbiguity::StagingInspectionRaceOrFailure,
+            ));
         }
+    };
+    let result = ProductionAbsentFinalRecoveryAdapter.inspect(request);
+    AbsentFinalRecoveryInspection {
+        classification: result.classification,
+        observation: result.observation,
     }
 }
 
 #[cfg(unix)]
-fn classify_unix(
-    prepared: &PreparedAbsentFinalNoReplace,
-    staged: &FilesystemStagedWaveformRestore,
-) -> AbsentFinalRecoveryInspection {
-    let FilesystemStagedParticipant::CopyValidated {
-        staging: expected_staging,
-        evidence: expected_content,
-    } = &staged.participant;
-
-    let (target_parent, reacquired_parent) = match open_root(&prepared.target_parent.path) {
+fn inspect_unix(request: &AbsentFinalRecoveryRequest) -> AbsentFinalRecoveryInspection {
+    let (target_parent, reacquired_parent) = match open_root(&request.target_parent_path) {
         Ok(value) => value,
         Err(_) => {
             return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
@@ -137,13 +244,13 @@ fn classify_unix(
             ));
         }
     };
-    if reacquired_parent.identity.stable_id != prepared.target_parent.identity.stable_id {
+    if reacquired_parent.identity.stable_id != request.expected_target_parent.stable_id {
         return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
             AbsentFinalRecoveryAmbiguity::TargetParentIdentityChanged,
         ));
     }
 
-    let staging = match inspect_leaf(&target_parent, &prepared.staging.relative_path) {
+    let staging = match inspect_leaf(&target_parent, &request.staging_leaf) {
         Ok(observation) => observation,
         Err(error) => {
             return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
@@ -154,12 +261,12 @@ fn classify_unix(
     let staging_present = match &staging {
         LeafObservation::Missing => false,
         LeafObservation::Present { identity, content } => {
-            if !stable_id_and_length_matches(identity, &expected_staging.identity) {
+            if !stable_id_and_length_matches(identity, &request.expected_staging) {
                 return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
                     AbsentFinalRecoveryAmbiguity::StagingIdentityDrift,
                 ));
             }
-            if !exact_content_evidence_matches(expected_content, content) {
+            if !exact_content_evidence_matches(&request.expected_content, content) {
                 return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
                     AbsentFinalRecoveryAmbiguity::StagingContentDrift,
                 ));
@@ -168,7 +275,7 @@ fn classify_unix(
         }
     };
 
-    let final_observation = match inspect_leaf(&target_parent, &prepared.final_leaf) {
+    let final_observation = match inspect_leaf(&target_parent, &request.final_leaf) {
         Ok(observation) => observation,
         Err(error) => {
             return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
@@ -182,7 +289,7 @@ fn classify_unix(
         }
         LeafObservation::Missing => inspection(AbsentFinalRecoveryClassification::NeitherPresent),
         LeafObservation::Present { identity, content } => {
-            if identity.stable_id != expected_staging.identity.stable_id {
+            if identity.stable_id != request.expected_staging.stable_id {
                 return inspection(AbsentFinalRecoveryClassification::Collision {
                     staging: if staging_present {
                         CollisionStagingState::Present
@@ -191,12 +298,12 @@ fn classify_unix(
                     },
                 });
             }
-            if !stable_id_and_length_matches(&identity, &expected_staging.identity) {
+            if !stable_id_and_length_matches(&identity, &request.expected_staging) {
                 return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
                     AbsentFinalRecoveryAmbiguity::FinalIdentityLengthDrift,
                 ));
             }
-            if !exact_content_evidence_matches(expected_content, &content) {
+            if !exact_content_evidence_matches(&request.expected_content, &content) {
                 return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
                     AbsentFinalRecoveryAmbiguity::FinalContentDrift,
                 ));
@@ -323,6 +430,37 @@ fn final_ambiguity(error: LeafInspectionError) -> AbsentFinalRecoveryAmbiguity {
             AbsentFinalRecoveryAmbiguity::FinalInspectionRaceOrFailure
         }
     }
+}
+
+fn request_from_prepared(
+    operation_id: Uuid,
+    prepared: &PreparedAbsentFinalNoReplace,
+    staged: &FilesystemStagedWaveformRestore,
+) -> Result<AbsentFinalRecoveryRequest, AbsentFinalRecoveryRequestError> {
+    let FilesystemStagedParticipant::CopyValidated { staging, evidence } = &staged.participant;
+    AbsentFinalRecoveryRequest::try_new(
+        operation_id,
+        prepared.target_parent.path.clone(),
+        prepared.target_parent.identity.clone(),
+        staging.relative_path.clone(),
+        prepared.final_leaf.clone(),
+        staging.identity.clone(),
+        evidence.clone(),
+    )
+}
+
+fn is_single_clean_normal_leaf(path: &Path) -> bool {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return false;
+    }
+    let mut components = path.components();
+    let Some(std::path::Component::Normal(component)) = components.next() else {
+        return false;
+    };
+    if components.next().is_some() || Path::new(component) != path {
+        return false;
+    }
+    !component.as_encoded_bytes().contains(&0)
 }
 
 #[cfg(all(test, unix))]
@@ -487,6 +625,30 @@ mod tests {
             fixture.classify(),
             AbsentFinalRecoveryClassification::NeitherPresent
         );
+    }
+
+    #[test]
+    fn owned_recovery_request_is_filesystem_free_before_adapter_inspection() {
+        let fixture = Fixture::new();
+        let operation_id = Uuid::new_v4();
+        let request = request_from_prepared(operation_id, &fixture.prepared, &fixture.staged)
+            .expect("durable recovery request");
+
+        fs::remove_dir_all(&fixture.target_parent_path).expect("remove live target parent");
+        assert_eq!(request.operation_id, operation_id);
+        assert_eq!(request.target_parent_path, fixture.target_parent_path);
+        assert_eq!(request.staging_leaf, PathBuf::from(STAGING_LEAF));
+        assert_eq!(request.final_leaf, PathBuf::from(FINAL_LEAF));
+
+        let result = ProductionAbsentFinalRecoveryAdapter.inspect(request);
+        assert_eq!(result.operation_id(), operation_id);
+        assert_eq!(
+            result.classification,
+            AbsentFinalRecoveryClassification::IdentityAmbiguous(
+                AbsentFinalRecoveryAmbiguity::TargetParentReacquisitionFailed
+            )
+        );
+        assert!(result.observation.is_none());
     }
 
     #[test]

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -20,10 +20,14 @@ use uuid::Uuid;
 
 use super::AbsentFinalRecoveryClassification;
 use super::absent_final_no_replace::{
-    AbsentFinalAdoptionAdapter, AbsentFinalAdoptionOutcome, AbsentFinalNoReplaceRequestError,
-    ProductionAbsentFinalAdoptionAdapter,
+    AbsentFinalAdoptionAdapter, AbsentFinalAdoptionOutcome,
+    AbsentFinalAdoptionQualificationRequest, AbsentFinalAdoptionQualificationResult,
+    AbsentFinalNoReplaceRequestError, ProductionAbsentFinalAdoptionAdapter,
 };
-use super::absent_final_recovery::inspect_absent_final_recovery;
+use super::absent_final_recovery::{
+    AbsentFinalRecoveryAdapter, AbsentFinalRecoveryRequest, AbsentFinalRecoveryResult,
+    ProductionAbsentFinalRecoveryAdapter,
+};
 pub(crate) use super::capacity_gate::VolumeIdentity;
 use super::capacity_gate::{DurableCapacityPlan, RejectedBeforeIntent};
 pub(crate) use super::expected_identity_replacement::ReplacementQualificationAssessment;
@@ -2762,6 +2766,36 @@ pub(crate) struct OperationJournalCoordinator {
     store: OperationJournalStore,
 }
 
+fn validate_absent_final_recovery_result_operation_id(
+    operation_id: Uuid,
+    result: AbsentFinalRecoveryResult,
+) -> Result<AbsentFinalRecoveryResult, JournalError> {
+    if result.operation_id() != operation_id {
+        return Err(JournalError::InvalidRecoveryObservation {
+            operation_id,
+            reason: String::from(
+                "absent-final recovery adapter returned evidence for another operation",
+            ),
+        });
+    }
+    Ok(result)
+}
+
+fn validate_absent_final_adoption_result_operation_id(
+    operation_id: Uuid,
+    result: AbsentFinalAdoptionQualificationResult,
+) -> Result<AbsentFinalAdoptionOutcome, JournalError> {
+    if result.operation_id() != operation_id {
+        return Err(JournalError::InvalidRecoveryObservation {
+            operation_id,
+            reason: String::from(
+                "absent-final adoption adapter returned evidence for another operation",
+            ),
+        });
+    }
+    Ok(result.outcome)
+}
+
 fn clean_relative_path(path: &Path) -> Result<(), String> {
     if path.as_os_str().is_empty() || path.is_absolute() {
         return Err(String::from("path must be a non-empty relative locator"));
@@ -3515,26 +3549,33 @@ impl OperationJournalCoordinator {
         self.store.recovery_summary()
     }
 
-    /// Classify one eligible schema-v2 absent-final record by reacquiring and inspecting its
-    /// target-parent capability. This method is observation-only: it never updates the record,
-    /// writes journal bytes, changes disposition, or alters capacity claims.
+    /// Classify one eligible schema-v2 absent-final record through the physical file-owner
+    /// adapter. This method is observation-only: it never updates the record, writes journal
+    /// bytes, changes disposition, or alters capacity claims.
     pub(crate) fn classify_schema_v2_absent_final_recovery(
         &self,
         operation_id: Uuid,
     ) -> Result<AbsentFinalRecoveryClassification, JournalError> {
         Ok(self
-            .inspect_schema_v2_absent_final_recovery(operation_id)?
+            .run_schema_v2_absent_final_recovery(operation_id)?
             .classification)
     }
 
-    fn inspect_schema_v2_absent_final_recovery(
+    /// Build an owned recovery handoff from durable evidence without touching the filesystem.
+    fn prepare_schema_v2_absent_final_recovery_request(
         &self,
         operation_id: Uuid,
-    ) -> Result<super::absent_final_recovery::AbsentFinalRecoveryInspection, JournalError> {
+    ) -> Result<AbsentFinalRecoveryRequest, JournalError> {
         let record = self
             .store
             .record(operation_id)
             .ok_or(JournalError::NotFound(operation_id))?;
+        if record.operation_id != operation_id {
+            return Err(JournalError::InvalidPublicationEvidence {
+                operation_id,
+                reason: String::from("absent-final recovery record operation identity changed"),
+            });
+        }
         if record.schema_version != SCHEMA_V2 {
             return Err(JournalError::InvalidPublicationEvidence {
                 operation_id,
@@ -3582,7 +3623,29 @@ impl OperationJournalCoordinator {
                 reason,
             }
         })?;
-        Ok(inspect_absent_final_recovery(prepared, staged))
+        let FilesystemStagedParticipant::CopyValidated { staging, evidence } = &staged.participant;
+        AbsentFinalRecoveryRequest::try_new(
+            operation_id,
+            prepared.target_parent.path.clone(),
+            prepared.target_parent.identity.clone(),
+            staging.relative_path.clone(),
+            prepared.final_leaf.clone(),
+            staging.identity.clone(),
+            evidence.clone(),
+        )
+        .map_err(|error| JournalError::InvalidPublicationEvidence {
+            operation_id,
+            reason: format!("invalid absent-final recovery request: {error:?}"),
+        })
+    }
+
+    fn run_schema_v2_absent_final_recovery(
+        &self,
+        operation_id: Uuid,
+    ) -> Result<AbsentFinalRecoveryResult, JournalError> {
+        let request = self.prepare_schema_v2_absent_final_recovery_request(operation_id)?;
+        let result = ProductionAbsentFinalRecoveryAdapter.inspect(request);
+        validate_absent_final_recovery_result_operation_id(operation_id, result)
     }
 
     /// Re-inspect one eligible absent-final record and durably retain only the exact
@@ -3592,12 +3655,12 @@ impl OperationJournalCoordinator {
         &mut self,
         operation_id: Uuid,
     ) -> Result<AbsentFinalRecoveryClassification, JournalError> {
-        let inspection = self.inspect_schema_v2_absent_final_recovery(operation_id)?;
+        let result = self.run_schema_v2_absent_final_recovery(operation_id)?;
         let existing = self
             .store
             .record(operation_id)
             .and_then(|record| record.absent_final_recovery_observation.clone());
-        match (inspection.classification, inspection.observation, existing) {
+        match (result.classification, result.observation, existing) {
             (
                 AbsentFinalRecoveryClassification::StagingMissingFinalMatches,
                 Some(observation),
@@ -3644,19 +3707,18 @@ impl OperationJournalCoordinator {
         &mut self,
         operation_id: Uuid,
     ) -> Result<AbsentFinalRecoveryClassification, JournalError> {
-        let inspection = self.inspect_schema_v2_absent_final_recovery(operation_id)?;
-        let AbsentFinalRecoveryClassification::StagingMissingFinalMatches =
-            inspection.classification
+        let result = self.run_schema_v2_absent_final_recovery(operation_id)?;
+        let AbsentFinalRecoveryClassification::StagingMissingFinalMatches = result.classification
         else {
             return Err(JournalError::InvalidRecoveryObservation {
                 operation_id,
                 reason: format!(
                     "absent-final transaction-owned proof requires StagingMissingFinalMatches, got {:?}",
-                    inspection.classification
+                    result.classification
                 ),
             });
         };
-        let Some(live_observation) = inspection.observation else {
+        let Some(live_observation) = result.observation else {
             return Err(JournalError::InvalidRecoveryObservation {
                 operation_id,
                 reason: String::from(
@@ -3706,15 +3768,15 @@ impl OperationJournalCoordinator {
         Ok(AbsentFinalRecoveryClassification::StagingMissingFinalMatches)
     }
 
-    /// Qualify an already-present absent-final entry through a freshly reacquired, identity-checked
-    /// target-parent capability. This is observation-only: it never writes the journal, changes
-    /// phase/timestamps/capacity, or mutates the filesystem.
+    /// Qualify an already-present absent-final entry through the physical file-owner adapters.
+    /// This is observation-only: it never writes the journal, changes phase/timestamps/capacity,
+    /// or mutates the filesystem.
     pub(crate) fn qualify_schema_v2_absent_final_adoption(
         &self,
         operation_id: Uuid,
     ) -> Result<AbsentFinalAdoptionOutcome, JournalError> {
-        let inspection = self
-            .inspect_schema_v2_absent_final_recovery(operation_id)
+        let recovery = self
+            .run_schema_v2_absent_final_recovery(operation_id)
             .map_err(|error| match error {
                 JournalError::NotFound(_) => error,
                 error => JournalError::InvalidRecoveryObservation {
@@ -3723,17 +3785,23 @@ impl OperationJournalCoordinator {
                 },
             })?;
         if !matches!(
-            inspection.classification,
+            recovery.classification,
             AbsentFinalRecoveryClassification::StagingMissingFinalMatches
         ) {
             return Err(JournalError::InvalidRecoveryObservation {
                 operation_id,
                 reason: format!(
                     "absent-final adoption requires StagingMissingFinalMatches, got {:?}",
-                    inspection.classification
+                    recovery.classification
                 ),
             });
         }
+        let Some(live_observation) = recovery.observation else {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from("absent-final adoption requires a live recovery observation"),
+            });
+        };
         let record = self
             .store
             .record(operation_id)
@@ -3750,6 +3818,14 @@ impl OperationJournalCoordinator {
                 reason: String::from("absent-final adoption requires transaction-owned proof"),
             });
         };
+        if live_observation != *observation {
+            return Err(JournalError::InvalidRecoveryObservation {
+                operation_id,
+                reason: String::from(
+                    "live absent-final recovery observation conflicts with durable observation",
+                ),
+            });
+        }
         if proof.target_parent_stable_id != observation.target_parent_stable_id
             || proof.final_stable_id != observation.final_stable_id
             || proof.final_len != observation.final_len
@@ -3773,41 +3849,23 @@ impl OperationJournalCoordinator {
                 reason: String::from("absent-final adoption requires exact content proof"),
             });
         };
-        let (target_parent, target_capability) =
-            open_root(&prepared.target_parent.path).map_err(|reason| {
-                JournalError::InvalidRecoveryObservation {
-                    operation_id,
-                    reason: format!("could not reacquire target-parent capability: {reason}"),
-                }
-            })?;
-        if target_capability.identity.stable_id != proof.target_parent_stable_id {
-            return Err(JournalError::InvalidRecoveryObservation {
-                operation_id,
-                reason: String::from("reacquired target-parent identity conflicts with proof"),
-            });
-        }
-        let request = super::absent_final_no_replace::AbsentFinalAdoptionRequest::try_new(
-            &target_parent,
-            &prepared.final_leaf,
-            &target_capability.identity,
-            &proof.final_stable_id,
+        let request = AbsentFinalAdoptionQualificationRequest::try_new(
+            operation_id,
+            prepared.target_parent.path.clone(),
+            prepared.final_leaf.clone(),
+            proof.target_parent_stable_id.clone(),
+            proof.final_stable_id.clone(),
             proof.final_len,
-            expected_content,
+            *expected_content,
         )
         .map_err(|error| JournalError::InvalidRecoveryObservation {
             operation_id,
-            reason: match error {
-                AbsentFinalNoReplaceRequestError::TargetLeafNotSingleCleanNormal => {
-                    String::from("absent-final adoption final leaf is not clean")
-                }
-                AbsentFinalNoReplaceRequestError::StagingLeafNotSingleCleanNormal => {
-                    String::from("absent-final adoption staging leaf is not applicable")
-                }
-            },
+            reason: format!("invalid absent-final adoption request: {error:?}"),
         })?;
-        let outcome = ProductionAbsentFinalAdoptionAdapter.qualify(request);
+        let result = ProductionAbsentFinalAdoptionAdapter.qualify_owned(request);
+        let outcome = validate_absent_final_adoption_result_operation_id(operation_id, result)?;
         if let AbsentFinalAdoptionOutcome::Qualified(qualified) = &outcome {
-            if qualified.target_parent != target_capability.identity
+            if qualified.target_parent.stable_id != proof.target_parent_stable_id
                 || qualified.final_object.stable_id != proof.final_stable_id
                 || qualified.final_object.len != proof.final_len
                 || qualified.final_content != proof.final_content
@@ -4926,6 +4984,31 @@ mod tests {
                 protected_free_bytes: super::super::capacity_gate::PROTECTED_FREE_SPACE_FLOOR,
             }],
         }
+    }
+
+    #[test]
+    fn absent_final_adapter_results_are_operation_fenced_before_use() {
+        let operation_id = Uuid::new_v4();
+        let recovery_result = AbsentFinalRecoveryResult {
+            operation_id: Uuid::new_v4(),
+            classification: AbsentFinalRecoveryClassification::NeitherPresent,
+            observation: None,
+        };
+        assert!(matches!(
+            validate_absent_final_recovery_result_operation_id(operation_id, recovery_result),
+            Err(JournalError::InvalidRecoveryObservation { operation_id: id, .. })
+                if id == operation_id
+        ));
+
+        let adoption_result = AbsentFinalAdoptionQualificationResult {
+            operation_id: Uuid::new_v4(),
+            outcome: AbsentFinalAdoptionOutcome::UnsupportedPlatform,
+        };
+        assert!(matches!(
+            validate_absent_final_adoption_result_operation_id(operation_id, adoption_result),
+            Err(JournalError::InvalidRecoveryObservation { operation_id: id, .. })
+                if id == operation_id
+        ));
     }
 
     fn absent_final_v2_fixture() -> (
@@ -7715,6 +7798,30 @@ mod tests {
         assert_eq!(journal.store.capacity_claims(), &claims_before);
         assert_eq!(fs::read(&final_path).unwrap(), final_bytes_before);
         assert!(!staging_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schema_v2_absent_final_recovery_request_is_filesystem_free() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let directory = fixture_directory();
+        let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
+            .expect("open real fixture journal");
+        let (operation_id, final_path, staging_path) =
+            admit_real_absent_final_v2_fixture(&mut journal, &directory);
+        let target_parent = final_path.parent().unwrap().to_path_buf();
+        fs::remove_dir_all(&target_parent).expect("remove live target parent");
+
+        let request = journal
+            .prepare_schema_v2_absent_final_recovery_request(operation_id)
+            .expect("durable recovery request must not inspect live paths");
+
+        assert_eq!(request.operation_id, operation_id);
+        assert_eq!(request.target_parent_path, target_parent);
+        assert_eq!(request.staging_leaf, PathBuf::from("staging.wav"));
+        assert_eq!(request.final_leaf, PathBuf::from("final.wav"));
+        assert!(!staging_path.exists());
+        assert!(!final_path.exists());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Goal

Align the schema-v2 absent-final recovery seam with the I/O target by making the file-operation owner explicit: the journal constructs durable, operation-bound requests and consumes typed results, while the adapter owns live descriptor-relative reacquisition and inspection.

## Scope and non-goals

In scope:
- Add owned recovery-observation and adoption-qualification request/result boundaries.
- Move live absent-final inspection, reacquisition, and adoption qualification behind sealed adapters.
- Fence adapter results to the operation and durable prepared/staged contract.
- Preserve conservative no-follow, identity, length, hash, and fail-closed behavior.
- Add regression coverage for filesystem-free request construction, operation fencing, and missing-parent/unsupported outcomes.

Out of scope:
- No production schema-v2 writer or admission.
- No namespace mutation, publication, database/reconciliation, watcher, projection, readiness, or capacity changes.
- No transition beyond `FilesystemStaged`.

## Definition of Done

- The coordinator/journal owns durable validation and request construction only.
- Observation, transaction-owned proof, and adoption qualification each perform fresh adapter executions.
- Results contain no live handles and are operation-fenced before durable evidence is persisted.
- Schema-v1 behavior and schema-v2 test-only gating remain unchanged.
- Focused and proportional validation passes, with no required Terra findings.

## Validation

Using an isolated clean Radiant archive at `/private/tmp/wavecrate-journal-radiant.KTJELI`:

- `cargo test --locked --target-dir /private/tmp/wavecrate-recovery-owner-target --config 'patch."file:///Users/portalsurfer/dev/radiant".radiant.path="/private/tmp/wavecrate-journal-radiant.KTJELI"' --lib absent_final -- --quiet --test-threads=1` — 57 passed.
- Same isolated command with `--lib operation_journal` — 86 passed.
- Same isolated command with `--lib absent_final_no_replace` — 18 passed.
- Same isolated command with `--lib publication` — 29 passed.
- Same isolated command with `--lib app_state` — 1 passed.
- `cargo check --locked --target-dir /private/tmp/wavecrate-recovery-owner-target --config 'patch."file:///Users/portalsurfer/dev/radiant".radiant.path="/private/tmp/wavecrate-journal-radiant.KTJELI"' --all-targets` — passed.
- Targeted rustfmt check on all three changed files — passed.
- `git diff --check` — passed.
- Independent Terra review — `APPROVE`, no blocker/major/minor findings.

## Known limitations

- The optional Windows cross-check was not completed because the temporary target exhausted the machine's remaining disk space; no source diagnostic was reached.
- The schema-v2 absent-final seam remains test-only and does not activate production publication.

## Next task

Continue with the next bounded target slice: consume the durable adoption guard to prove the guarded transition toward `FilesystemPublished`, still without enabling production schema-v2 admission.

User approval is required before merge.