### PR TITLE
Route targeted watcher checkpoints through source-processing owner

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -19,6 +19,25 @@ pub struct ManifestCommitResult {
 }
 
 impl SourceWriteBatch<'_> {
+    /// Read a metadata value from the active write transaction.
+    ///
+    /// The value is read from the same snapshot and writer reservation that will commit the
+    /// batch, so callers can make a revision-fenced decision without opening a second
+    /// connection or observing a newer transaction after the decision.
+    pub fn get_metadata(&self, key: &str) -> Result<Option<String>, SourceDbError> {
+        self.tx
+            .query_row("SELECT value FROM metadata WHERE key = ?1", [key], |row| {
+                row.get(0)
+            })
+            .optional()
+            .map_err(map_sql_error)
+    }
+
+    /// Read the current manifest revision from the active write transaction.
+    pub fn get_revision(&self) -> Result<u64, SourceDbError> {
+        manifest_revision(&self.tx)
+    }
+
     /// Return whether the source traversal policy still matches the scan snapshot.
     pub fn matches_source_traversal_policy(
         &self,

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -456,6 +456,8 @@ pub(in crate::native_app) struct SourceFilesystemSyncResult {
     pub(in crate::native_app) source_id: String,
     pub(in crate::native_app) lifecycle_generation: u64,
     pub(in crate::native_app) changed_count: usize,
+    /// Stable root identity captured by the background sync worker before filesystem/DB work.
+    pub(in crate::native_app) root_identity: Option<String>,
     pub(in crate::native_app) journal_checkpoint_event_id: Option<u64>,
     pub(in crate::native_app) cancelled: bool,
     pub(in crate::native_app) result: Result<SourceFilesystemSyncSuccess, String>,

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -38,8 +38,27 @@ impl FolderBrowserState {
         let Some(current_revision) = self.source.sources[source_index].projection_revision else {
             return false;
         };
-        if delta.manifest_revision <= current_revision {
+
+        if delta.manifest_revision != delta.snapshot_revision {
+            tracing::info!(
+                source_id,
+                manifest_revision = delta.manifest_revision,
+                snapshot_revision = delta.snapshot_revision,
+                "Browser projection delta has mismatched manifest and snapshot revisions"
+            );
+            return false;
+        }
+        if delta.manifest_revision == current_revision {
             return true;
+        }
+        if delta.manifest_revision < current_revision {
+            tracing::info!(
+                source_id,
+                current_revision,
+                incoming_revision = delta.manifest_revision,
+                "Stale browser projection delta requires a full snapshot refresh"
+            );
+            return false;
         }
         if delta.manifest_revision != current_revision.saturating_add(1) {
             tracing::info!(

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -276,6 +276,30 @@ fn committed_projection_delta_applies_only_at_the_next_revision() {
         Rating::KEEP_1
     );
 
+    assert!(browser.apply_committed_projection_delta(
+        &source_id,
+        BrowserProjectionDelta {
+            manifest_revision: revision + 1,
+            snapshot_revision: revision + 1,
+            folders: Vec::new(),
+            removed_file_ids: Vec::new(),
+            upserted_files: Vec::new(),
+        },
+    ));
+    assert!(browser.tree.folders[0].find_file(&path_id(&new)).is_some());
+
+    assert!(!browser.apply_committed_projection_delta(
+        &source_id,
+        BrowserProjectionDelta {
+            manifest_revision: revision,
+            snapshot_revision: revision,
+            folders: Vec::new(),
+            removed_file_ids: vec![path_id(&new)],
+            upserted_files: Vec::new(),
+        },
+    ));
+    assert!(browser.tree.folders[0].find_file(&path_id(&new)).is_some());
+
     assert!(!browser.apply_committed_projection_delta(
         &source_id,
         BrowserProjectionDelta {

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -7,12 +7,14 @@ use crate::native_app::app::{
     SourceRefreshCause, SourceRefreshRequest, emit_gui_action,
 };
 use crate::native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::{
-    recover_source_filesystem_sync, sync_source_database_paths_with_writer,
+    capture_source_root_identity, recover_source_filesystem_sync,
+    sync_source_database_paths_with_writer,
 };
 use crate::native_app::sample_library::source_prep::{
     CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
     SourcePrepIntents, SourcePriorityIntent,
 };
+use crate::native_app::sample_library::source_watcher::{CheckpointCause, RevisionBoundCheckpoint};
 use crate::native_app::source_processing::{
     ExternalScanHandoff, manifest_delta_requires_browser_refresh,
 };
@@ -135,6 +137,7 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let source_id = result.source_id;
+        let root_identity = result.root_identity;
         let journal_checkpoint_event_id = result.journal_checkpoint_event_id;
         self.library
             .mark_targeted_source_sync_finished(&source_id, result.lifecycle_generation);
@@ -162,6 +165,8 @@ impl NativeAppState {
             Ok(success) => {
                 let renames_reconciled = success.renames_reconciled;
                 let mut incomplete_error = success.incomplete_error;
+                let mut incomplete_reconciliation_reason =
+                    "filesystem_sync_incomplete_after_commit";
                 let delta = success.committed_delta;
                 let browser_delta_applied = if incomplete_error.is_none() {
                     match success.browser_projection_delta {
@@ -195,6 +200,39 @@ impl NativeAppState {
                         "Falling back to a full browser projection after committed projection completion failed"
                     );
                 }
+                if !result.cancelled && projection_accepted && incomplete_error.is_none() {
+                    match (root_identity, journal_checkpoint_event_id) {
+                        (Some(root_identity), Some(event_id)) => self
+                            .background
+                            .source_processing
+                            .budget_handle()
+                            .submit_watcher_checkpoint(RevisionBoundCheckpoint {
+                                source_id: source_id.clone(),
+                                lifecycle_generation: result.lifecycle_generation,
+                                source_revision: delta.revision,
+                                root_identity,
+                                event_id,
+                                cause: CheckpointCause::TargetedReplay,
+                            }),
+                        (None, _) => {
+                            incomplete_error = Some(String::from(
+                                "targeted filesystem sync completed without worker-captured source root identity",
+                            ));
+                            incomplete_reconciliation_reason =
+                                "targeted_sync_root_identity_missing";
+                            tracing::warn!(
+                                source_id = %source_id,
+                                revision = delta.revision,
+                                "Refusing targeted watcher checkpoint without worker-captured root identity"
+                            );
+                        }
+                        (Some(_), None) => tracing::debug!(
+                            source_id = %source_id,
+                            revision = delta.revision,
+                            "Skipping targeted watcher checkpoint because replay event identity is unavailable"
+                        ),
+                    }
+                }
                 self.reapply_desired_rating_overlay();
                 tracing::info!(
                     source_id = %source_id,
@@ -206,7 +244,11 @@ impl NativeAppState {
                     renames_reconciled,
                     "Committed filesystem source delta"
                 );
-                if !result.cancelled && !delta.is_empty() && projection_accepted {
+                if !result.cancelled
+                    && !delta.is_empty()
+                    && projection_accepted
+                    && incomplete_error.is_none()
+                {
                     self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
                     self.queue_source_prep(
                         source_id.clone(),
@@ -220,17 +262,8 @@ impl NativeAppState {
                         .source_processing
                         .wake_source_for_full_reconciliation(
                             &source_id,
-                            "filesystem_sync_incomplete_after_commit",
+                            incomplete_reconciliation_reason,
                         );
-                }
-                if !result.cancelled
-                    && projection_accepted
-                    && let (Some(watcher), Some(event_id)) = (
-                        self.library.source_watcher.as_ref(),
-                        journal_checkpoint_event_id,
-                    )
-                {
-                    watcher.advance_journal_checkpoint(source_id.clone(), event_id);
                 }
                 if result.cancelled || incomplete_error.is_some() {
                     self.queue_filesystem_source_refresh(
@@ -554,6 +587,7 @@ impl NativeAppState {
                         source_id,
                         lifecycle_generation: expected_lifecycle_generation,
                         changed_count,
+                        root_identity: capture_source_root_identity(&root),
                         journal_checkpoint_event_id,
                         cancelled: true,
                         result: Err(String::from("Source filesystem sync canceled")),
@@ -562,6 +596,7 @@ impl NativeAppState {
                 let lifecycle_generation = permit.lifecycle_generation();
                 let cancel = permit.cancel_token();
                 let scan_writer = permit.scan_writer();
+                let root_identity = capture_source_root_identity(&root);
                 let recovery_source_id = source_id.clone();
                 let mut result = recover_source_filesystem_sync(
                     recovery_source_id,
@@ -579,6 +614,7 @@ impl NativeAppState {
                         )
                     },
                 );
+                result.root_identity = root_identity;
                 result.journal_checkpoint_event_id = journal_checkpoint_event_id;
                 let projection_ticket = match &mut result.result {
                     Ok(success)
@@ -651,16 +687,18 @@ fn manifest_audit_followup(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use super::{ManifestAuditFollowup, manifest_audit_followup};
     use crate::native_app::{
         app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
         sample_library::folder_browser::{FolderBrowserState, scan::scan_source_with_progress},
+        sample_library::source_watcher::CheckpointCause,
         test_support::state::NativeAppStateFixture,
     };
     use wavecrate::sample_sources::scanner::{CommittedSourceDelta, ManifestIdentityDelta};
     use wavecrate::sample_sources::{SampleSource, SourceId};
+    use wavecrate_library::filesystem_identity::stable_filesystem_identity;
 
     #[test]
     fn content_generation_only_audit_reconciles_without_filesystem_rescan() {
@@ -743,6 +781,7 @@ mod tests {
             source_id,
             lifecycle_generation: generation,
             changed_count: 1,
+            root_identity: None,
             journal_checkpoint_event_id: Some(73),
             cancelled: false,
             result: Ok(SourceFilesystemSyncSuccess {
@@ -762,6 +801,240 @@ mod tests {
                 projection_handoff_ticket: None,
             }),
         }
+    }
+
+    fn stable_root_identity(root: &Path) -> String {
+        let metadata = std::fs::metadata(root).expect("source metadata");
+        stable_filesystem_identity(root, &metadata).expect("stable source root identity")
+    }
+
+    fn targeted_result_with_projection(
+        state: &crate::native_app::app::NativeAppState,
+        source_id: String,
+        generation: u64,
+        root_identity: Option<String>,
+        projection_revision: u64,
+    ) -> SourceFilesystemSyncResult {
+        let committed_delta = CommittedSourceDelta {
+            revision: projection_revision,
+            ..CommittedSourceDelta::default()
+        };
+        let ticket = state
+            .background
+            .source_processing
+            .budget_handle()
+            .acquire_scan_for_generation(&source_id, generation)
+            .expect("targeted replay scan permit")
+            .release_after_projection_handoff(committed_delta.clone());
+        SourceFilesystemSyncResult {
+            source_id,
+            lifecycle_generation: generation,
+            changed_count: 1,
+            root_identity,
+            journal_checkpoint_event_id: Some(73),
+            cancelled: false,
+            result: Ok(SourceFilesystemSyncSuccess {
+                renames_reconciled: 0,
+                incomplete_error: None,
+                committed_delta,
+                browser_projection_delta: Some(BrowserProjectionDelta {
+                    manifest_revision: projection_revision,
+                    snapshot_revision: projection_revision,
+                    folders: Vec::new(),
+                    removed_file_ids: Vec::new(),
+                    upserted_files: Vec::new(),
+                }),
+                projection_handoff_ticket: Some(ticket),
+            }),
+        }
+    }
+
+    #[test]
+    fn accepted_targeted_replay_submits_revision_bound_checkpoint_to_owner_queue() {
+        let (root, mut state, source_id, generation) = completion_test_state();
+        let current_revision = state
+            .library
+            .folder_browser
+            .source_projection_revision(&source_id)
+            .expect("current browser projection revision");
+        let result = targeted_result_with_projection(
+            &state,
+            source_id.clone(),
+            generation,
+            Some(stable_root_identity(root.path())),
+            current_revision.saturating_add(1),
+        );
+        let mut context = radiant::prelude::UiUpdateContext::default();
+
+        state.finish_source_filesystem_sync(result, &mut context);
+
+        let checkpoint = state
+            .background
+            .source_processing
+            .budget_handle()
+            .pending_watcher_checkpoint_for_tests()
+            .expect("accepted targeted replay checkpoint");
+        assert_eq!(checkpoint.source_id, source_id);
+        assert_eq!(checkpoint.lifecycle_generation, generation);
+        assert_eq!(checkpoint.source_revision, current_revision + 1);
+        assert_eq!(checkpoint.root_identity, stable_root_identity(root.path()));
+        assert_eq!(checkpoint.event_id, 73);
+        assert_eq!(checkpoint.cause, CheckpointCause::TargetedReplay);
+    }
+
+    #[test]
+    fn missing_worker_root_identity_requests_reconciliation_without_checkpoint() {
+        let (_root, mut state, source_id, generation) = completion_test_state();
+        let current_revision = state
+            .library
+            .folder_browser
+            .source_projection_revision(&source_id)
+            .expect("current browser projection revision");
+        let result = targeted_result_with_projection(
+            &state,
+            source_id.clone(),
+            generation,
+            None,
+            current_revision.saturating_add(1),
+        );
+        let mut context = radiant::prelude::UiUpdateContext::default();
+
+        state.finish_source_filesystem_sync(result, &mut context);
+
+        assert!(
+            state
+                .background
+                .source_processing
+                .budget_handle()
+                .pending_watcher_checkpoint_for_tests()
+                .is_none()
+        );
+        assert!(
+            state
+                .background
+                .source_processing
+                .source_dirty_for_tests(&source_id)
+        );
+    }
+
+    #[test]
+    fn stale_targeted_replay_completion_does_not_submit_checkpoint() {
+        let (root, mut state, source_id, generation) = completion_test_state();
+        let current_revision = state
+            .library
+            .folder_browser
+            .source_projection_revision(&source_id)
+            .expect("current browser projection revision");
+        let mut result = targeted_result_with_projection(
+            &state,
+            source_id.clone(),
+            generation,
+            Some(stable_root_identity(root.path())),
+            current_revision.saturating_add(1),
+        );
+        result.lifecycle_generation = generation.wrapping_sub(1);
+        let mut context = radiant::prelude::UiUpdateContext::default();
+
+        state.finish_source_filesystem_sync(result, &mut context);
+
+        assert!(
+            state
+                .background
+                .source_processing
+                .budget_handle()
+                .pending_watcher_checkpoint_for_tests()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejected_projection_ticket_does_not_submit_checkpoint() {
+        let (root, mut state, source_id, generation) = completion_test_state();
+        let current_revision = state
+            .library
+            .folder_browser
+            .source_projection_revision(&source_id)
+            .expect("current browser projection revision");
+        let result = targeted_result_with_projection(
+            &state,
+            source_id.clone(),
+            generation,
+            Some(stable_root_identity(root.path())),
+            current_revision.saturating_add(2),
+        );
+        let mut context = radiant::prelude::UiUpdateContext::default();
+
+        state.finish_source_filesystem_sync(result, &mut context);
+
+        assert!(
+            state
+                .background
+                .source_processing
+                .budget_handle()
+                .pending_watcher_checkpoint_for_tests()
+                .is_none()
+        );
+        assert!(
+            state
+                .background
+                .source_processing
+                .source_dirty_for_tests(&source_id)
+        );
+    }
+
+    #[test]
+    fn stale_already_surpassed_projection_requests_recovery_without_checkpoint() {
+        let (root, mut state, source_id, generation) = completion_test_state();
+        let current_revision = state
+            .library
+            .folder_browser
+            .source_projection_revision(&source_id)
+            .expect("current browser projection revision");
+        assert!(
+            state
+                .library
+                .folder_browser
+                .apply_committed_projection_delta(
+                    &source_id,
+                    BrowserProjectionDelta {
+                        manifest_revision: current_revision + 1,
+                        snapshot_revision: current_revision + 1,
+                        folders: Vec::new(),
+                        removed_file_ids: Vec::new(),
+                        upserted_files: Vec::new(),
+                    },
+                )
+        );
+
+        let result = targeted_result_with_projection(
+            &state,
+            source_id.clone(),
+            generation,
+            Some(stable_root_identity(root.path())),
+            current_revision,
+        );
+        let mut context = radiant::prelude::UiUpdateContext::default();
+
+        state.finish_source_filesystem_sync(result, &mut context);
+
+        assert!(
+            state
+                .background
+                .source_processing
+                .budget_handle()
+                .pending_watcher_checkpoint_for_tests()
+                .is_none(),
+            "a stale projection must not acknowledge the watcher cursor"
+        );
+        assert!(
+            state
+                .background
+                .source_processing
+                .source_dirty_for_tests(&source_id),
+            "a stale projection must request conservative source recovery"
+        );
+        assert!(state.library.folder_scan_active());
+        assert!(state.library.source_watcher.is_none());
     }
 
     #[test]

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -1,11 +1,12 @@
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
     thread,
     time::Duration,
 };
 
 use wavecrate::sample_sources::SourceDatabase;
+use wavecrate_library::filesystem_identity::stable_filesystem_identity;
 use wavecrate_library::sample_sources::is_supported_audio;
 use wavecrate_scan::sample_sources::scanner::{
     self, ScanWritePhase, ScanWriter, UncoordinatedScanWriter,
@@ -35,6 +36,7 @@ pub(in crate::native_app) fn recover_source_filesystem_sync(
             source_id,
             lifecycle_generation,
             changed_count,
+            root_identity: None,
             journal_checkpoint_event_id: None,
             cancelled: false,
             result: Err(String::from(
@@ -63,6 +65,12 @@ pub(in crate::native_app) fn sync_source_database_paths(
     )
 }
 
+pub(in crate::native_app) fn capture_source_root_identity(root: &Path) -> Option<String> {
+    std::fs::metadata(root)
+        .ok()
+        .and_then(|metadata| stable_filesystem_identity(root, &metadata))
+}
+
 pub(in crate::native_app) fn sync_source_database_paths_with_writer(
     source_id: String,
     root: PathBuf,
@@ -72,6 +80,7 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
     cancel: &AtomicBool,
     writer: &impl ScanWriter,
 ) -> SourceFilesystemSyncResult {
+    let root_identity = capture_source_root_identity(&root);
     let mut result = Err(String::from("Source filesystem sync did not run"));
     for attempt in 0..MAX_SYNC_ATTEMPTS {
         result = sync_source_database_paths_once(
@@ -104,6 +113,7 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
         source_id,
         lifecycle_generation: 0,
         changed_count,
+        root_identity,
         journal_checkpoint_event_id: None,
         cancelled: cancel.load(Ordering::Acquire),
         result,
@@ -392,6 +402,7 @@ mod tests {
         );
 
         let success = result.result.expect("sync result");
+        assert!(result.root_identity.is_some());
         assert_eq!(success.renames_reconciled, 1);
         assert_eq!(success.committed_delta.moved.len(), 1);
         let projection = success

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -25,6 +25,10 @@ fn doubled_duration(current: Duration, maximum: Duration) -> Duration {
 }
 
 pub(in crate::native_app) use handle::GuiSourceWatcherHandle;
+pub(in crate::native_app) use journal::{
+    CheckpointAdvanceOutcome, CheckpointCause, RevisionBoundCheckpoint,
+    write_revision_bound_checkpoint,
+};
 
 #[cfg(test)]
 #[path = "source_watcher/tests.rs"]

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -285,19 +285,6 @@ impl GuiSourceWatcherHandle {
             });
     }
 
-    pub(in crate::native_app) fn advance_journal_checkpoint(
-        &self,
-        source_id: String,
-        event_id: u64,
-    ) {
-        let _ = self
-            .command_tx
-            .send(GuiSourceWatchCommand::AdvanceJournalCheckpoint {
-                source_id,
-                event_id,
-            });
-    }
-
     pub(in crate::native_app) fn finish_journal_barrier_audit(
         &self,
         source_id: String,
@@ -380,10 +367,6 @@ enum GuiSourceWatchCommand {
         echoes: Vec<CommittedWatcherEcho>,
         cursor: RevisionFirstCursor,
     },
-    AdvanceJournalCheckpoint {
-        source_id: String,
-        event_id: u64,
-    },
     FinishJournalBarrierAudit {
         source_id: String,
         complete: bool,
@@ -453,10 +436,6 @@ fn run_source_watcher(
                     Instant::now(),
                 );
             }
-            Ok(GuiSourceWatchCommand::AdvanceJournalCheckpoint {
-                source_id,
-                event_id,
-            }) => journal::advance_after_reconciliation(&state.sources, &source_id, event_id),
             Ok(GuiSourceWatchCommand::FinishJournalBarrierAudit {
                 source_id,
                 complete,
@@ -893,11 +872,24 @@ fn publish_closed_app_journal_recovery(
         match recovery {
             #[cfg(target_os = "macos")]
             JournalRecovery::Changes { paths, event_id } if paths.is_empty() => {
-                journal::advance_after_reconciliation(sources, source.id.as_str(), event_id);
-                tracing::debug!(
+                tracing::info!(
                     source_id = source.id.as_str(),
-                    "Durable source watcher journal found no closed-application changes"
+                    event_id,
+                    "Empty closed-application source watcher replay requires a bounded manifest audit"
                 );
+                if defer_audit_barriers {
+                    deferred_audit_barrier_sources.insert(source.id.as_str().to_string());
+                } else {
+                    if let Some(barrier) =
+                        journal::capture_audit_barrier(sources, source.id.as_str())
+                    {
+                        audit_barriers.insert(source.id.as_str().to_string(), barrier);
+                    }
+                    let _ = message_tx.send(GuiMessage::SourceWatcherJournalGap {
+                        source_id: source.id.as_str().to_string(),
+                        reason: "journal_replay_empty_paths",
+                    });
+                }
             }
             #[cfg(target_os = "macos")]
             JournalRecovery::Changes { paths, event_id } => {

--- a/src/native_app/sample_library/source_watcher/journal.rs
+++ b/src/native_app/sample_library/source_watcher/journal.rs
@@ -11,17 +11,385 @@ use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "macos")]
 use notify::EventKind;
-use serde::{Deserialize, Serialize};
-use wavecrate::sample_sources::{SampleSource, db::SourceDatabase};
+use serde::{
+    Deserialize, Serialize,
+    de::{self, Deserializer, MapAccess, Visitor},
+};
+use std::fmt;
+use wavecrate::sample_sources::{
+    SampleSource,
+    db::{SourceDatabase, SourceWriteBatch},
+};
 use wavecrate_library::{
     filesystem_identity::stable_filesystem_identity,
     sample_sources::db::META_SOURCE_WATCHER_CHECKPOINT,
 };
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+const CHECKPOINT_FORMAT_VERSION: u32 = 2;
+const LEGACY_CHECKPOINT_FIELDS: [&str; 2] = ["root_identity", "event_id"];
+const V2_CHECKPOINT_FIELDS: [&str; 7] = [
+    "root_identity",
+    "event_id",
+    "format_version",
+    "source_id",
+    "lifecycle_generation",
+    "source_revision",
+    "cause",
+];
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::native_app) enum CheckpointCause {
+    TargetedReplay,
+    CompletedFallbackAudit,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(in crate::native_app) struct RevisionBoundCheckpoint {
+    pub(in crate::native_app) source_id: String,
+    pub(in crate::native_app) lifecycle_generation: u64,
+    pub(in crate::native_app) source_revision: u64,
+    pub(in crate::native_app) root_identity: String,
+    pub(in crate::native_app) event_id: u64,
+    pub(in crate::native_app) cause: CheckpointCause,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::native_app) enum CheckpointAdvanceOutcome {
+    Applied,
+    AlreadyApplied,
+    Superseded,
+    Retryable,
+    AuditRequired,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 struct SourceWatcherCheckpoint {
     root_identity: String,
     event_id: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    format_version: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    lifecycle_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_revision: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cause: Option<CheckpointCause>,
+}
+
+impl SourceWatcherCheckpoint {
+    fn legacy(root_identity: String, event_id: u64) -> Self {
+        Self {
+            root_identity,
+            event_id,
+            format_version: None,
+            source_id: None,
+            lifecycle_generation: None,
+            source_revision: None,
+            cause: None,
+        }
+    }
+
+    fn from_revision_bound(checkpoint: &RevisionBoundCheckpoint) -> Self {
+        Self {
+            root_identity: checkpoint.root_identity.clone(),
+            event_id: checkpoint.event_id,
+            format_version: Some(CHECKPOINT_FORMAT_VERSION),
+            source_id: Some(checkpoint.source_id.clone()),
+            lifecycle_generation: Some(checkpoint.lifecycle_generation),
+            source_revision: Some(checkpoint.source_revision),
+            cause: Some(checkpoint.cause),
+        }
+    }
+
+    fn revision_bound(&self) -> Option<RevisionBoundCheckpoint> {
+        let (
+            Some(CHECKPOINT_FORMAT_VERSION),
+            Some(source_id),
+            Some(lifecycle_generation),
+            Some(source_revision),
+            Some(cause),
+        ) = (
+            self.format_version,
+            self.source_id.clone(),
+            self.lifecycle_generation,
+            self.source_revision,
+            self.cause,
+        )
+        else {
+            return None;
+        };
+        Some(RevisionBoundCheckpoint {
+            source_id,
+            lifecycle_generation,
+            source_revision,
+            root_identity: self.root_identity.clone(),
+            event_id: self.event_id,
+            cause,
+        })
+    }
+}
+
+fn has_exact_checkpoint_fields(
+    object: &serde_json::Map<String, serde_json::Value>,
+    expected_fields: &[&str],
+) -> bool {
+    object.len() == expected_fields.len()
+        && expected_fields
+            .iter()
+            .all(|field| object.contains_key(*field))
+}
+
+fn checkpoint_string(
+    object: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<String, String> {
+    object
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| format!("checkpoint field {field} must be a string"))
+}
+
+fn checkpoint_u64(
+    object: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<u64, String> {
+    object
+        .get(field)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| format!("checkpoint field {field} must be an unsigned integer"))
+}
+
+fn parse_checkpoint_object(
+    value: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    struct CheckpointObjectVisitor;
+
+    impl<'de> Visitor<'de> for CheckpointObjectVisitor {
+        type Value = serde_json::Map<String, serde_json::Value>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a JSON object")
+        }
+
+        fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut object = serde_json::Map::new();
+            while let Some(key) = map.next_key::<String>()? {
+                if object.contains_key(&key) {
+                    return Err(de::Error::custom(format!(
+                        "duplicate checkpoint field: {key}"
+                    )));
+                }
+                object.insert(key, map.next_value::<serde_json::Value>()?);
+            }
+            Ok(object)
+        }
+    }
+
+    let mut deserializer = serde_json::Deserializer::from_str(value);
+    let object = deserializer
+        .deserialize_map(CheckpointObjectVisitor)
+        .map_err(|error| error.to_string())?;
+    deserializer.end().map_err(|error| error.to_string())?;
+    Ok(object)
+}
+
+fn parse_checkpoint(value: &str) -> Result<SourceWatcherCheckpoint, String> {
+    let object = parse_checkpoint_object(value)?;
+
+    if has_exact_checkpoint_fields(&object, &LEGACY_CHECKPOINT_FIELDS) {
+        return Ok(SourceWatcherCheckpoint::legacy(
+            checkpoint_string(&object, "root_identity")?,
+            checkpoint_u64(&object, "event_id")?,
+        ));
+    }
+
+    if !has_exact_checkpoint_fields(&object, &V2_CHECKPOINT_FIELDS) {
+        return Err("watcher checkpoint has an unsupported field shape".to_string());
+    }
+    if checkpoint_u64(&object, "format_version")? != u64::from(CHECKPOINT_FORMAT_VERSION) {
+        return Err("watcher checkpoint has an unsupported format version".to_string());
+    }
+
+    let cause = serde_json::from_value(
+        object
+            .get("cause")
+            .cloned()
+            .ok_or_else(|| "watcher checkpoint is missing cause".to_string())?,
+    )
+    .map_err(|error| format!("checkpoint cause is invalid: {error}"))?;
+    Ok(SourceWatcherCheckpoint {
+        root_identity: checkpoint_string(&object, "root_identity")?,
+        event_id: checkpoint_u64(&object, "event_id")?,
+        format_version: Some(CHECKPOINT_FORMAT_VERSION),
+        source_id: Some(checkpoint_string(&object, "source_id")?),
+        lifecycle_generation: Some(checkpoint_u64(&object, "lifecycle_generation")?),
+        source_revision: Some(checkpoint_u64(&object, "source_revision")?),
+        cause: Some(cause),
+    })
+}
+
+fn decide_checkpoint_advance(
+    current: Option<&SourceWatcherCheckpoint>,
+    requested: &RevisionBoundCheckpoint,
+    expected_source_id: &str,
+    current_lifecycle_generation: u64,
+    current_source_revision: u64,
+    current_root_identity: &str,
+) -> CheckpointAdvanceOutcome {
+    if requested.source_id != expected_source_id
+        || requested.lifecycle_generation != current_lifecycle_generation
+        || requested.source_revision != current_source_revision
+        || requested.root_identity != current_root_identity
+    {
+        return CheckpointAdvanceOutcome::AuditRequired;
+    }
+
+    let Some(current) = current else {
+        return CheckpointAdvanceOutcome::AuditRequired;
+    };
+    let Some(current) = current.revision_bound() else {
+        return CheckpointAdvanceOutcome::AuditRequired;
+    };
+
+    if current.source_id != requested.source_id
+        || current.lifecycle_generation != requested.lifecycle_generation
+        || current.source_revision != requested.source_revision
+        || current.root_identity != requested.root_identity
+    {
+        return CheckpointAdvanceOutcome::AuditRequired;
+    }
+    if current == *requested {
+        return CheckpointAdvanceOutcome::AlreadyApplied;
+    }
+    if requested.event_id < current.event_id {
+        return CheckpointAdvanceOutcome::AuditRequired;
+    }
+    if requested.event_id > current.event_id {
+        return CheckpointAdvanceOutcome::Applied;
+    }
+    CheckpointAdvanceOutcome::Superseded
+}
+
+/// Apply a revision-bound watcher checkpoint from the source-processing owner.
+///
+/// The caller owns lifecycle and live-root validation. This helper only performs bounded source
+/// database work: it opens the configured source database, holds one immediate write batch while
+/// reading the current revision and checkpoint evidence, and commits the new checkpoint only when
+/// the pure advance decision is `Applied`. Legacy, malformed, missing, stale, and superseded
+/// evidence is never rewritten.
+pub(in crate::native_app) fn write_revision_bound_checkpoint(
+    source: &SampleSource,
+    requested: &RevisionBoundCheckpoint,
+    current_lifecycle_generation: u64,
+    current_root_identity: &str,
+) -> CheckpointAdvanceOutcome {
+    let database = match source_database(source) {
+        Ok(database) => database,
+        Err(error) => {
+            tracing::debug!(
+                source_id = source.id.as_str(),
+                ?error,
+                "Could not open source database for watcher checkpoint"
+            );
+            return CheckpointAdvanceOutcome::Retryable;
+        }
+    };
+    let mut batch = match database.write_batch() {
+        Ok(batch) => batch,
+        Err(error) => {
+            tracing::debug!(
+                source_id = source.id.as_str(),
+                ?error,
+                "Could not start source transaction for watcher checkpoint"
+            );
+            return CheckpointAdvanceOutcome::Retryable;
+        }
+    };
+    let current_source_revision = match batch.get_revision() {
+        Ok(revision) => revision,
+        Err(error) => {
+            tracing::debug!(
+                source_id = source.id.as_str(),
+                ?error,
+                "Could not read source revision for watcher checkpoint"
+            );
+            return CheckpointAdvanceOutcome::Retryable;
+        }
+    };
+    let current = match read_checkpoint_from_batch(&batch) {
+        Ok(current) => current,
+        Err(outcome) => return outcome,
+    };
+    let outcome = decide_checkpoint_advance(
+        current.as_ref(),
+        requested,
+        source.id.as_str(),
+        current_lifecycle_generation,
+        current_source_revision,
+        current_root_identity,
+    );
+    if outcome != CheckpointAdvanceOutcome::Applied {
+        return outcome;
+    }
+
+    let value =
+        match serde_json::to_string(&SourceWatcherCheckpoint::from_revision_bound(requested)) {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::debug!(
+                    source_id = source.id.as_str(),
+                    ?error,
+                    "Could not serialize watcher checkpoint"
+                );
+                return CheckpointAdvanceOutcome::Retryable;
+            }
+        };
+    if let Err(error) = batch.set_metadata(META_SOURCE_WATCHER_CHECKPOINT, &value) {
+        tracing::debug!(
+            source_id = source.id.as_str(),
+            ?error,
+            "Could not write watcher checkpoint metadata"
+        );
+        return CheckpointAdvanceOutcome::Retryable;
+    }
+    if let Err(error) = batch.commit_auxiliary_state() {
+        tracing::debug!(
+            source_id = source.id.as_str(),
+            ?error,
+            "Could not commit watcher checkpoint metadata"
+        );
+        return CheckpointAdvanceOutcome::Retryable;
+    }
+    CheckpointAdvanceOutcome::Applied
+}
+
+fn read_checkpoint_from_batch(
+    batch: &SourceWriteBatch<'_>,
+) -> Result<Option<SourceWatcherCheckpoint>, CheckpointAdvanceOutcome> {
+    let Some(value) = batch
+        .get_metadata(META_SOURCE_WATCHER_CHECKPOINT)
+        .map_err(|error| {
+            tracing::debug!(?error, "Could not read watcher checkpoint metadata");
+            CheckpointAdvanceOutcome::Retryable
+        })?
+    else {
+        return Ok(None);
+    };
+    match parse_checkpoint(&value) {
+        Ok(checkpoint) => Ok(Some(checkpoint)),
+        Err(error) => {
+            tracing::debug!(?error, "Stored watcher checkpoint is malformed");
+            Err(CheckpointAdvanceOutcome::AuditRequired)
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -52,6 +420,29 @@ pub(super) fn recover_sources(
         .iter()
         .map(|source| recover_source(source, native_watcher))
         .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn classify_replayed_paths(
+    source: &SampleSource,
+    paths: Vec<PathBuf>,
+    event_id: u64,
+) -> JournalRecovery {
+    let paths = paths
+        .into_iter()
+        .filter(|path| {
+            super::classification::path_is_source_refresh_candidate(path, EventKind::Any)
+        })
+        .filter_map(|path| path.strip_prefix(&source.root).ok().map(PathBuf::from))
+        .filter(|path| !path.as_os_str().is_empty())
+        .collect::<Vec<_>>();
+    if paths.is_empty() {
+        JournalRecovery::FullAudit {
+            reason: "journal_replay_empty_paths",
+        }
+    } else {
+        JournalRecovery::Changes { paths, event_id }
+    }
 }
 
 fn recover_source(source: &SampleSource, native_watcher: bool) -> JournalRecovery {
@@ -98,20 +489,7 @@ fn recover_source(source: &SampleSource, native_watcher: bool) -> JournalRecover
     #[cfg(target_os = "macos")]
     {
         match replay_fsevents(&source.root, checkpoint.event_id) {
-            Ok((paths, event_id)) => JournalRecovery::Changes {
-                paths: paths
-                    .into_iter()
-                    .filter(|path| {
-                        super::classification::path_is_source_refresh_candidate(
-                            path,
-                            EventKind::Any,
-                        )
-                    })
-                    .filter_map(|path| path.strip_prefix(&source.root).ok().map(PathBuf::from))
-                    .filter(|path| !path.as_os_str().is_empty())
-                    .collect(),
-                event_id,
-            },
+            Ok((paths, event_id)) => classify_replayed_paths(source, paths, event_id),
             Err(reason) => JournalRecovery::FullAudit { reason },
         }
     }
@@ -125,6 +503,7 @@ fn recover_source(source: &SampleSource, native_watcher: bool) -> JournalRecover
 }
 
 /// Advance a replay cursor only after the target filesystem reconciliation has committed.
+#[cfg(test)]
 pub(super) fn advance_after_reconciliation(
     sources: &[SampleSource],
     source_id: &str,
@@ -174,10 +553,10 @@ pub(super) fn capture_audit_barrier(
     let root_identity = std::fs::metadata(&source.root)
         .ok()
         .and_then(|metadata| stable_filesystem_identity(&source.root, &metadata))?;
-    Some(AuditBarrier(SourceWatcherCheckpoint {
+    Some(AuditBarrier(SourceWatcherCheckpoint::legacy(
         root_identity,
         event_id,
-    }))
+    )))
 }
 
 /// Commit a pre-audit barrier only after a complete audit. Never sample the current global ID at
@@ -221,7 +600,7 @@ fn load_checkpoint(source: &SampleSource) -> Result<Option<SourceWatcherCheckpoi
     database
         .get_metadata(META_SOURCE_WATCHER_CHECKPOINT)
         .map_err(|error| error.to_string())?
-        .map(|value| serde_json::from_str(&value).map_err(|error| error.to_string()))
+        .map(|value| parse_checkpoint(&value))
         .transpose()
 }
 
@@ -486,6 +865,521 @@ mod macos {
 mod tests {
     use super::*;
     use wavecrate::sample_sources::SourceId;
+    use wavecrate_library::sample_sources::SourceDatabase;
+
+    fn revision_bound_checkpoint(event_id: u64) -> RevisionBoundCheckpoint {
+        RevisionBoundCheckpoint {
+            source_id: "source-a".to_string(),
+            lifecycle_generation: 4,
+            source_revision: 9,
+            root_identity: "root-a".to_string(),
+            event_id,
+            cause: CheckpointCause::TargetedReplay,
+        }
+    }
+
+    fn decide(
+        current: Option<&SourceWatcherCheckpoint>,
+        requested: &RevisionBoundCheckpoint,
+    ) -> CheckpointAdvanceOutcome {
+        decide_checkpoint_advance(current, requested, "source-a", 4, 9, "root-a")
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn empty_replayed_paths_require_a_conservative_audit() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("empty-replay"),
+            directory.path().to_path_buf(),
+        );
+
+        assert_eq!(
+            classify_replayed_paths(&source, Vec::new(), 11),
+            JournalRecovery::FullAudit {
+                reason: "journal_replay_empty_paths",
+            }
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn nonempty_replayed_paths_remain_targeted_changes() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("nonempty-replay"),
+            directory.path().to_path_buf(),
+        );
+
+        assert_eq!(
+            classify_replayed_paths(&source, vec![source.root.join("kick.wav")], 11,),
+            JournalRecovery::Changes {
+                paths: vec![PathBuf::from("kick.wav")],
+                event_id: 11,
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_checkpoint_json_remains_deserializable() {
+        let checkpoint = parse_checkpoint(r#"{"root_identity":"root-a","event_id":7}"#)
+            .expect("legacy checkpoint JSON");
+
+        assert_eq!(checkpoint.root_identity, "root-a");
+        assert_eq!(checkpoint.event_id, 7);
+        assert_eq!(checkpoint.format_version, None);
+        assert_eq!(checkpoint.revision_bound(), None);
+        assert_eq!(
+            serde_json::to_string(&checkpoint).expect("legacy checkpoint JSON"),
+            r#"{"root_identity":"root-a","event_id":7}"#
+        );
+    }
+
+    #[test]
+    fn complete_extension_checkpoint_without_v2_format_requires_an_audit() {
+        let requested = revision_bound_checkpoint(8);
+        let checkpoints = [
+            r#"{"root_identity":"root-a","event_id":7,"source_id":"source-a","lifecycle_generation":4,"source_revision":9,"cause":"targeted_replay"}"#,
+            r#"{"root_identity":"root-a","event_id":7,"format_version":null,"source_id":"source-a","lifecycle_generation":4,"source_revision":9,"cause":"targeted_replay"}"#,
+        ];
+
+        for value in checkpoints {
+            assert!(parse_checkpoint(value).is_err());
+            let checkpoint: SourceWatcherCheckpoint =
+                serde_json::from_str(value).expect("extension checkpoint JSON");
+            assert_eq!(checkpoint.revision_bound(), None);
+            assert_eq!(
+                decide(Some(&checkpoint), &requested),
+                CheckpointAdvanceOutcome::AuditRequired
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_checkpoint_fields_fail_closed() {
+        let json = r#"{
+            "root_identity":"root-a",
+            "event_id":7,
+            "format_version":2,
+            "source_id":"source-a",
+            "lifecycle_generation":4,
+            "source_revision":9,
+            "cause":"targeted_replay",
+            "unexpected":"evidence"
+        }"#;
+
+        assert!(parse_checkpoint(json).is_err());
+    }
+
+    #[test]
+    fn checkpoint_parser_rejects_missing_required_fields_and_invalid_json() {
+        for value in [
+            "{not-json",
+            "null",
+            "[]",
+            "{}",
+            r#"{"root_identity":"root-a"}"#,
+            r#"{"event_id":7}"#,
+            r#"{"root_identity":null,"event_id":7}"#,
+            r#"{"root_identity":"root-a","event_id":null}"#,
+            r#"{"root_identity":"root-a","event_id":7} trailing-data"#,
+        ] {
+            assert!(
+                parse_checkpoint(value).is_err(),
+                "accepted invalid JSON: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_checkpoint_members_fail_closed_without_rewriting_bytes() {
+        let cases = [
+            (
+                "duplicate-legacy",
+                r#"{"root_identity":"root-a","event_id":7,"event_id":7}"#,
+            ),
+            (
+                "duplicate-v2",
+                r#"{"root_identity":"root-a","event_id":7,"format_version":2,"source_id":"duplicate-v2","lifecycle_generation":4,"source_revision":0,"cause":"targeted_replay","format_version":2}"#,
+            ),
+        ];
+
+        for (source_id, bytes) in cases {
+            let directory = tempfile::tempdir().expect("duplicate-evidence source");
+            let source = SampleSource::new_with_id(
+                SourceId::from_string(source_id),
+                directory.path().to_path_buf(),
+            );
+            let requested = owner_checkpoint(source_id, 4, 0, "root-a", 8);
+
+            assert!(
+                parse_checkpoint(bytes).is_err(),
+                "accepted {source_id} evidence"
+            );
+            seed_owner_checkpoint(&source, bytes);
+            assert!(
+                load_checkpoint(&source).is_err(),
+                "loaded {source_id} evidence"
+            );
+            assert_eq!(
+                recover_source(&source, true),
+                JournalRecovery::FullAudit {
+                    reason: "watcher_checkpoint_unavailable",
+                }
+            );
+            assert_eq!(
+                write_revision_bound_checkpoint(&source, &requested, 4, "root-a"),
+                CheckpointAdvanceOutcome::AuditRequired
+            );
+            assert_eq!(owner_checkpoint_bytes(&source).as_deref(), Some(bytes));
+        }
+    }
+
+    #[test]
+    fn checkpoint_parser_rejects_null_v2_field_values() {
+        let valid = serde_json::json!({
+            "root_identity": "root-a",
+            "event_id": 7,
+            "format_version": 2,
+            "source_id": "source-a",
+            "lifecycle_generation": 4,
+            "source_revision": 9,
+            "cause": "targeted_replay"
+        });
+        for field in [
+            "root_identity",
+            "event_id",
+            "format_version",
+            "source_id",
+            "lifecycle_generation",
+            "source_revision",
+            "cause",
+        ] {
+            let mut invalid = valid.clone();
+            invalid[field] = serde_json::Value::Null;
+            assert!(
+                parse_checkpoint(&invalid.to_string()).is_err(),
+                "accepted null v2 field: {field}"
+            );
+        }
+    }
+
+    #[test]
+    fn revision_bound_checkpoint_round_trips_with_version_and_cause() {
+        let expected = revision_bound_checkpoint(7);
+        let checkpoint = SourceWatcherCheckpoint::from_revision_bound(&expected);
+        let json = serde_json::to_string(&checkpoint).expect("revision-bound checkpoint JSON");
+
+        assert!(json.contains(r#""format_version":2"#));
+        assert!(json.contains(r#""cause":"targeted_replay""#));
+        assert_eq!(
+            parse_checkpoint(&json)
+                .expect("revision-bound checkpoint JSON")
+                .revision_bound(),
+            Some(expected)
+        );
+        assert_eq!(
+            serde_json::to_value(CheckpointCause::CompletedFallbackAudit)
+                .expect("checkpoint cause JSON"),
+            serde_json::json!("completed_fallback_audit")
+        );
+    }
+
+    #[test]
+    fn invalid_revision_bound_requests_require_an_audit() {
+        let current_request = revision_bound_checkpoint(7);
+        let current = SourceWatcherCheckpoint::from_revision_bound(&current_request);
+
+        let mut stale_lifecycle = revision_bound_checkpoint(8);
+        stale_lifecycle.lifecycle_generation = 3;
+        assert_eq!(
+            decide(Some(&current), &stale_lifecycle),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let mut mismatched_revision = revision_bound_checkpoint(8);
+        mismatched_revision.source_revision = 8;
+        assert_eq!(
+            decide(Some(&current), &mismatched_revision),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let mut mismatched_root = revision_bound_checkpoint(8);
+        mismatched_root.root_identity = "root-b".to_string();
+        assert_eq!(
+            decide(Some(&current), &mismatched_root),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let regressed_cursor = revision_bound_checkpoint(6);
+        assert_eq!(
+            decide(Some(&current), &regressed_cursor),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+    }
+
+    #[test]
+    fn configured_source_id_mismatch_requires_an_audit() {
+        let requested = RevisionBoundCheckpoint {
+            source_id: "source-b".to_string(),
+            ..revision_bound_checkpoint(8)
+        };
+        let current = SourceWatcherCheckpoint::from_revision_bound(&requested);
+
+        assert_eq!(
+            decide(Some(&current), &requested),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+    }
+
+    #[test]
+    fn missing_current_checkpoint_requires_an_audit() {
+        assert_eq!(
+            decide(None, &revision_bound_checkpoint(8)),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+    }
+
+    #[test]
+    fn duplicate_checkpoint_is_idempotent_and_newer_checkpoint_applies() {
+        let current_request = revision_bound_checkpoint(7);
+        let current = SourceWatcherCheckpoint::from_revision_bound(&current_request);
+
+        assert_eq!(
+            decide(Some(&current), &current_request),
+            CheckpointAdvanceOutcome::AlreadyApplied
+        );
+        assert_eq!(
+            decide(Some(&current), &revision_bound_checkpoint(8)),
+            CheckpointAdvanceOutcome::Applied
+        );
+    }
+
+    #[test]
+    fn legacy_checkpoint_without_revision_bound_evidence_requires_an_audit() {
+        let legacy = SourceWatcherCheckpoint::legacy("root-a".to_string(), 7);
+
+        assert_eq!(
+            decide(Some(&legacy), &revision_bound_checkpoint(8)),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+    }
+
+    fn owner_checkpoint(
+        source_id: &str,
+        lifecycle_generation: u64,
+        source_revision: u64,
+        root_identity: &str,
+        event_id: u64,
+    ) -> RevisionBoundCheckpoint {
+        RevisionBoundCheckpoint {
+            source_id: source_id.to_string(),
+            lifecycle_generation,
+            source_revision,
+            root_identity: root_identity.to_string(),
+            event_id,
+            cause: CheckpointCause::TargetedReplay,
+        }
+    }
+
+    fn seed_owner_checkpoint(source: &SampleSource, value: &str) {
+        let database = SourceDatabase::open_for_test_fixture_source_write(&source.root)
+            .expect("source database");
+        let mut batch = database.write_batch().expect("checkpoint seed transaction");
+        batch
+            .set_metadata(META_SOURCE_WATCHER_CHECKPOINT, value)
+            .expect("seed checkpoint metadata");
+        batch
+            .commit_auxiliary_state()
+            .expect("commit checkpoint seed");
+    }
+
+    fn owner_checkpoint_bytes(source: &SampleSource) -> Option<String> {
+        SourceDatabase::open_for_test_fixture_source_write(&source.root)
+            .expect("source database")
+            .get_metadata(META_SOURCE_WATCHER_CHECKPOINT)
+            .expect("read checkpoint metadata")
+    }
+
+    #[test]
+    fn owner_commits_valid_checkpoint_idempotently_without_advancing_source_revision() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("owner-valid"),
+            directory.path().to_path_buf(),
+        );
+        let current = owner_checkpoint("owner-valid", 4, 0, "root-a", 7);
+        let requested = owner_checkpoint("owner-valid", 4, 0, "root-a", 8);
+        seed_owner_checkpoint(
+            &source,
+            &serde_json::to_string(&SourceWatcherCheckpoint::from_revision_bound(&current))
+                .expect("serialize checkpoint seed"),
+        );
+
+        assert_eq!(
+            write_revision_bound_checkpoint(&source, &requested, 4, "root-a"),
+            CheckpointAdvanceOutcome::Applied
+        );
+        let database = SourceDatabase::open_for_test_fixture_source_write(&source.root)
+            .expect("source database");
+        assert_eq!(database.get_revision().expect("source revision"), 0);
+        assert_eq!(
+            owner_checkpoint_bytes(&source)
+                .and_then(|value| parse_checkpoint(&value).ok())
+                .and_then(|checkpoint| checkpoint.revision_bound()),
+            Some(requested.clone())
+        );
+        assert_eq!(
+            write_revision_bound_checkpoint(&source, &requested, 4, "root-a"),
+            CheckpointAdvanceOutcome::AlreadyApplied
+        );
+        assert_eq!(
+            SourceDatabase::open_for_test_fixture_source_write(&source.root)
+                .expect("source database")
+                .get_revision()
+                .expect("source revision"),
+            0
+        );
+    }
+
+    #[test]
+    fn owner_preserves_missing_legacy_unknown_and_malformed_evidence() {
+        let requested = owner_checkpoint("owner-evidence", 4, 0, "root-a", 8);
+
+        let missing_directory = tempfile::tempdir().expect("missing-evidence source");
+        let missing_source = SampleSource::new_with_id(
+            SourceId::from_string("owner-evidence"),
+            missing_directory.path().to_path_buf(),
+        );
+        assert_eq!(
+            write_revision_bound_checkpoint(&missing_source, &requested, 4, "root-a"),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+        assert_eq!(owner_checkpoint_bytes(&missing_source), None);
+
+        let legacy_directory = tempfile::tempdir().expect("legacy-evidence source");
+        let legacy_source = SampleSource::new_with_id(
+            SourceId::from_string("owner-evidence"),
+            legacy_directory.path().to_path_buf(),
+        );
+        let legacy_bytes = r#"{"root_identity":"root-a","event_id":7}"#;
+        seed_owner_checkpoint(&legacy_source, legacy_bytes);
+        assert_eq!(
+            write_revision_bound_checkpoint(&legacy_source, &requested, 4, "root-a"),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+        assert_eq!(
+            owner_checkpoint_bytes(&legacy_source).as_deref(),
+            Some(legacy_bytes)
+        );
+
+        let unknown_directory = tempfile::tempdir().expect("unknown-evidence source");
+        let unknown_source = SampleSource::new_with_id(
+            SourceId::from_string("owner-evidence"),
+            unknown_directory.path().to_path_buf(),
+        );
+        let unknown_bytes = r#"{"root_identity":"root-a","event_id":7,"format_version":2,"source_id":"owner-evidence","lifecycle_generation":4,"source_revision":0,"cause":"targeted_replay","unexpected":"evidence"}"#;
+        seed_owner_checkpoint(&unknown_source, unknown_bytes);
+        assert_eq!(
+            write_revision_bound_checkpoint(&unknown_source, &requested, 4, "root-a"),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+        assert_eq!(
+            owner_checkpoint_bytes(&unknown_source).as_deref(),
+            Some(unknown_bytes)
+        );
+
+        let malformed_directory = tempfile::tempdir().expect("malformed-evidence source");
+        let malformed_source = SampleSource::new_with_id(
+            SourceId::from_string("owner-evidence"),
+            malformed_directory.path().to_path_buf(),
+        );
+        let malformed_bytes = "{not-json";
+        seed_owner_checkpoint(&malformed_source, malformed_bytes);
+        assert_eq!(
+            write_revision_bound_checkpoint(&malformed_source, &requested, 4, "root-a"),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+        assert_eq!(
+            owner_checkpoint_bytes(&malformed_source).as_deref(),
+            Some(malformed_bytes)
+        );
+    }
+
+    #[test]
+    fn startup_rejects_partial_v2_evidence_and_owner_preserves_bytes() {
+        let cases = [
+            (
+                "omitted",
+                r#"{"root_identity":"root-a","event_id":7,"source_id":"owner-v2-omitted","lifecycle_generation":4,"source_revision":0,"cause":"targeted_replay"}"#,
+            ),
+            (
+                "null",
+                r#"{"root_identity":"root-a","event_id":7,"format_version":null,"source_id":"owner-v2-null","lifecycle_generation":4,"source_revision":0,"cause":"targeted_replay"}"#,
+            ),
+            (
+                "wrong-version",
+                r#"{"root_identity":"root-a","event_id":7,"format_version":1,"source_id":"owner-v2-wrong-version","lifecycle_generation":4,"source_revision":0,"cause":"targeted_replay"}"#,
+            ),
+            (
+                "partial",
+                r#"{"root_identity":"root-a","event_id":7,"format_version":2,"source_id":"owner-v2-partial","lifecycle_generation":4,"source_revision":0}"#,
+            ),
+        ];
+
+        for (label, bytes) in cases {
+            let directory = tempfile::tempdir().expect("version-evidence source");
+            let source_id = format!("owner-v2-{label}");
+            let source = SampleSource::new_with_id(
+                SourceId::from_string(source_id.clone()),
+                directory.path().to_path_buf(),
+            );
+            let requested = owner_checkpoint(&source_id, 4, 0, "root-a", 8);
+
+            assert!(
+                parse_checkpoint(bytes).is_err(),
+                "accepted {label} evidence"
+            );
+            seed_owner_checkpoint(&source, &bytes);
+
+            assert!(load_checkpoint(&source).is_err(), "loaded {label} evidence");
+            assert_eq!(
+                recover_source(&source, true),
+                JournalRecovery::FullAudit {
+                    reason: "watcher_checkpoint_unavailable",
+                }
+            );
+            assert_eq!(
+                write_revision_bound_checkpoint(&source, &requested, 4, "root-a"),
+                CheckpointAdvanceOutcome::AuditRequired
+            );
+            assert_eq!(owner_checkpoint_bytes(&source).as_deref(), Some(bytes));
+        }
+    }
+
+    #[test]
+    fn owner_preserves_checkpoint_when_requested_revision_is_not_current() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("owner-revision"),
+            directory.path().to_path_buf(),
+        );
+        let current = owner_checkpoint("owner-revision", 4, 0, "root-a", 7);
+        let requested = owner_checkpoint("owner-revision", 4, 1, "root-a", 8);
+        let current_bytes =
+            serde_json::to_string(&SourceWatcherCheckpoint::from_revision_bound(&current))
+                .expect("serialize checkpoint seed");
+        seed_owner_checkpoint(&source, &current_bytes);
+
+        assert_eq!(
+            write_revision_bound_checkpoint(&source, &requested, 4, "root-a"),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+        assert_eq!(
+            owner_checkpoint_bytes(&source).as_deref(),
+            Some(current_bytes.as_str())
+        );
+    }
 
     #[test]
     fn committed_reconciliation_advances_but_never_regresses_the_cursor() {
@@ -497,14 +1391,8 @@ mod tests {
         let metadata = std::fs::metadata(&source.root).expect("source metadata");
         let root_identity = stable_filesystem_identity(&source.root, &metadata)
             .expect("stable source root identity");
-        store_checkpoint(
-            &source,
-            &SourceWatcherCheckpoint {
-                root_identity,
-                event_id: 7,
-            },
-        )
-        .expect("store checkpoint");
+        store_checkpoint(&source, &SourceWatcherCheckpoint::legacy(root_identity, 7))
+            .expect("store checkpoint");
 
         advance_after_reconciliation(std::slice::from_ref(&source), source.id.as_str(), 11);
         advance_after_reconciliation(std::slice::from_ref(&source), source.id.as_str(), 9);

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -647,6 +647,7 @@ fn source_completions_from_previous_readded_epoch_are_ignored() {
             source_id: source_id.clone(),
             lifecycle_generation: old_generation,
             changed_count: 1,
+            root_identity: None,
             journal_checkpoint_event_id: None,
             cancelled: true,
             result: Err(String::from("old epoch cancelled")),

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -89,6 +89,7 @@ mod state;
 #[cfg(test)]
 mod state_machine_observation;
 mod telemetry;
+mod watcher_checkpoint;
 
 use admission::install_worker_app_root;
 pub(in crate::native_app) use admission::{

--- a/src/native_app/source_processing/supervisor/admission.rs
+++ b/src/native_app/source_processing/supervisor/admission.rs
@@ -3,6 +3,7 @@ use super::{
     ExternalScanRegistration, Ordering, PathBuf, ProcessingLane, SampleSource, Shared,
     SourceDeltaQueueResult, resolve_registered_source_for_scan_locked,
 };
+use crate::native_app::sample_library::source_watcher::RevisionBoundCheckpoint;
 
 /// The typed handoff an external scan must make before releasing its source-processing budget.
 ///
@@ -212,6 +213,33 @@ pub(in crate::native_app) enum SourceScanAdmissionState {
 }
 
 impl SourceProcessingBudgetHandle {
+    /// Enqueue a typed watcher checkpoint for the source-processing coordinator.
+    ///
+    /// Submission is deliberately limited to the in-memory queue and coordinator wakeup. The
+    /// caller never opens SQLite, inspects filesystem metadata, or waits on the database writer
+    /// gate.
+    pub(in crate::native_app) fn submit_watcher_checkpoint(
+        &self,
+        request: RevisionBoundCheckpoint,
+    ) {
+        let mut control = self.shared.control();
+        control.pending_watcher_checkpoints.push_back(request);
+        control.notify("watcher_checkpoint_submitted");
+        drop(control);
+        self.shared.wake.notify_one();
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn pending_watcher_checkpoint_for_tests(
+        &self,
+    ) -> Option<RevisionBoundCheckpoint> {
+        self.shared
+            .control()
+            .pending_watcher_checkpoints
+            .front()
+            .cloned()
+    }
+
     #[cfg(test)]
     pub(in crate::native_app) fn lifecycle_generation(&self, source_id: &str) -> Option<u64> {
         self.shared

--- a/src/native_app/source_processing/supervisor/commands.rs
+++ b/src/native_app/source_processing/supervisor/commands.rs
@@ -23,6 +23,24 @@ impl SourceAuditLifecycleCause {
     }
 }
 
+pub(super) fn request_source_manifest_audit(
+    shared: &super::Shared,
+    source_id: &str,
+    reason: &'static str,
+) {
+    let mut control = shared.control();
+    if !control.source_is_active(source_id) {
+        return;
+    }
+    control
+        .force_manifest_audit_sources
+        .insert(source_id.to_string());
+    control.deferred_lifecycle_audit_sources.remove(source_id);
+    control.mark_source_dirty(source_id, reason);
+    drop(control);
+    shared.wake.notify_one();
+}
+
 impl SourceProcessingSupervisor {
     /// Admit a newly configured source before its first external scan starts.
     ///
@@ -88,17 +106,7 @@ impl SourceProcessingSupervisor {
         source_id: &str,
         reason: &'static str,
     ) {
-        let mut control = self.shared.control();
-        if !control.source_is_active(source_id) {
-            return;
-        }
-        control
-            .force_manifest_audit_sources
-            .insert(source_id.to_string());
-        control.deferred_lifecycle_audit_sources.remove(source_id);
-        control.mark_source_dirty(source_id, reason);
-        drop(control);
-        self.shared.wake.notify_one();
+        request_source_manifest_audit(self.shared.as_ref(), source_id, reason);
     }
 
     pub(in crate::native_app) fn wake_source(&self, source_id: &str, reason: &'static str) {

--- a/src/native_app/source_processing/supervisor/control.rs
+++ b/src/native_app/source_processing/supervisor/control.rs
@@ -3,6 +3,8 @@ use super::{
     PendingProjectionFence, PendingReadinessDelta, PendingReadinessDeltaMerge,
     PendingSourceRetirement, PriorityContext, SampleSource, source_storage_identity_matches,
 };
+use crate::native_app::sample_library::source_watcher::RevisionBoundCheckpoint;
+use std::collections::VecDeque;
 
 pub(super) struct ControlState {
     pub(super) sources: BTreeMap<String, SampleSource>,
@@ -18,6 +20,7 @@ pub(super) struct ControlState {
     pub(super) deferred_lifecycle_audit_sources: BTreeSet<String>,
     pub(super) pending_readiness_deltas: BTreeMap<String, PendingReadinessDelta>,
     pub(super) pending_projection_fences: BTreeMap<String, PendingProjectionFence>,
+    pub(super) pending_watcher_checkpoints: VecDeque<RevisionBoundCheckpoint>,
     pub(super) accepted_manifest_revisions: BTreeMap<String, AcceptedManifestRevision>,
     pub(super) awaiting_foreground_refresh_sources: BTreeSet<String>,
     pub(super) force_manifest_audit_sources: BTreeSet<String>,

--- a/src/native_app/source_processing/supervisor/coordinator.rs
+++ b/src/native_app/source_processing/supervisor/coordinator.rs
@@ -1,3 +1,4 @@
+use super::watcher_checkpoint::process_pending_watcher_checkpoints;
 use super::{
     Arc, BTreeMap, BTreeSet, CoordinatorExecutionState, Duration, ExecutionPool, FairScheduler,
     Instant, RuntimeCandidate, RuntimeTask, SAFETY_SWEEP_INTERVAL, Shared, SourceDiscoveryStats,
@@ -28,6 +29,10 @@ pub(super) fn run_coordinator(shared: Arc<Shared>) {
     #[cfg(test)]
     let mut synthetic_connections = BTreeMap::<String, rusqlite::Connection>::new();
     loop {
+        if shared.control().shutdown {
+            break;
+        }
+        process_pending_watcher_checkpoints(&shared);
         let (
             sources,
             dirty_sources,

--- a/src/native_app/source_processing/supervisor/state.rs
+++ b/src/native_app/source_processing/supervisor/state.rs
@@ -10,6 +10,7 @@ use super::{
     SampleSource, SourceAuditLifecycleCause, SourceHealthPublicationOutcome, SourceProcessingEvent,
     SourceProcessingEventSink, SourceProcessingHealthEvent, SupervisorTelemetry, sources_by_id,
 };
+use std::collections::VecDeque;
 
 #[derive(Clone)]
 pub(super) struct ExternalScanAdmission {
@@ -148,6 +149,7 @@ impl Shared {
                 deferred_lifecycle_audit_sources: BTreeSet::new(),
                 pending_readiness_deltas: BTreeMap::new(),
                 pending_projection_fences: BTreeMap::new(),
+                pending_watcher_checkpoints: VecDeque::new(),
                 accepted_manifest_revisions: BTreeMap::new(),
                 awaiting_foreground_refresh_sources: BTreeSet::new(),
                 force_manifest_audit_sources: BTreeSet::new(),

--- a/src/native_app/source_processing/supervisor/watcher_checkpoint.rs
+++ b/src/native_app/source_processing/supervisor/watcher_checkpoint.rs
@@ -1,0 +1,376 @@
+use super::{
+    Arc, DatabasePhase, SampleSource, Shared, commands::request_source_manifest_audit,
+    source_descriptors_match,
+};
+use crate::native_app::sample_library::source_watcher::{
+    CheckpointAdvanceOutcome, RevisionBoundCheckpoint, write_revision_bound_checkpoint,
+};
+use wavecrate_library::filesystem_identity::stable_filesystem_identity;
+
+/// Drain and execute checkpoint requests on the source-processing coordinator thread.
+pub(super) fn process_pending_watcher_checkpoints(shared: &Arc<Shared>) {
+    let requests = {
+        let mut control = shared.control();
+        std::mem::take(&mut control.pending_watcher_checkpoints)
+    };
+    for request in requests {
+        process_watcher_checkpoint(shared, request);
+    }
+}
+
+fn process_watcher_checkpoint(shared: &Arc<Shared>, request: RevisionBoundCheckpoint) {
+    let Some(source) = configured_source_for_request(shared, &request) else {
+        tracing::debug!(
+            source_id = request.source_id.as_str(),
+            lifecycle_generation = request.lifecycle_generation,
+            "Dropping stale watcher checkpoint request before source DB open"
+        );
+        return;
+    };
+    let outcome = {
+        let _writer = shared.database_writer.lock(DatabasePhase::Publish);
+        let Some(current_source) = configured_source_for_request(shared, &request) else {
+            tracing::debug!(
+                source_id = request.source_id.as_str(),
+                lifecycle_generation = request.lifecycle_generation,
+                "Dropping watcher checkpoint after source lifecycle changed"
+            );
+            return;
+        };
+        if !source_descriptors_match(&source, &current_source) {
+            tracing::debug!(
+                source_id = request.source_id.as_str(),
+                lifecycle_generation = request.lifecycle_generation,
+                "Dropping watcher checkpoint after source descriptor replacement"
+            );
+            return;
+        }
+        let Some(root_identity) = live_root_identity(&current_source) else {
+            tracing::debug!(
+                source_id = current_source.id.as_str(),
+                outcome = ?CheckpointAdvanceOutcome::Retryable,
+                "Could not capture live source root identity for watcher checkpoint"
+            );
+            request_source_manifest_audit(
+                shared.as_ref(),
+                request.source_id.as_str(),
+                "watcher_checkpoint_root_identity_unavailable",
+            );
+            return;
+        };
+        if root_identity != request.root_identity {
+            tracing::debug!(
+                source_id = current_source.id.as_str(),
+                requested_root_identity = request.root_identity.as_str(),
+                live_root_identity = root_identity.as_str(),
+                outcome = ?CheckpointAdvanceOutcome::AuditRequired,
+                "Dropping watcher checkpoint with a stale source root identity"
+            );
+            request_source_manifest_audit(
+                shared.as_ref(),
+                request.source_id.as_str(),
+                "watcher_checkpoint_root_identity_changed",
+            );
+            return;
+        }
+        write_revision_bound_checkpoint(
+            &current_source,
+            &request,
+            request.lifecycle_generation,
+            &root_identity,
+        )
+    };
+    match outcome {
+        CheckpointAdvanceOutcome::Applied => tracing::debug!(
+            source_id = request.source_id.as_str(),
+            event_id = request.event_id,
+            "Committed revision-bound watcher checkpoint"
+        ),
+        CheckpointAdvanceOutcome::AlreadyApplied | CheckpointAdvanceOutcome::Superseded => {
+            tracing::debug!(
+                source_id = request.source_id.as_str(),
+                event_id = request.event_id,
+                ?outcome,
+                "Watcher checkpoint did not advance"
+            )
+        }
+        CheckpointAdvanceOutcome::AuditRequired => {
+            tracing::debug!(
+                source_id = request.source_id.as_str(),
+                event_id = request.event_id,
+                ?outcome,
+                "Watcher checkpoint requires a source manifest audit"
+            );
+            request_source_manifest_audit(
+                shared.as_ref(),
+                request.source_id.as_str(),
+                "watcher_checkpoint_audit_required",
+            );
+        }
+        CheckpointAdvanceOutcome::Retryable => {
+            tracing::warn!(
+                source_id = request.source_id.as_str(),
+                event_id = request.event_id,
+                ?outcome,
+                "Watcher checkpoint publication is retryable"
+            );
+            request_source_manifest_audit(
+                shared.as_ref(),
+                request.source_id.as_str(),
+                "watcher_checkpoint_retryable",
+            );
+        }
+    }
+}
+
+fn configured_source_for_request(
+    shared: &Shared,
+    request: &RevisionBoundCheckpoint,
+) -> Option<SampleSource> {
+    let control = shared.control();
+    let source = control.sources.get(&request.source_id)?;
+    if !control.source_is_active(&request.source_id)
+        || control.source_lifecycle_generations.get(&request.source_id)
+            != Some(&request.lifecycle_generation)
+    {
+        return None;
+    }
+    Some(source.clone())
+}
+
+fn live_root_identity(source: &SampleSource) -> Option<String> {
+    std::fs::metadata(&source.root)
+        .ok()
+        .and_then(|metadata| stable_filesystem_identity(&source.root, &metadata))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native_app::sample_library::source_watcher::CheckpointCause;
+    use crate::native_app::source_processing::SourceProcessingSupervisor;
+    use std::{
+        sync::atomic::Ordering,
+        thread,
+        time::{Duration, Instant},
+    };
+    use wavecrate::sample_sources::SourceId;
+    use wavecrate_library::sample_sources::{SourceDatabase, db::META_SOURCE_WATCHER_CHECKPOINT};
+
+    fn source(root: &std::path::Path, id: &str) -> SampleSource {
+        SampleSource::new_with_id(SourceId::from_string(id), root.to_path_buf())
+    }
+
+    fn root_identity(source: &SampleSource) -> String {
+        live_root_identity(source).expect("source root identity")
+    }
+
+    fn request(
+        source: &SampleSource,
+        lifecycle_generation: u64,
+        root_identity: String,
+    ) -> RevisionBoundCheckpoint {
+        RevisionBoundCheckpoint {
+            source_id: source.id.as_str().to_string(),
+            lifecycle_generation,
+            source_revision: 0,
+            root_identity,
+            event_id: 8,
+            cause: CheckpointCause::TargetedReplay,
+        }
+    }
+
+    fn seed_checkpoint(source: &SampleSource, lifecycle_generation: u64, root_identity: &str) {
+        seed_checkpoint_value(
+            source,
+            &serde_json::json!({
+                "root_identity": root_identity,
+                "event_id": 7,
+                "format_version": 2,
+                "source_id": source.id.as_str(),
+                "lifecycle_generation": lifecycle_generation,
+                "source_revision": 0,
+                "cause": "targeted_replay"
+            })
+            .to_string(),
+        );
+    }
+
+    fn seed_checkpoint_value(source: &SampleSource, value: &str) {
+        let database = SourceDatabase::open_for_test_fixture_source_write(&source.root)
+            .expect("source database");
+        let mut batch = database.write_batch().expect("seed transaction");
+        batch
+            .set_metadata(META_SOURCE_WATCHER_CHECKPOINT, value)
+            .expect("seed watcher checkpoint");
+        batch
+            .commit_auxiliary_state()
+            .expect("seed watcher checkpoint");
+    }
+
+    fn checkpoint_bytes(source: &SampleSource) -> Option<String> {
+        SourceDatabase::open_for_test_fixture_source_write(&source.root)
+            .expect("source database")
+            .get_metadata(META_SOURCE_WATCHER_CHECKPOINT)
+            .expect("read watcher checkpoint")
+    }
+
+    #[test]
+    fn submission_only_enqueues_and_wakes_without_database_gate_or_open() {
+        let supervisor = SourceProcessingSupervisor::dormant();
+        let handle = supervisor.budget_handle();
+        let before = handle.shared.database_writer.snapshot();
+        let request = RevisionBoundCheckpoint {
+            source_id: "source-a".to_string(),
+            lifecycle_generation: 1,
+            source_revision: 0,
+            root_identity: "root-a".to_string(),
+            event_id: 1,
+            cause: CheckpointCause::TargetedReplay,
+        };
+
+        handle.submit_watcher_checkpoint(request);
+
+        assert_eq!(
+            handle.shared.database_writer.snapshot().publish.count,
+            before.publish.count
+        );
+        assert_eq!(handle.shared.control().pending_watcher_checkpoints.len(), 1);
+        assert!(handle.shared.control().wake_generation > 1);
+    }
+
+    #[test]
+    fn queue_commits_valid_checkpoint_and_preserves_root_mismatch_bytes() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = source(directory.path(), "source-a");
+        let shared = Arc::new(Shared::new(vec![source.clone()], None));
+        let generation = shared.control().source_lifecycle_generations["source-a"];
+        let root_identity = root_identity(&source);
+        seed_checkpoint(&source, generation, &root_identity);
+        let handle = super::super::SourceProcessingBudgetHandle {
+            shared: Arc::clone(&shared),
+        };
+        handle.submit_watcher_checkpoint(request(&source, generation, root_identity.clone()));
+        process_pending_watcher_checkpoints(&shared);
+        let committed = checkpoint_bytes(&source).expect("committed checkpoint");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&committed).expect("checkpoint JSON")["event_id"],
+            8
+        );
+
+        handle.submit_watcher_checkpoint(request(
+            &source,
+            generation,
+            "replacement-root".to_string(),
+        ));
+        process_pending_watcher_checkpoints(&shared);
+        assert_eq!(
+            checkpoint_bytes(&source).expect("checkpoint bytes"),
+            committed
+        );
+    }
+
+    #[test]
+    fn audit_required_checkpoint_requests_source_scoped_manifest_audit_and_preserves_bytes() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = source(directory.path(), "source-a");
+        let shared = Arc::new(Shared::new(vec![source.clone()], None));
+        let generation = shared.control().source_lifecycle_generations["source-a"];
+        let root_identity = root_identity(&source);
+        let unknown_bytes = format!(
+            r#"{{"root_identity":"{root_identity}","event_id":7,"format_version":2,"source_id":"source-a","lifecycle_generation":{generation},"source_revision":0,"cause":"targeted_replay","unexpected":"evidence"}}"#
+        );
+        seed_checkpoint_value(&source, &unknown_bytes);
+        {
+            let mut control = shared.control();
+            control.dirty_sources.clear();
+            control.safety_probe_sources.clear();
+            control.force_manifest_audit_sources.clear();
+        }
+        let handle = super::super::SourceProcessingBudgetHandle {
+            shared: Arc::clone(&shared),
+        };
+        handle.submit_watcher_checkpoint(request(&source, generation, root_identity));
+
+        process_pending_watcher_checkpoints(&shared);
+
+        let control = shared.control();
+        assert!(
+            control
+                .force_manifest_audit_sources
+                .contains(source.id.as_str())
+        );
+        assert!(control.dirty_sources.contains(source.id.as_str()));
+        drop(control);
+        assert_eq!(
+            checkpoint_bytes(&source).as_deref(),
+            Some(unknown_bytes.as_str())
+        );
+    }
+
+    #[test]
+    fn replaced_source_is_fenced_before_writable_open() {
+        let old_directory = tempfile::tempdir().expect("old source directory");
+        let new_directory = tempfile::tempdir().expect("new source directory");
+        let old_source = source(old_directory.path(), "source-a");
+        let replacement = source(new_directory.path(), "source-a");
+        let shared = Arc::new(Shared::new(vec![old_source.clone()], None));
+        let old_generation = shared.control().source_lifecycle_generations["source-a"];
+        let root_identity = root_identity(&old_source);
+        seed_checkpoint(&old_source, old_generation, &root_identity);
+        let old_bytes = checkpoint_bytes(&old_source).expect("old checkpoint bytes");
+        let handle = super::super::SourceProcessingBudgetHandle {
+            shared: Arc::clone(&shared),
+        };
+        handle.submit_watcher_checkpoint(request(&old_source, old_generation, root_identity));
+        let supervisor = SourceProcessingSupervisor {
+            shared: Arc::clone(&shared),
+            coordinator: None,
+            retirement_worker: None,
+        };
+        supervisor
+            .replace_sources(vec![replacement])
+            .expect("replace source");
+        process_pending_watcher_checkpoints(&shared);
+        assert_eq!(
+            checkpoint_bytes(&old_source).expect("old checkpoint bytes"),
+            old_bytes
+        );
+    }
+
+    #[test]
+    fn queued_checkpoint_waits_for_publish_gate_then_serializes() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = source(directory.path(), "source-a");
+        let shared = Arc::new(Shared::new(vec![source.clone()], None));
+        let generation = shared.control().source_lifecycle_generations["source-a"];
+        let root_identity = root_identity(&source);
+        seed_checkpoint(&source, generation, &root_identity);
+        let handle = super::super::SourceProcessingBudgetHandle {
+            shared: Arc::clone(&shared),
+        };
+        handle.submit_watcher_checkpoint(request(&source, generation, root_identity));
+        let held = shared.database_writer.lock(DatabasePhase::Publish);
+        let worker_shared = Arc::clone(&shared);
+        let worker = thread::spawn(move || process_pending_watcher_checkpoints(&worker_shared));
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while shared.database_writer.waiting_count() == 0 {
+            assert!(
+                Instant::now() < deadline,
+                "checkpoint did not wait on publish gate"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+        drop(held);
+        worker.join().expect("checkpoint worker");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(
+                &checkpoint_bytes(&source).expect("checkpoint bytes")
+            )
+            .expect("checkpoint JSON")["event_id"],
+            8
+        );
+        assert_eq!(shared.database_writer.snapshot().publish.count, 2);
+        assert!(!shared.cancel.load(Ordering::Acquire));
+    }
+}


### PR DESCRIPTION
## Goal

Align targeted closed-application watcher replay with the I/O target by making the source-processing owner the only production writer of the durable watcher checkpoint.

## Scope

- Carry worker-captured stable source-root identity, committed source revision, lifecycle generation, and replay event identity through the accepted filesystem-sync handoff.
- Queue revision-bound checkpoint requests without SQLite, filesystem, or writer-gate work on the watcher/UI submission path.
- Process requests on the source-processing coordinator behind the publish writer gate and commit auxiliary checkpoint metadata from one transaction-local source revision/checkpoint snapshot.
- Make checkpoint persistence fail closed for legacy, partial, unknown, malformed, duplicate, stale, and wrong-version evidence while preserving rejected bytes.
- Reject stale browser projection deltas before checkpoint acknowledgement.
- Convert empty replay paths to conservative full-audit recovery.
- Add regression coverage for lifecycle/root fencing, projection acceptance, transaction revision preservation, parser compatibility, duplicate evidence, and owner serialization.

## Non-goals

- The fallback `commit_audit_barrier` writer remains unchanged and is the next bounded owner-routing slice.
- No schema migration, source-manifest revision change, filesystem replacement primitive, FSEvents redesign, leases, readiness/artifact redesign, or broad writer-routing cleanup.
- No changes to PR #980 or the sibling Radiant checkout.
- No live-library or normal development-profile runtime mutation.

## Definition of Done

- Targeted replay has no production watcher-side checkpoint SQLite write.
- A checkpoint can advance only after exact accepted projection, source/lifecycle/root/revision/event fencing, and owner-gated transaction validation.
- Missing or ambiguous evidence preserves the old cursor and requests conservative source audit.
- Legacy two-field checkpoint bytes remain readable and serializable unchanged.
- Terra independently reviews the complete current diff with `APPROVE`.

## Validation

Using the clean isolated Radiant archive at `/private/tmp/wavecrate-journal-radiant.KTJELI`:

- `cargo test --locked --lib native_app::sample_library::source_watcher`: 52 passed.
- `cargo test --locked --lib native_app::sample_library::source_watcher::journal::tests`: 19 passed.
- `cargo test --locked --lib native_app::sample_library::folder_scan_actions::filesystem_refresh`: 17 passed.
- `cargo test --locked --lib native_app::sample_library::folder_browser::tests::source_scanning`: 21 passed.
- `cargo test --locked --lib native_app::source_processing::supervisor::watcher_checkpoint`: 5 passed.
- `cargo test --locked --lib native_app::shell::message_dispatch`: 32 passed.
- `cargo check --locked --all-targets`: passed.
- Targeted rustfmt check and `git diff --check`: passed.
- Terra fresh review: `APPROVE`, no blocking findings.

## Known limitations

Native FSEvents history replay and the deferred fallback barrier writer were not exercised against a live watcher in this pass. The fallback barrier still performs its legacy direct write and remains an explicit residual for the next slice.

## Next architecture task

Route completed fallback-audit barrier publication through the same source-processing owner, preserving audit barrier timing and exact committed revision/root/lifecycle evidence.

User approval is required before merge; explicit approval is recorded in the task context.