### PR TITLE
Route fallback audit barriers through source-processing owner

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -42,6 +42,7 @@ use crate::native_app::sample_library::folder_scan_actions::FolderScanMaintenanc
 use crate::native_app::sample_library::native_file_drop_actions::PreparedFileMutationChange;
 use crate::native_app::sample_library::native_file_open_actions::NativeAudioDocumentOpenValidation;
 use crate::native_app::sample_library::similarity_scores::SimilarityScoresResult;
+use crate::native_app::sample_library::source_watcher::RevisionBoundCheckpoint;
 use crate::native_app::sample_library::trash_actions::movement::TrashMoveOutcome;
 use crate::native_app::transaction_history::{HistoryFileIoCommand, HistoryFileIoResult};
 use crate::native_app::waveform::{PlaymarkLabelMessage, WaveformInteraction};
@@ -104,6 +105,9 @@ pub(in crate::native_app) enum GuiMessage {
         source_id: String,
         reason: &'static str,
     },
+    /// A completed fallback audit produced a barrier that must be persisted by the source
+    /// processing owner. This message carries only typed in-memory evidence; it performs no I/O.
+    SourceWatcherCheckpointReady(RevisionBoundCheckpoint),
     SourceFilesystemSyncFinished(SourceFilesystemSyncResult),
     CommittedFileMutationRequested(FileMutationWork),
     CommittedFileMutationFinished(FileMutationOutcome),
@@ -119,6 +123,7 @@ pub(in crate::native_app) enum GuiMessage {
     SourceManifestAuditFinished {
         source_id: String,
         lifecycle_generation: u64,
+        source_revision: Option<u64>,
         complete: bool,
     },
     NormalizationProgress(NormalizationProgress),

--- a/src/native_app/app/source_processing_events.rs
+++ b/src/native_app/app/source_processing_events.rs
@@ -57,10 +57,12 @@ fn map_event(event: SourceProcessingEvent) -> GuiMessage {
         },
         SourceProcessingEvent::ManifestAuditFinished {
             lifecycle,
+            source_revision,
             complete,
         } => GuiMessage::SourceManifestAuditFinished {
             source_id: lifecycle.source_id,
             lifecycle_generation: lifecycle.generation,
+            source_revision,
             complete,
         },
         SourceProcessingEvent::Completed => {
@@ -450,6 +452,20 @@ mod tests {
                 source_id,
                 lifecycle_generation: 23,
                 ..
+            } if source_id == "source"
+        ));
+
+        assert!(matches!(
+            map_event(SourceProcessingEvent::ManifestAuditFinished {
+                lifecycle: SourceProcessingLifecycle::new("source", 23),
+                source_revision: Some(41),
+                complete: true,
+            }),
+            GuiMessage::SourceManifestAuditFinished {
+                source_id,
+                lifecycle_generation: 23,
+                source_revision: Some(41),
+                complete: true,
             } if source_id == "source"
         ));
     }

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -288,12 +288,16 @@ impl GuiSourceWatcherHandle {
     pub(in crate::native_app) fn finish_journal_barrier_audit(
         &self,
         source_id: String,
+        lifecycle_generation: u64,
+        source_revision: Option<u64>,
         complete: bool,
     ) {
         let _ = self
             .command_tx
             .send(GuiSourceWatchCommand::FinishJournalBarrierAudit {
                 source_id,
+                lifecycle_generation,
+                source_revision,
                 complete,
             });
     }
@@ -369,6 +373,8 @@ enum GuiSourceWatchCommand {
     },
     FinishJournalBarrierAudit {
         source_id: String,
+        lifecycle_generation: u64,
+        source_revision: Option<u64>,
         complete: bool,
     },
     #[cfg(test)]
@@ -402,7 +408,7 @@ fn run_source_watcher(
     let mut restart_delay = WATCHER_RESTART_MIN;
     let mut next_root_refresh = Instant::now();
     let mut root_identity_recovery = RootIdentityRecovery::default();
-    let mut audit_barriers = HashMap::new();
+    let mut audit_barriers = HashMap::<String, journal::AuditBarrier>::new();
     let mut deferred_audit_barrier_sources = HashSet::new();
     let mut watcher_has_been_ready = false;
     let mut watcher_unavailable_reported = false;
@@ -438,11 +444,27 @@ fn run_source_watcher(
             }
             Ok(GuiSourceWatchCommand::FinishJournalBarrierAudit {
                 source_id,
+                lifecycle_generation,
+                source_revision,
                 complete,
             }) => {
                 if complete {
-                    if let Some(barrier) = audit_barriers.remove(&source_id) {
-                        journal::commit_audit_barrier(&state.sources, &source_id, barrier);
+                    if let Some(source_revision) = source_revision {
+                        if let Some(barrier) = audit_barriers.remove(&source_id) {
+                            let checkpoint = barrier.into_revision_bound(
+                                source_id.clone(),
+                                lifecycle_generation,
+                                source_revision,
+                            );
+                            let _ = message_tx
+                                .send(GuiMessage::SourceWatcherCheckpointReady(checkpoint));
+                        }
+                    } else {
+                        tracing::warn!(
+                            source_id,
+                            lifecycle_generation,
+                            "Completed source audit did not provide a committed revision for its watcher barrier"
+                        );
                     }
                 }
                 if deferred_audit_barrier_sources.remove(&source_id) {

--- a/src/native_app/sample_library/source_watcher/journal.rs
+++ b/src/native_app/sample_library/source_watcher/journal.rs
@@ -252,6 +252,25 @@ fn decide_checkpoint_advance(
         return CheckpointAdvanceOutcome::AuditRequired;
     }
 
+    if requested.cause == CheckpointCause::CompletedFallbackAudit {
+        let Some(current) = current else {
+            // A completed source-wide audit is the authority that establishes the first
+            // revision-bound cursor after a missing checkpoint.
+            return CheckpointAdvanceOutcome::Applied;
+        };
+        if current.revision_bound().is_none() {
+            if current.root_identity != requested.root_identity
+                || current.event_id > requested.event_id
+            {
+                return CheckpointAdvanceOutcome::AuditRequired;
+            }
+            // A valid legacy cursor can be upgraded by the completed audit. Malformed and
+            // unknown bytes never reach this branch because read_checkpoint_from_batch fails
+            // closed before the pure decision.
+            return CheckpointAdvanceOutcome::Applied;
+        }
+    }
+
     let Some(current) = current else {
         return CheckpointAdvanceOutcome::AuditRequired;
     };
@@ -282,8 +301,9 @@ fn decide_checkpoint_advance(
 /// The caller owns lifecycle and live-root validation. This helper only performs bounded source
 /// database work: it opens the configured source database, holds one immediate write batch while
 /// reading the current revision and checkpoint evidence, and commits the new checkpoint only when
-/// the pure advance decision is `Applied`. Legacy, malformed, missing, stale, and superseded
-/// evidence is never rewritten.
+/// the pure advance decision is `Applied`. Malformed, unknown, stale, and superseded evidence is
+/// never rewritten; a completed authoritative source audit may upgrade a valid missing or legacy
+/// cursor to the revision-bound format.
 pub(in crate::native_app) fn write_revision_bound_checkpoint(
     source: &SampleSource,
     requested: &RevisionBoundCheckpoint,
@@ -393,6 +413,24 @@ fn read_checkpoint_from_batch(
 
 #[derive(Clone, Debug)]
 pub(super) struct AuditBarrier(SourceWatcherCheckpoint);
+
+impl AuditBarrier {
+    pub(super) fn into_revision_bound(
+        self,
+        source_id: String,
+        lifecycle_generation: u64,
+        source_revision: u64,
+    ) -> RevisionBoundCheckpoint {
+        RevisionBoundCheckpoint {
+            source_id,
+            lifecycle_generation,
+            source_revision,
+            root_identity: self.0.root_identity,
+            event_id: self.0.event_id,
+            cause: CheckpointCause::CompletedFallbackAudit,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) enum JournalRecovery {
@@ -558,36 +596,6 @@ pub(super) fn capture_audit_barrier(
     )))
 }
 
-/// Commit a pre-audit barrier only after a complete audit. Never sample the current global ID at
-/// completion: a live event after the barrier may not yet have committed and must stay replayable.
-pub(super) fn commit_audit_barrier(
-    sources: &[SampleSource],
-    source_id: &str,
-    barrier: AuditBarrier,
-) {
-    let Some(source) = sources
-        .iter()
-        .find(|source| source.id.as_str() == source_id)
-    else {
-        return;
-    };
-    let Some(root_identity) = std::fs::metadata(&source.root)
-        .ok()
-        .and_then(|metadata| stable_filesystem_identity(&source.root, &metadata))
-    else {
-        return;
-    };
-    if root_identity != barrier.0.root_identity {
-        return;
-    }
-    if let Err(error) = store_checkpoint(source, &barrier.0) {
-        tracing::warn!(
-            source_id,
-            "Could not establish post-audit source watcher checkpoint: {error}"
-        );
-    }
-}
-
 fn source_database(source: &SampleSource) -> Result<SourceDatabase, String> {
     let database_root = source.database_root().map_err(|error| error.to_string())?;
     SourceDatabase::open_for_background_job_with_database_root(&source.root, database_root)
@@ -603,6 +611,7 @@ fn load_checkpoint(source: &SampleSource) -> Result<Option<SourceWatcherCheckpoi
         .transpose()
 }
 
+#[cfg(test)]
 fn store_checkpoint(
     source: &SampleSource,
     checkpoint: &SourceWatcherCheckpoint,
@@ -1195,6 +1204,47 @@ mod tests {
         );
     }
 
+    #[test]
+    fn completed_fallback_audit_establishes_or_upgrades_a_valid_cursor() {
+        let mut requested = revision_bound_checkpoint(8);
+        requested.cause = CheckpointCause::CompletedFallbackAudit;
+        let legacy = SourceWatcherCheckpoint::legacy("root-a".to_string(), 7);
+
+        assert_eq!(decide(None, &requested), CheckpointAdvanceOutcome::Applied);
+        assert_eq!(
+            decide(Some(&legacy), &requested),
+            CheckpointAdvanceOutcome::Applied
+        );
+
+        let mut current = requested.clone();
+        current.event_id = 8;
+        assert_eq!(
+            decide(
+                Some(&SourceWatcherCheckpoint::from_revision_bound(&current)),
+                &requested,
+            ),
+            CheckpointAdvanceOutcome::AlreadyApplied
+        );
+    }
+
+    #[test]
+    fn completed_fallback_audit_never_regresses_or_crosses_root_identity() {
+        let mut requested = revision_bound_checkpoint(8);
+        requested.cause = CheckpointCause::CompletedFallbackAudit;
+
+        let mut newer = SourceWatcherCheckpoint::legacy("root-a".to_string(), 9);
+        assert_eq!(
+            decide(Some(&newer), &requested),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        newer = SourceWatcherCheckpoint::legacy("root-b".to_string(), 7);
+        assert_eq!(
+            decide(Some(&newer), &requested),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+    }
+
     fn owner_checkpoint(
         source_id: &str,
         lifecycle_generation: u64,
@@ -1468,6 +1518,39 @@ mod tests {
             owner_checkpoint_bytes(&malformed_source).as_deref(),
             Some(malformed_bytes)
         );
+    }
+
+    #[test]
+    fn owner_commits_completed_audit_barrier_over_missing_or_legacy_cursor() {
+        for (source_id, initial_bytes) in [
+            ("owner-audit-missing", None),
+            (
+                "owner-audit-legacy",
+                Some(r#"{"root_identity":"root-a","event_id":7}"#),
+            ),
+        ] {
+            let directory = tempfile::tempdir().expect("audit-barrier source");
+            let source = SampleSource::new_with_id(
+                SourceId::from_string(source_id),
+                directory.path().to_path_buf(),
+            );
+            if let Some(bytes) = initial_bytes {
+                seed_owner_checkpoint(&source, bytes);
+            }
+            let mut requested = owner_checkpoint(source_id, 4, 0, "root-a", 8);
+            requested.cause = CheckpointCause::CompletedFallbackAudit;
+
+            assert_eq!(
+                write_revision_bound_checkpoint(&source, &requested, 4, "root-a"),
+                CheckpointAdvanceOutcome::Applied
+            );
+            assert_eq!(
+                owner_checkpoint_bytes(&source)
+                    .and_then(|value| parse_checkpoint(&value).ok())
+                    .and_then(|checkpoint| checkpoint.revision_bound()),
+                Some(requested)
+            );
+        }
     }
 
     #[test]

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -93,6 +93,7 @@ impl NativeAppState {
             | GuiMessage::SourceFilesystemChanged { .. }
             | GuiMessage::SourceWatcherReady { .. }
             | GuiMessage::SourceWatcherJournalGap { .. }
+            | GuiMessage::SourceWatcherCheckpointReady(_)
             | GuiMessage::SourceFilesystemSyncFinished(_)
             | GuiMessage::SourceManifestAuditCommitted { .. }
             | GuiMessage::SourceManifestAuditFinished { .. }
@@ -394,6 +395,7 @@ fn gui_message_profile_label(message: &GuiMessage) -> &'static str {
         GuiMessage::SourceFilesystemChanged { .. } => "SourceFilesystemChanged",
         GuiMessage::SourceWatcherReady { .. } => "SourceWatcherReady",
         GuiMessage::SourceWatcherJournalGap { .. } => "SourceWatcherJournalGap",
+        GuiMessage::SourceWatcherCheckpointReady(_) => "SourceWatcherCheckpointReady",
         GuiMessage::SourceFilesystemSyncFinished(_) => "SourceFilesystemSyncFinished",
         GuiMessage::SourceManifestAuditCommitted { .. } => "SourceManifestAuditCommitted",
         GuiMessage::SourceManifestAuditFinished { .. } => "SourceManifestAuditFinished",

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -163,6 +163,23 @@ impl NativeAppState {
                     .source_processing
                     .request_source_manifest_audit(&source_id, reason);
             }
+            GuiMessage::SourceWatcherCheckpointReady(request) => {
+                if self
+                    .library
+                    .folder_browser
+                    .source_exists(&request.source_id)
+                    && self
+                        .background
+                        .source_lifecycle_generations
+                        .get(&request.source_id)
+                        == Some(&request.lifecycle_generation)
+                {
+                    self.background
+                        .source_processing
+                        .budget_handle()
+                        .submit_watcher_checkpoint(request);
+                }
+            }
             GuiMessage::SourceFilesystemSyncFinished(result) => {
                 self.finish_source_filesystem_sync(result, context);
             }
@@ -183,6 +200,7 @@ impl NativeAppState {
             GuiMessage::SourceManifestAuditFinished {
                 source_id,
                 lifecycle_generation,
+                source_revision,
                 complete,
             } => {
                 let source_is_current = self.library.folder_browser.source_exists(&source_id)
@@ -190,7 +208,12 @@ impl NativeAppState {
                         == Some(&lifecycle_generation);
                 if source_is_current {
                     if let Some(watcher) = self.library.source_watcher.as_ref() {
-                        watcher.finish_journal_barrier_audit(source_id, complete);
+                        watcher.finish_journal_barrier_audit(
+                            source_id,
+                            lifecycle_generation,
+                            source_revision,
+                            complete,
+                        );
                     }
                 }
             }

--- a/src/native_app/source_processing/events.rs
+++ b/src/native_app/source_processing/events.rs
@@ -117,6 +117,7 @@ pub(in crate::native_app) enum SourceProcessingEvent {
     },
     ManifestAuditFinished {
         lifecycle: SourceProcessingLifecycle,
+        source_revision: Option<u64>,
         complete: bool,
     },
     Completed,

--- a/src/native_app/source_processing/supervisor/execution.rs
+++ b/src/native_app/source_processing/supervisor/execution.rs
@@ -128,6 +128,7 @@ pub(super) fn execute_candidate_with_presentation(
                                 candidate.source.id.as_str(),
                                 lifecycle_generation,
                             ),
+                            source_revision: None,
                             complete: false,
                         });
                         return Err(error.to_string());
@@ -181,6 +182,7 @@ pub(super) fn execute_candidate_with_presentation(
                 && crate::native_app::source_processing::manifest_delta_requires_browser_refresh(
                     &outcome.committed_delta,
                 );
+            let committed_source_revision = outcome.committed_delta.revision;
             let audit_published = publish_event(SourceProcessingEvent::ManifestAuditCommitted {
                 lifecycle: SourceProcessingLifecycle::new(
                     candidate.source.id.as_str(),
@@ -196,6 +198,7 @@ pub(super) fn execute_candidate_with_presentation(
                     candidate.source.id.as_str(),
                     lifecycle_generation,
                 ),
+                source_revision: Some(committed_source_revision),
                 complete: manifest_complete,
             });
             if let Some(error) = content_incomplete_error {


### PR DESCRIPTION
## Goal

Align completed fallback-audit watcher recovery with the I/O target by routing the captured pre-audit barrier through the source-processing owner and carrying the audit's exact committed source revision.

## Scope

- Carry committed source revision evidence through manifest-audit completion, including complete audits with an empty delta.
- Convert the watcher-owned pre-audit barrier into a typed `CompletedFallbackAudit` checkpoint request without writing SQLite on the watcher thread.
- Submit that request through the existing source-processing queue and publish writer gate.
- Allow only a complete authoritative fallback audit to establish or promote a missing or valid legacy checkpoint to explicit V2.
- Preserve the historical V2 revision/lifecycle transition semantics already merged in PR #1019; malformed, unknown, duplicate, partial, or wrong-version evidence remains fail-closed and byte-preserved.
- Add regression coverage for fallback baseline/promotion, exact audit revision mapping, idempotency, and owner serialization.

## Non-goals

- No full `WatcherContinuityProof` backend-stream or contiguous-replay implementation.
- No raw Finder event normalizer, `ExactEntry`/`Subtree`/`SourceAudit` redesign, or live Finder acceptance.
- No universal journal rollout, cross-database saga, cross-process source leases, readiness/artifact redesign, WAL watermark, or recovery-reserve redesign.
- No changes to open PR #980 or the sibling Radiant checkout.

## Definition of Done

- No production watcher-loop call writes `META_SOURCE_WATCHER_CHECKPOINT`; the source-processing owner is the only production writer.
- A complete fallback audit carries its exact pre-audit event ID and committed source revision through lifecycle/root fences to the owner.
- Missing/legacy promotion occurs only after complete fallback audit; ambiguous evidence remains byte-preserved and requests audit.
- Existing V2 equal-event and historical-baseline behavior from PR #1019 remains unchanged.
- Terra independently reviews the complete current diff with `APPROVE`.

## Validation

Based on canonical main `bb32b4c9a` (including merged PR #1019), using the clean isolated Radiant archive at `/private/tmp/wavecrate-journal-radiant.KTJELI`:

- `cargo test --locked --lib native_app::sample_library::source_watcher`: 61 passed.
- `cargo test --locked --lib native_app::source_processing::supervisor::watcher_checkpoint`: 5 passed.
- `cargo test --locked --lib native_app::app::source_processing_events`: 6 passed.
- `cargo test --locked --lib native_app::shell::message_dispatch`: 32 passed.
- `cargo test --locked --lib native_app::sample_library::folder_scan_actions::filesystem_refresh`: 17 passed.
- `cargo check --locked --all-targets`: passed.
- Targeted rustfmt check and `git diff --check`: passed.
- Terra fresh review of the rebased diff: `APPROVE`, no blocking findings.

## Known limitations

Live macOS FSEvents/Finder delivery and runtime shutdown/restart timing were not exercised in this pass. Full watcher continuity proof, Finder normalization, and cross-process writer ownership remain later slices.

## Next architecture task

Define and persist the complete watcher continuity tuple—source/root, backend stream identity, watcher generation, replayable cursor, and contiguous replay coverage—before broader Finder normalization work.

User approval is required before merge; explicit approval is recorded in the task context.