### PR TITLE
Route completed fallback audit barriers through the source owner

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -104,6 +104,15 @@ pub(in crate::native_app) enum GuiMessage {
         source_id: String,
         reason: &'static str,
     },
+    /// Pre-audit watcher evidence ready for revision-bound publication by the source-processing
+    /// owner. The watcher only retains and forwards these in-memory values.
+    SourceWatcherAuditBarrierReady {
+        source_id: String,
+        lifecycle_generation: u64,
+        source_revision: u64,
+        root_identity: String,
+        event_id: u64,
+    },
     SourceFilesystemSyncFinished(SourceFilesystemSyncResult),
     CommittedFileMutationRequested(FileMutationWork),
     CommittedFileMutationFinished(FileMutationOutcome),
@@ -119,6 +128,7 @@ pub(in crate::native_app) enum GuiMessage {
     SourceManifestAuditFinished {
         source_id: String,
         lifecycle_generation: u64,
+        source_revision: Option<u64>,
         complete: bool,
     },
     NormalizationProgress(NormalizationProgress),

--- a/src/native_app/app/source_processing_events.rs
+++ b/src/native_app/app/source_processing_events.rs
@@ -57,10 +57,12 @@ fn map_event(event: SourceProcessingEvent) -> GuiMessage {
         },
         SourceProcessingEvent::ManifestAuditFinished {
             lifecycle,
+            source_revision,
             complete,
         } => GuiMessage::SourceManifestAuditFinished {
             source_id: lifecycle.source_id,
             lifecycle_generation: lifecycle.generation,
+            source_revision,
             complete,
         },
         SourceProcessingEvent::Completed => {
@@ -451,6 +453,38 @@ mod tests {
                 lifecycle_generation: 23,
                 ..
             } if source_id == "source"
+        ));
+    }
+
+    #[test]
+    fn maps_manifest_audit_completion_revision_and_incomplete_state() {
+        let complete = map_event(SourceProcessingEvent::ManifestAuditFinished {
+            lifecycle: SourceProcessingLifecycle::new("source", 31),
+            source_revision: Some(47),
+            complete: true,
+        });
+        assert!(matches!(
+            complete,
+            GuiMessage::SourceManifestAuditFinished {
+                source_id,
+                lifecycle_generation: 31,
+                source_revision: Some(47),
+                complete: true,
+            } if source_id == "source"
+        ));
+
+        let incomplete = map_event(SourceProcessingEvent::ManifestAuditFinished {
+            lifecycle: SourceProcessingLifecycle::new("source", 31),
+            source_revision: None,
+            complete: false,
+        });
+        assert!(matches!(
+            incomplete,
+            GuiMessage::SourceManifestAuditFinished {
+                source_revision: None,
+                complete: false,
+                ..
+            }
         ));
     }
 }

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -27,7 +27,7 @@ fn doubled_duration(current: Duration, maximum: Duration) -> Duration {
 pub(in crate::native_app) use handle::GuiSourceWatcherHandle;
 pub(in crate::native_app) use journal::{
     CheckpointAdvanceOutcome, CheckpointCause, RevisionBoundCheckpoint,
-    write_revision_bound_checkpoint,
+    write_completed_fallback_audit_checkpoint, write_revision_bound_checkpoint,
 };
 
 #[cfg(test)]

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -288,12 +288,16 @@ impl GuiSourceWatcherHandle {
     pub(in crate::native_app) fn finish_journal_barrier_audit(
         &self,
         source_id: String,
+        lifecycle_generation: u64,
+        source_revision: Option<u64>,
         complete: bool,
     ) {
         let _ = self
             .command_tx
             .send(GuiSourceWatchCommand::FinishJournalBarrierAudit {
                 source_id,
+                lifecycle_generation,
+                source_revision,
                 complete,
             });
     }
@@ -369,6 +373,8 @@ enum GuiSourceWatchCommand {
     },
     FinishJournalBarrierAudit {
         source_id: String,
+        lifecycle_generation: u64,
+        source_revision: Option<u64>,
         complete: bool,
     },
     #[cfg(test)]
@@ -438,27 +444,20 @@ fn run_source_watcher(
             }
             Ok(GuiSourceWatchCommand::FinishJournalBarrierAudit {
                 source_id,
+                lifecycle_generation,
+                source_revision,
                 complete,
             }) => {
-                if complete {
-                    if let Some(barrier) = audit_barriers.remove(&source_id) {
-                        journal::commit_audit_barrier(&state.sources, &source_id, barrier);
-                    }
-                }
-                if deferred_audit_barrier_sources.remove(&source_id) {
-                    // The unavailable-watcher audit predates watcher recovery. Capture only now,
-                    // after that audit has completed, then schedule a fresh audit tied to this
-                    // barrier instead of letting the older completion advance a new cursor.
-                    if let Some(barrier) =
-                        journal::capture_audit_barrier(&state.sources, &source_id)
-                    {
-                        audit_barriers.insert(source_id.clone(), barrier);
-                        let _ = message_tx.send(GuiMessage::SourceWatcherJournalGap {
-                            source_id,
-                            reason: "watcher_recovered_after_unavailable",
-                        });
-                    }
-                }
+                finish_audit_barrier_completion(
+                    &state.sources,
+                    &message_tx,
+                    &mut audit_barriers,
+                    &mut deferred_audit_barrier_sources,
+                    source_id,
+                    lifecycle_generation,
+                    source_revision,
+                    complete,
+                );
             }
             #[cfg(test)]
             Ok(GuiSourceWatchCommand::ReconcileAllSources) => {
@@ -854,6 +853,50 @@ fn run_source_watcher(
         lifecycle_tx
             .send(lifecycle)
             .expect("source watcher lifecycle service must outlive its coordinator");
+    }
+}
+
+fn finish_audit_barrier_completion(
+    sources: &[SampleSource],
+    message_tx: &Sender<GuiMessage>,
+    audit_barriers: &mut HashMap<String, journal::AuditBarrier>,
+    deferred_audit_barrier_sources: &mut HashSet<String>,
+    source_id: String,
+    lifecycle_generation: u64,
+    source_revision: Option<u64>,
+    complete: bool,
+) {
+    if !complete {
+        return;
+    }
+    let Some(source_revision) = source_revision else {
+        return;
+    };
+
+    if let Some(barrier) = audit_barriers.remove(&source_id) {
+        let (root_identity, event_id) = barrier.into_evidence();
+        let _ = message_tx.send(GuiMessage::SourceWatcherAuditBarrierReady {
+            source_id: source_id.clone(),
+            lifecycle_generation,
+            source_revision,
+            root_identity,
+            event_id,
+        });
+    }
+
+    if deferred_audit_barrier_sources.contains(&source_id) {
+        // The unavailable-watcher audit predates watcher recovery. Capture only now, after that
+        // audit has completed, then schedule a fresh audit tied to this barrier instead of
+        // letting the older completion advance a new cursor. Keep the deferred marker when root
+        // identity capture is unavailable so a later valid completion can retry conservatively.
+        if let Some(barrier) = journal::capture_audit_barrier(sources, &source_id) {
+            deferred_audit_barrier_sources.remove(&source_id);
+            audit_barriers.insert(source_id.clone(), barrier);
+            let _ = message_tx.send(GuiMessage::SourceWatcherJournalGap {
+                source_id,
+                reason: "watcher_recovered_after_unavailable",
+            });
+        }
     }
 }
 
@@ -1536,5 +1579,133 @@ mod lifecycle_tests {
         for release in teardown_releases {
             release.send(()).expect("release teardown worker");
         }
+    }
+
+    #[test]
+    fn complete_barrier_completion_forwards_captured_evidence_and_removes_memory() {
+        let directory = tempfile::tempdir().expect("barrier source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("barrier-complete"),
+            directory.path().to_path_buf(),
+        );
+        let barrier = journal::capture_audit_barrier(&[source.clone()], source.id.as_str())
+            .expect("capture audit barrier");
+        let (root_identity, event_id) = {
+            let (root_identity, event_id) = barrier.evidence();
+            (root_identity.to_owned(), event_id)
+        };
+        let source_id = source.id.as_str().to_owned();
+        let (message_tx, message_rx) = std::sync::mpsc::channel();
+        let mut audit_barriers = HashMap::from([(source_id.clone(), barrier)]);
+        let mut deferred_sources = HashSet::new();
+
+        finish_audit_barrier_completion(
+            &[source],
+            &message_tx,
+            &mut audit_barriers,
+            &mut deferred_sources,
+            source_id.clone(),
+            23,
+            Some(41),
+            true,
+        );
+
+        assert!(!audit_barriers.contains_key(&source_id));
+        assert!(matches!(
+            message_rx.recv().expect("barrier handoff"),
+            GuiMessage::SourceWatcherAuditBarrierReady {
+                source_id: message_source_id,
+                lifecycle_generation: 23,
+                source_revision: 41,
+                root_identity: message_root_identity,
+                event_id: message_event_id,
+            } if message_source_id == source_id
+                && message_root_identity == root_identity
+                && message_event_id == event_id
+        ));
+    }
+
+    #[test]
+    fn incomplete_barrier_completion_preserves_the_barrier_without_a_handoff() {
+        let directory = tempfile::tempdir().expect("barrier source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("barrier-incomplete"),
+            directory.path().to_path_buf(),
+        );
+        let source_id = source.id.as_str().to_owned();
+        let barrier = journal::capture_audit_barrier(&[source.clone()], source.id.as_str())
+            .expect("capture audit barrier");
+        let (message_tx, message_rx) = std::sync::mpsc::channel();
+        let mut audit_barriers = HashMap::from([(source_id.clone(), barrier)]);
+        let mut deferred_sources = HashSet::new();
+
+        finish_audit_barrier_completion(
+            &[source],
+            &message_tx,
+            &mut audit_barriers,
+            &mut deferred_sources,
+            source_id.clone(),
+            23,
+            None,
+            false,
+        );
+
+        assert!(audit_barriers.contains_key(&source_id));
+        assert!(matches!(
+            message_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn deferred_unavailable_watcher_does_not_recapture_after_incomplete_completion() {
+        let directory = tempfile::tempdir().expect("barrier source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("barrier-deferred"),
+            directory.path().to_path_buf(),
+        );
+        let source_id = source.id.as_str().to_owned();
+        let (message_tx, message_rx) = std::sync::mpsc::channel();
+        let mut audit_barriers = HashMap::new();
+        let mut deferred_sources = HashSet::from([source_id.clone()]);
+
+        finish_audit_barrier_completion(
+            &[source.clone()],
+            &message_tx,
+            &mut audit_barriers,
+            &mut deferred_sources,
+            source_id.clone(),
+            23,
+            None,
+            false,
+        );
+
+        assert!(deferred_sources.contains(&source_id));
+        assert!(audit_barriers.is_empty());
+        assert!(matches!(
+            message_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+
+        finish_audit_barrier_completion(
+            &[source],
+            &message_tx,
+            &mut audit_barriers,
+            &mut deferred_sources,
+            source_id.clone(),
+            23,
+            Some(42),
+            true,
+        );
+
+        assert!(!deferred_sources.contains(&source_id));
+        assert!(audit_barriers.contains_key(&source_id));
+        assert!(matches!(
+            message_rx.recv().expect("replacement audit gap"),
+            GuiMessage::SourceWatcherJournalGap {
+                source_id: message_source_id,
+                reason: "watcher_recovered_after_unavailable",
+            } if message_source_id == source_id
+        ));
     }
 }

--- a/src/native_app/sample_library/source_watcher/journal.rs
+++ b/src/native_app/sample_library/source_watcher/journal.rs
@@ -244,11 +244,13 @@ fn decide_checkpoint_advance(
     current_source_revision: u64,
     current_root_identity: &str,
 ) -> CheckpointAdvanceOutcome {
-    if requested.source_id != expected_source_id
-        || requested.lifecycle_generation != current_lifecycle_generation
-        || requested.source_revision != current_source_revision
-        || requested.root_identity != current_root_identity
-    {
+    if !request_matches_current_fences(
+        requested,
+        expected_source_id,
+        current_lifecycle_generation,
+        current_source_revision,
+        current_root_identity,
+    ) {
         return CheckpointAdvanceOutcome::AuditRequired;
     }
 
@@ -277,6 +279,67 @@ fn decide_checkpoint_advance(
     CheckpointAdvanceOutcome::Superseded
 }
 
+fn request_matches_current_fences(
+    requested: &RevisionBoundCheckpoint,
+    expected_source_id: &str,
+    current_lifecycle_generation: u64,
+    current_source_revision: u64,
+    current_root_identity: &str,
+) -> bool {
+    requested.source_id == expected_source_id
+        && requested.lifecycle_generation == current_lifecycle_generation
+        && requested.source_revision == current_source_revision
+        && requested.root_identity == current_root_identity
+}
+
+fn decide_completed_fallback_audit(
+    current: Option<&SourceWatcherCheckpoint>,
+    requested: &RevisionBoundCheckpoint,
+    expected_source_id: &str,
+    current_lifecycle_generation: u64,
+    current_source_revision: u64,
+    current_root_identity: &str,
+) -> CheckpointAdvanceOutcome {
+    if requested.cause != CheckpointCause::CompletedFallbackAudit
+        || !request_matches_current_fences(
+            requested,
+            expected_source_id,
+            current_lifecycle_generation,
+            current_source_revision,
+            current_root_identity,
+        )
+    {
+        return CheckpointAdvanceOutcome::AuditRequired;
+    }
+
+    let Some(current) = current else {
+        // A completed source-wide audit is the authority that establishes the first
+        // revision-bound cursor after a missing checkpoint.
+        return CheckpointAdvanceOutcome::Applied;
+    };
+    if current.revision_bound().is_none() {
+        if current.root_identity != requested.root_identity || current.event_id > requested.event_id
+        {
+            return CheckpointAdvanceOutcome::AuditRequired;
+        }
+        // A valid legacy cursor can be upgraded by the completed audit. Malformed and unknown
+        // bytes never reach this branch because read_checkpoint_from_batch fails closed before
+        // the pure decision.
+        return CheckpointAdvanceOutcome::Applied;
+    }
+
+    // Existing v2 evidence keeps the ordinary monotonic decision, including idempotence and
+    // historical-baseline advancement.
+    decide_checkpoint_advance(
+        Some(current),
+        requested,
+        expected_source_id,
+        current_lifecycle_generation,
+        current_source_revision,
+        current_root_identity,
+    )
+}
+
 /// Apply a revision-bound watcher checkpoint from the source-processing owner.
 ///
 /// The caller owns lifecycle and live-root validation. This helper only performs bounded source
@@ -289,6 +352,44 @@ pub(in crate::native_app) fn write_revision_bound_checkpoint(
     requested: &RevisionBoundCheckpoint,
     current_lifecycle_generation: u64,
     current_root_identity: &str,
+) -> CheckpointAdvanceOutcome {
+    write_checkpoint(
+        source,
+        requested,
+        current_lifecycle_generation,
+        current_root_identity,
+        false,
+    )
+}
+
+/// Publish a completed fallback-audit barrier from the source-processing owner.
+///
+/// Unlike targeted replay, a complete source-wide audit is authoritative when no checkpoint
+/// exists and may upgrade a valid legacy cursor. The owner must have already checked the active
+/// lifecycle, source descriptor, live root identity, and completed-audit revision fences before
+/// calling this helper. Malformed, unknown, partial, stale, and regressed evidence remains
+/// audit-required and is never rewritten.
+pub(in crate::native_app) fn write_completed_fallback_audit_checkpoint(
+    source: &SampleSource,
+    requested: &RevisionBoundCheckpoint,
+    current_lifecycle_generation: u64,
+    current_root_identity: &str,
+) -> CheckpointAdvanceOutcome {
+    write_checkpoint(
+        source,
+        requested,
+        current_lifecycle_generation,
+        current_root_identity,
+        true,
+    )
+}
+
+fn write_checkpoint(
+    source: &SampleSource,
+    requested: &RevisionBoundCheckpoint,
+    current_lifecycle_generation: u64,
+    current_root_identity: &str,
+    allow_completed_fallback: bool,
 ) -> CheckpointAdvanceOutcome {
     let database = match source_database(source) {
         Ok(database) => database,
@@ -327,14 +428,25 @@ pub(in crate::native_app) fn write_revision_bound_checkpoint(
         Ok(current) => current,
         Err(outcome) => return outcome,
     };
-    let outcome = decide_checkpoint_advance(
-        current.as_ref(),
-        requested,
-        source.id.as_str(),
-        current_lifecycle_generation,
-        current_source_revision,
-        current_root_identity,
-    );
+    let outcome = if allow_completed_fallback {
+        decide_completed_fallback_audit(
+            current.as_ref(),
+            requested,
+            source.id.as_str(),
+            current_lifecycle_generation,
+            current_source_revision,
+            current_root_identity,
+        )
+    } else {
+        decide_checkpoint_advance(
+            current.as_ref(),
+            requested,
+            source.id.as_str(),
+            current_lifecycle_generation,
+            current_source_revision,
+            current_root_identity,
+        )
+    };
     if outcome != CheckpointAdvanceOutcome::Applied {
         return outcome;
     }
@@ -393,6 +505,17 @@ fn read_checkpoint_from_batch(
 
 #[derive(Clone, Debug)]
 pub(super) struct AuditBarrier(SourceWatcherCheckpoint);
+
+impl AuditBarrier {
+    pub(super) fn into_evidence(self) -> (String, u64) {
+        (self.0.root_identity, self.0.event_id)
+    }
+
+    #[cfg(test)]
+    pub(super) fn evidence(&self) -> (&str, u64) {
+        (&self.0.root_identity, self.0.event_id)
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) enum JournalRecovery {
@@ -558,36 +681,6 @@ pub(super) fn capture_audit_barrier(
     )))
 }
 
-/// Commit a pre-audit barrier only after a complete audit. Never sample the current global ID at
-/// completion: a live event after the barrier may not yet have committed and must stay replayable.
-pub(super) fn commit_audit_barrier(
-    sources: &[SampleSource],
-    source_id: &str,
-    barrier: AuditBarrier,
-) {
-    let Some(source) = sources
-        .iter()
-        .find(|source| source.id.as_str() == source_id)
-    else {
-        return;
-    };
-    let Some(root_identity) = std::fs::metadata(&source.root)
-        .ok()
-        .and_then(|metadata| stable_filesystem_identity(&source.root, &metadata))
-    else {
-        return;
-    };
-    if root_identity != barrier.0.root_identity {
-        return;
-    }
-    if let Err(error) = store_checkpoint(source, &barrier.0) {
-        tracing::warn!(
-            source_id,
-            "Could not establish post-audit source watcher checkpoint: {error}"
-        );
-    }
-}
-
 fn source_database(source: &SampleSource) -> Result<SourceDatabase, String> {
     let database_root = source.database_root().map_err(|error| error.to_string())?;
     SourceDatabase::open_for_background_job_with_database_root(&source.root, database_root)
@@ -603,6 +696,7 @@ fn load_checkpoint(source: &SampleSource) -> Result<Option<SourceWatcherCheckpoi
         .transpose()
 }
 
+#[cfg(test)]
 fn store_checkpoint(
     source: &SampleSource,
     checkpoint: &SourceWatcherCheckpoint,
@@ -882,6 +976,13 @@ mod tests {
         requested: &RevisionBoundCheckpoint,
     ) -> CheckpointAdvanceOutcome {
         decide_checkpoint_advance(current, requested, "source-a", 4, 9, "root-a")
+    }
+
+    fn decide_fallback(
+        current: Option<&SourceWatcherCheckpoint>,
+        requested: &RevisionBoundCheckpoint,
+    ) -> CheckpointAdvanceOutcome {
+        decide_completed_fallback_audit(current, requested, "source-a", 4, 9, "root-a")
     }
 
     #[cfg(target_os = "macos")]
@@ -1195,6 +1296,47 @@ mod tests {
         );
     }
 
+    #[test]
+    fn completed_fallback_audit_establishes_or_upgrades_only_matching_cursor_evidence() {
+        let mut requested = revision_bound_checkpoint(8);
+        requested.cause = CheckpointCause::CompletedFallbackAudit;
+        let legacy = SourceWatcherCheckpoint::legacy("root-a".to_string(), 7);
+
+        assert_eq!(
+            decide_fallback(None, &requested),
+            CheckpointAdvanceOutcome::Applied
+        );
+        assert_eq!(
+            decide_fallback(Some(&legacy), &requested),
+            CheckpointAdvanceOutcome::Applied
+        );
+
+        let newer = SourceWatcherCheckpoint::legacy("root-a".to_string(), 9);
+        assert_eq!(
+            decide_fallback(Some(&newer), &requested),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let wrong_root = SourceWatcherCheckpoint::legacy("root-b".to_string(), 7);
+        assert_eq!(
+            decide_fallback(Some(&wrong_root), &requested),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let targeted_request = revision_bound_checkpoint(8);
+        assert_eq!(
+            decide_fallback(None, &targeted_request),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let mut incomplete_request = requested;
+        incomplete_request.source_revision = 8;
+        assert_eq!(
+            decide_fallback(None, &incomplete_request),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+    }
+
     fn owner_checkpoint(
         source_id: &str,
         lifecycle_generation: u64,
@@ -1468,6 +1610,86 @@ mod tests {
             owner_checkpoint_bytes(&malformed_source).as_deref(),
             Some(malformed_bytes)
         );
+    }
+
+    #[test]
+    fn owner_commits_completed_fallback_audit_over_missing_or_legacy_checkpoint() {
+        for (source_id, initial_bytes) in [
+            ("owner-audit-missing", None),
+            (
+                "owner-audit-legacy",
+                Some(r#"{"root_identity":"{root_identity}","event_id":7}"#),
+            ),
+        ] {
+            let directory = tempfile::tempdir().expect("audit-barrier source");
+            let source = SampleSource::new_with_id(
+                SourceId::from_string(source_id),
+                directory.path().to_path_buf(),
+            );
+            let root_identity = stable_filesystem_identity(
+                &source.root,
+                &std::fs::metadata(&source.root).expect("source metadata"),
+            )
+            .expect("source root identity");
+            if let Some(template) = initial_bytes {
+                seed_owner_checkpoint(
+                    &source,
+                    &template.replace("{root_identity}", &root_identity),
+                );
+            }
+            let mut requested = owner_checkpoint(source_id, 4, 0, &root_identity, 8);
+            requested.cause = CheckpointCause::CompletedFallbackAudit;
+
+            assert_eq!(
+                write_completed_fallback_audit_checkpoint(&source, &requested, 4, &root_identity),
+                CheckpointAdvanceOutcome::Applied
+            );
+            assert_eq!(
+                owner_checkpoint_bytes(&source)
+                    .and_then(|value| parse_checkpoint(&value).ok())
+                    .and_then(|checkpoint| checkpoint.revision_bound()),
+                Some(requested)
+            );
+        }
+    }
+
+    #[test]
+    fn completed_fallback_audit_preserves_malformed_unknown_and_partial_bytes() {
+        let directory = tempfile::tempdir().expect("invalid fallback source");
+        let source_id = "owner-invalid-fallback";
+        let source = SampleSource::new_with_id(
+            SourceId::from_string(source_id),
+            directory.path().to_path_buf(),
+        );
+        let root_identity = stable_filesystem_identity(
+            &source.root,
+            &std::fs::metadata(&source.root).expect("source metadata"),
+        )
+        .expect("source root identity");
+        let cases = [
+            String::from("{not-json"),
+            format!(
+                r#"{{"root_identity":"{root_identity}","event_id":7,"format_version":2,"source_id":"{source_id}","lifecycle_generation":4,"source_revision":0,"cause":"completed_fallback_audit","unexpected":"evidence"}}"#
+            ),
+            format!(
+                r#"{{"root_identity":"{root_identity}","event_id":7,"format_version":2,"source_id":"{source_id}","lifecycle_generation":4,"source_revision":0}}"#
+            ),
+        ];
+
+        for bytes in cases {
+            seed_owner_checkpoint(&source, &bytes);
+            let mut requested = owner_checkpoint(source_id, 4, 0, &root_identity, 8);
+            requested.cause = CheckpointCause::CompletedFallbackAudit;
+
+            assert_eq!(
+                write_completed_fallback_audit_checkpoint(&source, &requested, 4, &root_identity,),
+                CheckpointAdvanceOutcome::AuditRequired
+            );
+            assert_eq!(
+                owner_checkpoint_bytes(&source).as_deref(),
+                Some(bytes.as_str())
+            );
+        }
     }
 
     #[test]

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -93,6 +93,7 @@ impl NativeAppState {
             | GuiMessage::SourceFilesystemChanged { .. }
             | GuiMessage::SourceWatcherReady { .. }
             | GuiMessage::SourceWatcherJournalGap { .. }
+            | GuiMessage::SourceWatcherAuditBarrierReady { .. }
             | GuiMessage::SourceFilesystemSyncFinished(_)
             | GuiMessage::SourceManifestAuditCommitted { .. }
             | GuiMessage::SourceManifestAuditFinished { .. }
@@ -394,6 +395,7 @@ fn gui_message_profile_label(message: &GuiMessage) -> &'static str {
         GuiMessage::SourceFilesystemChanged { .. } => "SourceFilesystemChanged",
         GuiMessage::SourceWatcherReady { .. } => "SourceWatcherReady",
         GuiMessage::SourceWatcherJournalGap { .. } => "SourceWatcherJournalGap",
+        GuiMessage::SourceWatcherAuditBarrierReady { .. } => "SourceWatcherAuditBarrierReady",
         GuiMessage::SourceFilesystemSyncFinished(_) => "SourceFilesystemSyncFinished",
         GuiMessage::SourceManifestAuditCommitted { .. } => "SourceManifestAuditCommitted",
         GuiMessage::SourceManifestAuditFinished { .. } => "SourceManifestAuditFinished",

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -2,6 +2,7 @@ use radiant::prelude as ui;
 
 use crate::native_app::app::{ClipboardHandoffTarget, GuiMessage, NativeAppState};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
+use crate::native_app::sample_library::source_watcher::{CheckpointCause, RevisionBoundCheckpoint};
 
 impl NativeAppState {
     pub(super) fn apply_browser_dispatch(
@@ -163,6 +164,25 @@ impl NativeAppState {
                     .source_processing
                     .request_source_manifest_audit(&source_id, reason);
             }
+            GuiMessage::SourceWatcherAuditBarrierReady {
+                source_id,
+                lifecycle_generation,
+                source_revision,
+                root_identity,
+                event_id,
+            } => {
+                self.background
+                    .source_processing
+                    .budget_handle()
+                    .submit_watcher_checkpoint(RevisionBoundCheckpoint {
+                        source_id,
+                        lifecycle_generation,
+                        source_revision,
+                        root_identity,
+                        event_id,
+                        cause: CheckpointCause::CompletedFallbackAudit,
+                    });
+            }
             GuiMessage::SourceFilesystemSyncFinished(result) => {
                 self.finish_source_filesystem_sync(result, context);
             }
@@ -183,6 +203,7 @@ impl NativeAppState {
             GuiMessage::SourceManifestAuditFinished {
                 source_id,
                 lifecycle_generation,
+                source_revision,
                 complete,
             } => {
                 let source_is_current = self.library.folder_browser.source_exists(&source_id)
@@ -190,7 +211,12 @@ impl NativeAppState {
                         == Some(&lifecycle_generation);
                 if source_is_current {
                     if let Some(watcher) = self.library.source_watcher.as_ref() {
-                        watcher.finish_journal_barrier_audit(source_id, complete);
+                        watcher.finish_journal_barrier_audit(
+                            source_id,
+                            lifecycle_generation,
+                            source_revision,
+                            complete,
+                        );
                     }
                 }
             }

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -682,6 +682,46 @@ fn source_completions_from_previous_readded_epoch_are_ignored() {
 }
 
 #[test]
+fn complete_fallback_barrier_handoff_enqueues_a_revision_bound_owner_checkpoint() {
+    let directory = tempfile::tempdir().expect("fallback barrier source");
+    let mut state = NativeAppStateFixture::default().build();
+    let source_id = state
+        .library
+        .folder_browser
+        .defer_add_source_path(directory.path().to_path_buf(), false)
+        .expect("source registered");
+    state.sync_source_watcher();
+    let lifecycle_generation = state.background.source_lifecycle_generations[&source_id];
+
+    state.apply_message(
+        GuiMessage::SourceWatcherAuditBarrierReady {
+            source_id: source_id.clone(),
+            lifecycle_generation,
+            source_revision: 37,
+            root_identity: String::from("captured-root"),
+            event_id: 91,
+        },
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    let request = state
+        .background
+        .source_processing
+        .budget_handle()
+        .pending_watcher_checkpoint_for_tests()
+        .expect("owner checkpoint request");
+    assert_eq!(request.source_id, source_id);
+    assert_eq!(request.lifecycle_generation, lifecycle_generation);
+    assert_eq!(request.source_revision, 37);
+    assert_eq!(request.root_identity, "captured-root");
+    assert_eq!(request.event_id, 91);
+    assert_eq!(
+        request.cause,
+        crate::native_app::sample_library::source_watcher::CheckpointCause::CompletedFallbackAudit
+    );
+}
+
+#[test]
 fn incomplete_current_manifest_audit_delivery_requests_full_reconciliation() {
     let directory = tempfile::tempdir().expect("completion source");
     let mut state = NativeAppStateFixture::default().build();

--- a/src/native_app/source_processing/events.rs
+++ b/src/native_app/source_processing/events.rs
@@ -117,6 +117,7 @@ pub(in crate::native_app) enum SourceProcessingEvent {
     },
     ManifestAuditFinished {
         lifecycle: SourceProcessingLifecycle,
+        source_revision: Option<u64>,
         complete: bool,
     },
     Completed,

--- a/src/native_app/source_processing/supervisor/execution.rs
+++ b/src/native_app/source_processing/supervisor/execution.rs
@@ -128,6 +128,7 @@ pub(super) fn execute_candidate_with_presentation(
                                 candidate.source.id.as_str(),
                                 lifecycle_generation,
                             ),
+                            source_revision: None,
                             complete: false,
                         });
                         return Err(error.to_string());
@@ -177,6 +178,7 @@ pub(super) fn execute_candidate_with_presentation(
                     .collect::<Vec<_>>(),
                 "Periodic source manifest audit committed"
             );
+            let source_revision = manifest_complete.then_some(outcome.committed_delta.revision);
             let browser_refresh_required = !outcome.committed_delta.is_empty()
                 && crate::native_app::source_processing::manifest_delta_requires_browser_refresh(
                     &outcome.committed_delta,
@@ -196,6 +198,7 @@ pub(super) fn execute_candidate_with_presentation(
                     candidate.source.id.as_str(),
                     lifecycle_generation,
                 ),
+                source_revision,
                 complete: manifest_complete,
             });
             if let Some(error) = content_incomplete_error {

--- a/src/native_app/source_processing/supervisor/tests/progress_lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/tests/progress_lifecycle.rs
@@ -451,9 +451,23 @@ fn periodic_manifest_audit_wakes_browser_projection_after_committed_repair() {
             _ => None,
         })
         .expect("audit should publish a browser projection wake");
+    let (finished_lifecycle, finished_revision, finished_complete) = events
+        .iter()
+        .find_map(|event| match event {
+            SourceProcessingEvent::ManifestAuditFinished {
+                lifecycle,
+                source_revision,
+                complete,
+            } => Some((lifecycle, *source_revision, *complete)),
+            _ => None,
+        })
+        .expect("audit should publish its completion revision");
 
     assert_eq!(lifecycle.source_id, "audit-browser-wake");
     assert_eq!(lifecycle.generation, 0);
+    assert_eq!(finished_lifecycle, lifecycle);
+    assert_eq!(finished_revision, Some(committed_delta.revision));
+    assert!(finished_complete);
     assert_eq!(progress.lifecycle.source_id, "audit-browser-wake");
     assert_eq!(progress.completed, 1);
     assert_eq!(progress.total, 1);

--- a/src/native_app/source_processing/supervisor/watcher_checkpoint.rs
+++ b/src/native_app/source_processing/supervisor/watcher_checkpoint.rs
@@ -3,7 +3,8 @@ use super::{
     source_descriptors_match,
 };
 use crate::native_app::sample_library::source_watcher::{
-    CheckpointAdvanceOutcome, RevisionBoundCheckpoint, write_revision_bound_checkpoint,
+    CheckpointAdvanceOutcome, CheckpointCause, RevisionBoundCheckpoint,
+    write_completed_fallback_audit_checkpoint, write_revision_bound_checkpoint,
 };
 use wavecrate_library::filesystem_identity::stable_filesystem_identity;
 
@@ -73,12 +74,20 @@ fn process_watcher_checkpoint(shared: &Arc<Shared>, request: RevisionBoundCheckp
             );
             return;
         }
-        write_revision_bound_checkpoint(
-            &current_source,
-            &request,
-            request.lifecycle_generation,
-            &root_identity,
-        )
+        match request.cause {
+            CheckpointCause::CompletedFallbackAudit => write_completed_fallback_audit_checkpoint(
+                &current_source,
+                &request,
+                request.lifecycle_generation,
+                &root_identity,
+            ),
+            CheckpointCause::TargetedReplay => write_revision_bound_checkpoint(
+                &current_source,
+                &request,
+                request.lifecycle_generation,
+                &root_identity,
+            ),
+        }
     };
     match outcome {
         CheckpointAdvanceOutcome::Applied => tracing::debug!(
@@ -268,6 +277,42 @@ mod tests {
             checkpoint_bytes(&source).expect("checkpoint bytes"),
             committed
         );
+    }
+
+    #[test]
+    fn queued_completed_fallback_audit_upgrades_legacy_checkpoint() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = source(directory.path(), "source-a");
+        let shared = Arc::new(Shared::new(vec![source.clone()], None));
+        let generation = shared.control().source_lifecycle_generations["source-a"];
+        let root_identity = root_identity(&source);
+        seed_checkpoint_value(
+            &source,
+            &serde_json::json!({
+                "root_identity": root_identity,
+                "event_id": 7,
+            })
+            .to_string(),
+        );
+
+        let mut request = request(&source, generation, root_identity);
+        request.cause = CheckpointCause::CompletedFallbackAudit;
+        let handle = super::super::SourceProcessingBudgetHandle {
+            shared: Arc::clone(&shared),
+        };
+        handle.submit_watcher_checkpoint(request);
+        process_pending_watcher_checkpoints(&shared);
+
+        let checkpoint = serde_json::from_str::<serde_json::Value>(
+            &checkpoint_bytes(&source).expect("upgraded checkpoint bytes"),
+        )
+        .expect("checkpoint JSON");
+        assert_eq!(checkpoint["format_version"], 2);
+        assert_eq!(checkpoint["source_id"], source.id.as_str());
+        assert_eq!(checkpoint["lifecycle_generation"], generation);
+        assert_eq!(checkpoint["source_revision"], 0);
+        assert_eq!(checkpoint["event_id"], 8);
+        assert_eq!(checkpoint["cause"], "completed_fallback_audit");
     }
 
     #[test]


### PR DESCRIPTION
## Goal

Route completed fallback-audit watcher barriers through the source-processing owner so the watcher/UI never writes durable checkpoint metadata directly.

## Scope and non-goals

- Carry the committed source revision and completion state through source-processing events, GUI dispatch, and the watcher command boundary.
- Forward captured barrier evidence to the source-processing owner as a revision-bound `CompletedFallbackAudit` request.
- Allow that owner-only path to establish or upgrade missing/valid legacy checkpoint evidence after a complete audit.
- Preserve strict targeted-replay behavior and fail closed for malformed, unknown, partial, stale, regressed, or mismatched evidence.
- Preserve deferred unavailable-watcher recovery semantics.
- Non-goals: fallback `commit_audit_barrier` behavior beyond this owner handoff, broader filesystem publication, or unrelated source-processing refactors.

## Definition of Done

- Production watcher and GUI paths contain no direct checkpoint database write for completed fallback barriers.
- Incomplete audits retain the in-memory barrier and do not publish it.
- Complete barriers carry exact lifecycle/source-revision/root/event evidence to the source-processing owner.
- Missing and valid legacy evidence can be upgraded only by the completed-fallback owner path; targeted replay and invalid evidence remain conservative.
- Focused tests cover the handoff, incomplete/deferred behavior, fallback upgrade, and evidence preservation.

## Validation

- `cargo test --locked --lib native_app::sample_library::source_watcher` — 64 passed
- `cargo test --locked --lib native_app::source_processing::supervisor::watcher_checkpoint` — 5 passed
- `cargo test --locked --lib native_app::shell::message_dispatch` — 33 passed
- `cargo test --locked --lib periodic_manifest_audit_wakes_browser_projection_after_committed_repair` — 1 passed
- `cargo check --locked --all-targets` — passed
- rustfmt changed-file check — passed
- `git diff --check` — passed

## Known limitations

Native real-app acceptance of watcher recovery and fallback auditing remains a user-owned acceptance step. The broader cross-filesystem publication and fallback audit-barrier architecture remains outside this bounded slice.

Terra independent review and explicit user approval are required before merge.