### PR TITLE
Prove watcher replay continuity before checkpoint advancement

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -42,7 +42,9 @@ use crate::native_app::sample_library::folder_scan_actions::FolderScanMaintenanc
 use crate::native_app::sample_library::native_file_drop_actions::PreparedFileMutationChange;
 use crate::native_app::sample_library::native_file_open_actions::NativeAudioDocumentOpenValidation;
 use crate::native_app::sample_library::similarity_scores::SimilarityScoresResult;
-use crate::native_app::sample_library::source_watcher::RevisionBoundCheckpoint;
+use crate::native_app::sample_library::source_watcher::{
+    RevisionBoundCheckpoint, WatcherContinuityProof,
+};
 use crate::native_app::sample_library::trash_actions::movement::TrashMoveOutcome;
 use crate::native_app::transaction_history::{HistoryFileIoCommand, HistoryFileIoResult};
 use crate::native_app::waveform::{PlaymarkLabelMessage, WaveformInteraction};
@@ -90,6 +92,9 @@ pub(in crate::native_app) enum GuiMessage {
         source_root_available: bool,
         /// A durable FSEvents cursor that may advance only after this targeted sync commits.
         journal_checkpoint_event_id: Option<u64>,
+        /// Backend evidence for a targeted replay cursor. Legacy cursor-only messages remain
+        /// accepted but cannot advance the durable checkpoint owner.
+        watcher_continuity_proof: Option<WatcherContinuityProof>,
     },
     /// The initial watcher stream is live and journal recovery has completed. This boundary
     /// admits the durable lifecycle gate without assuming that every source needs a traversal.
@@ -464,6 +469,7 @@ pub(in crate::native_app) struct SourceFilesystemSyncResult {
     /// Stable root identity captured by the background sync worker before filesystem/DB work.
     pub(in crate::native_app) root_identity: Option<String>,
     pub(in crate::native_app) journal_checkpoint_event_id: Option<u64>,
+    pub(in crate::native_app) watcher_continuity_proof: Option<WatcherContinuityProof>,
     pub(in crate::native_app) cancelled: bool,
     pub(in crate::native_app) result: Result<SourceFilesystemSyncSuccess, String>,
 }

--- a/src/native_app/app/state/library.rs
+++ b/src/native_app/app/state/library.rs
@@ -6,7 +6,9 @@ use crate::native_app::sample_library::folder_browser::{
     scan::{FolderScanDiscoveryBatch, FolderScanRequest, FolderScanResult},
 };
 use crate::native_app::sample_library::similarity_artifacts::SimilarityArtifactRefreshState;
-use crate::native_app::sample_library::source_watcher::GuiSourceWatcherHandle;
+use crate::native_app::sample_library::source_watcher::{
+    GuiSourceWatcherHandle, WatcherContinuityProof,
+};
 
 use super::{
     PendingSourceRefresh, SourceFilesystemChangePlan, SourceRefreshCause, SourceRefreshRequest,
@@ -156,6 +158,8 @@ impl LibraryAppState {
         overflowed: bool,
         source_root_available: bool,
         lifecycle_generation: Option<u64>,
+        journal_checkpoint_event_id: Option<u64>,
+        watcher_continuity_proof: Option<WatcherContinuityProof>,
     ) -> SourceFilesystemChangePlan {
         self.source_scan.plan_filesystem_change_for_generation(
             &mut self.folder_browser,
@@ -164,6 +168,8 @@ impl LibraryAppState {
             overflowed,
             source_root_available,
             lifecycle_generation,
+            journal_checkpoint_event_id,
+            watcher_continuity_proof,
         )
     }
 

--- a/src/native_app/app/state/source_refresh.rs
+++ b/src/native_app/app/state/source_refresh.rs
@@ -1,5 +1,7 @@
 use std::{collections::BTreeSet, path::PathBuf, time::Instant};
 
+use crate::native_app::sample_library::source_watcher::WatcherContinuityProof;
+
 pub(super) struct QueuedSourceRefresh {
     pub(super) source_id: String,
     pub(super) selection_requested: bool,
@@ -13,6 +15,9 @@ pub(super) struct QueuedTargetedSourceSync {
     pub(super) source_id: String,
     pub(super) paths: BTreeSet<PathBuf>,
     pub(super) lifecycle_generation: Option<u64>,
+    pub(super) journal_checkpoint_event_id: Option<u64>,
+    pub(super) watcher_continuity_proof: Option<WatcherContinuityProof>,
+    pub(super) audit_required: bool,
     pub(super) enqueued_at: Instant,
 }
 
@@ -82,5 +87,8 @@ pub(in crate::native_app) struct PendingTargetedSourceSync {
     pub(in crate::native_app) source_id: String,
     pub(in crate::native_app) paths: Vec<PathBuf>,
     pub(in crate::native_app) lifecycle_generation: Option<u64>,
+    pub(in crate::native_app) journal_checkpoint_event_id: Option<u64>,
+    pub(in crate::native_app) watcher_continuity_proof: Option<WatcherContinuityProof>,
+    pub(in crate::native_app) audit_required: bool,
     pub(in crate::native_app) enqueued_at: Instant,
 }

--- a/src/native_app/app/state/source_refresh.rs
+++ b/src/native_app/app/state/source_refresh.rs
@@ -17,6 +17,7 @@ pub(super) struct QueuedTargetedSourceSync {
     pub(super) lifecycle_generation: Option<u64>,
     pub(super) journal_checkpoint_event_id: Option<u64>,
     pub(super) watcher_continuity_proof: Option<WatcherContinuityProof>,
+    pub(super) proofless_evidence_seen: bool,
     pub(super) audit_required: bool,
     pub(super) enqueued_at: Instant,
 }
@@ -89,6 +90,7 @@ pub(in crate::native_app) struct PendingTargetedSourceSync {
     pub(in crate::native_app) lifecycle_generation: Option<u64>,
     pub(in crate::native_app) journal_checkpoint_event_id: Option<u64>,
     pub(in crate::native_app) watcher_continuity_proof: Option<WatcherContinuityProof>,
+    pub(in crate::native_app) proofless_evidence_seen: bool,
     pub(in crate::native_app) audit_required: bool,
     pub(in crate::native_app) enqueued_at: Instant,
 }

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -16,6 +16,7 @@ use crate::native_app::sample_library::folder_browser::{
         FolderScanResult,
     },
 };
+use crate::native_app::sample_library::source_watcher::{WatcherBackend, WatcherContinuityProof};
 use wavecrate::sample_sources::scanner::CommittedSourceDelta;
 
 #[cfg(test)]
@@ -378,6 +379,8 @@ impl SourceScanWorkflow {
         overflowed: bool,
         source_root_available: bool,
         lifecycle_generation: Option<u64>,
+        journal_checkpoint_event_id: Option<u64>,
+        watcher_continuity_proof: Option<WatcherContinuityProof>,
     ) -> SourceFilesystemChangePlan {
         let Some(source_missing) =
             browser.apply_observed_source_availability(&source_id, source_root_available)
@@ -401,6 +404,15 @@ impl SourceScanWorkflow {
                 .iter()
                 .any(|pending| pending.source_id == source_id);
             if full_scan_pending_for_source && !full_scan_active_for_source {
+                if journal_checkpoint_event_id.is_some() || watcher_continuity_proof.is_some() {
+                    self.queue_targeted_sync(
+                        source_id.clone(),
+                        paths,
+                        lifecycle_generation,
+                        journal_checkpoint_event_id,
+                        watcher_continuity_proof,
+                    );
+                }
                 tracing::info!(
                     target: "wavecrate::source_processing",
                     source_id,
@@ -411,7 +423,13 @@ impl SourceScanWorkflow {
                 return SourceFilesystemChangePlan::DeferredAlreadyRunning { source_id };
             }
             if full_scan_active_for_source || self.active_targeted_syncs.contains_key(&source_id) {
-                self.queue_targeted_sync(source_id.clone(), paths, lifecycle_generation);
+                self.queue_targeted_sync(
+                    source_id.clone(),
+                    paths,
+                    lifecycle_generation,
+                    journal_checkpoint_event_id,
+                    watcher_continuity_proof,
+                );
                 return SourceFilesystemChangePlan::DeferredAlreadyRunning { source_id };
             }
             return SourceFilesystemChangePlan::SyncPaths {
@@ -482,6 +500,9 @@ impl SourceScanWorkflow {
             source_id: pending.source_id,
             paths: pending.paths.into_iter().collect(),
             lifecycle_generation: pending.lifecycle_generation,
+            journal_checkpoint_event_id: pending.journal_checkpoint_event_id,
+            watcher_continuity_proof: pending.watcher_continuity_proof,
+            audit_required: pending.audit_required,
             enqueued_at: pending.enqueued_at,
         })
     }
@@ -501,6 +522,8 @@ impl SourceScanWorkflow {
             paths,
             overflowed,
             source_root_available,
+            None,
+            None,
             None,
         )
     }
@@ -741,6 +764,8 @@ impl SourceScanWorkflow {
         source_id: String,
         paths: &[PathBuf],
         lifecycle_generation: Option<u64>,
+        journal_checkpoint_event_id: Option<u64>,
+        watcher_continuity_proof: Option<WatcherContinuityProof>,
     ) {
         let pending = self
             .pending_targeted_syncs
@@ -749,14 +774,56 @@ impl SourceScanWorkflow {
                 source_id: source_id.clone(),
                 paths: BTreeSet::new(),
                 lifecycle_generation,
+                journal_checkpoint_event_id: None,
+                watcher_continuity_proof: None,
+                audit_required: false,
                 enqueued_at: Instant::now(),
             });
         if pending.lifecycle_generation != lifecycle_generation {
             pending.paths.clear();
             pending.lifecycle_generation = lifecycle_generation;
+            pending.journal_checkpoint_event_id = None;
+            pending.watcher_continuity_proof = None;
+            pending.audit_required = false;
             pending.enqueued_at = Instant::now();
         }
         pending.paths.extend(paths.iter().cloned());
+        if !pending.audit_required {
+            let incoming_boundary_is_valid = match (
+                journal_checkpoint_event_id,
+                watcher_continuity_proof.as_ref(),
+            ) {
+                (None, None) => true,
+                (Some(event_id), Some(proof)) => {
+                    !proof.root_identity.is_empty()
+                        && proof.backend == WatcherBackend::Fsevents
+                        && proof.backend_device != 0
+                        && proof.watcher_generation != 0
+                        && proof.replay_coverage_start_event_id
+                            <= proof.replay_coverage_end_event_id
+                        && proof.replay_coverage_end_event_id == proof.acknowledged_end_event_id
+                        && proof.acknowledged_end_event_id == event_id
+                }
+                _ => false,
+            };
+            if !incoming_boundary_is_valid {
+                pending.audit_required = true;
+                pending.journal_checkpoint_event_id = None;
+                pending.watcher_continuity_proof = None;
+            } else if let Some(event_id) = journal_checkpoint_event_id {
+                let boundary_matches = pending.journal_checkpoint_event_id == Some(event_id)
+                    && pending.watcher_continuity_proof.as_ref()
+                        == watcher_continuity_proof.as_ref();
+                if pending.journal_checkpoint_event_id.is_none() {
+                    pending.journal_checkpoint_event_id = Some(event_id);
+                    pending.watcher_continuity_proof = watcher_continuity_proof;
+                } else if !boundary_matches {
+                    pending.audit_required = true;
+                    pending.journal_checkpoint_event_id = None;
+                    pending.watcher_continuity_proof = None;
+                }
+            }
+        }
         tracing::info!(
             target: "wavecrate::source_processing",
             source_id,

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -502,6 +502,7 @@ impl SourceScanWorkflow {
             lifecycle_generation: pending.lifecycle_generation,
             journal_checkpoint_event_id: pending.journal_checkpoint_event_id,
             watcher_continuity_proof: pending.watcher_continuity_proof,
+            proofless_evidence_seen: pending.proofless_evidence_seen,
             audit_required: pending.audit_required,
             enqueued_at: pending.enqueued_at,
         })
@@ -776,6 +777,7 @@ impl SourceScanWorkflow {
                 lifecycle_generation,
                 journal_checkpoint_event_id: None,
                 watcher_continuity_proof: None,
+                proofless_evidence_seen: false,
                 audit_required: false,
                 enqueued_at: Instant::now(),
             });
@@ -784,6 +786,7 @@ impl SourceScanWorkflow {
             pending.lifecycle_generation = lifecycle_generation;
             pending.journal_checkpoint_event_id = None;
             pending.watcher_continuity_proof = None;
+            pending.proofless_evidence_seen = false;
             pending.audit_required = false;
             pending.enqueued_at = Instant::now();
         }
@@ -807,6 +810,17 @@ impl SourceScanWorkflow {
                 _ => false,
             };
             if !incoming_boundary_is_valid {
+                pending.audit_required = true;
+                pending.journal_checkpoint_event_id = None;
+                pending.watcher_continuity_proof = None;
+            } else if journal_checkpoint_event_id.is_none() {
+                pending.proofless_evidence_seen = true;
+                if pending.journal_checkpoint_event_id.is_some() {
+                    pending.audit_required = true;
+                    pending.journal_checkpoint_event_id = None;
+                    pending.watcher_continuity_proof = None;
+                }
+            } else if pending.proofless_evidence_seen {
                 pending.audit_required = true;
                 pending.journal_checkpoint_event_id = None;
                 pending.watcher_continuity_proof = None;

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -1128,7 +1128,7 @@ fn watcher_paths_arriving_during_full_scan_coalesce_for_one_followup_sync() {
     workflow.start_scan(&request);
 
     let proof = replay_proof(11);
-    for (index, paths) in [
+    for paths in [
         vec![PathBuf::from("sample.wav")],
         vec![
             PathBuf::from("sample.wav"),
@@ -1136,13 +1136,7 @@ fn watcher_paths_arriving_during_full_scan_coalesce_for_one_followup_sync() {
         ],
     ]
     .into_iter()
-    .enumerate()
     {
-        let (journal_checkpoint_event_id, watcher_continuity_proof) = if index == 0 {
-            (Some(11), Some(proof.clone()))
-        } else {
-            (None, None)
-        };
         assert!(matches!(
             workflow.plan_filesystem_change_for_generation(
                 &mut browser,
@@ -1151,8 +1145,8 @@ fn watcher_paths_arriving_during_full_scan_coalesce_for_one_followup_sync() {
                 false,
                 true,
                 Some(7),
-                journal_checkpoint_event_id,
-                watcher_continuity_proof,
+                Some(11),
+                Some(proof.clone()),
             ),
             SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
         ));
@@ -1171,6 +1165,7 @@ fn watcher_paths_arriving_during_full_scan_coalesce_for_one_followup_sync() {
     assert_eq!(pending.lifecycle_generation, Some(7));
     assert_eq!(pending.journal_checkpoint_event_id, Some(11));
     assert_eq!(pending.watcher_continuity_proof, Some(proof));
+    assert!(!pending.proofless_evidence_seen);
     assert!(!pending.audit_required);
     assert_eq!(
         pending.paths,
@@ -1180,6 +1175,88 @@ fn watcher_paths_arriving_during_full_scan_coalesce_for_one_followup_sync() {
         ]
     );
     assert!(workflow.next_pending_targeted_sync().is_none());
+}
+
+#[test]
+fn proof_then_proofless_watcher_paths_during_full_scan_require_audit() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 129)
+        .expect("active scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+
+    for (path, journal_checkpoint_event_id, watcher_continuity_proof) in [
+        ("proof.wav", Some(31), Some(replay_proof(31))),
+        ("proofless.wav", None, None),
+    ] {
+        assert!(matches!(
+            workflow.plan_filesystem_change_for_generation(
+                &mut browser,
+                source_id.clone(),
+                &[PathBuf::from(path)],
+                false,
+                true,
+                Some(12),
+                journal_checkpoint_event_id,
+                watcher_continuity_proof,
+            ),
+            SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
+        ));
+    }
+
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+    let pending = workflow
+        .next_pending_targeted_sync()
+        .expect("deferred targeted sync");
+    assert!(pending.audit_required);
+    assert!(pending.proofless_evidence_seen);
+    assert_eq!(pending.journal_checkpoint_event_id, None);
+    assert_eq!(pending.watcher_continuity_proof, None);
+}
+
+#[test]
+fn proofless_then_proof_watcher_paths_during_full_scan_require_audit() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 130)
+        .expect("active scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+
+    for (path, journal_checkpoint_event_id, watcher_continuity_proof) in [
+        ("proofless.wav", None, None),
+        ("proof.wav", Some(32), Some(replay_proof(32))),
+    ] {
+        assert!(matches!(
+            workflow.plan_filesystem_change_for_generation(
+                &mut browser,
+                source_id.clone(),
+                &[PathBuf::from(path)],
+                false,
+                true,
+                Some(12),
+                journal_checkpoint_event_id,
+                watcher_continuity_proof,
+            ),
+            SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
+        ));
+    }
+
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+    let pending = workflow
+        .next_pending_targeted_sync()
+        .expect("deferred targeted sync");
+    assert!(pending.audit_required);
+    assert!(pending.proofless_evidence_seen);
+    assert_eq!(pending.journal_checkpoint_event_id, None);
+    assert_eq!(pending.watcher_continuity_proof, None);
 }
 
 #[test]
@@ -1197,19 +1274,21 @@ fn replay_watcher_paths_arriving_during_targeted_sync_retain_boundary() {
     assert!(workflow.mark_targeted_sync_started(&source_id, 9));
 
     let proof = replay_proof(21);
-    assert!(matches!(
-        workflow.plan_filesystem_change_for_generation(
-            &mut browser,
-            source_id.clone(),
-            &[PathBuf::from("sample.wav")],
-            false,
-            true,
-            Some(9),
-            Some(21),
-            Some(proof.clone()),
-        ),
-        SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
-    ));
+    for path in ["sample.wav", "nested/extra.wav"] {
+        assert!(matches!(
+            workflow.plan_filesystem_change_for_generation(
+                &mut browser,
+                source_id.clone(),
+                &[PathBuf::from(path)],
+                false,
+                true,
+                Some(9),
+                Some(21),
+                Some(proof.clone()),
+            ),
+            SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
+        ));
+    }
 
     workflow.mark_targeted_sync_finished(&source_id, 9);
     let pending = workflow
@@ -1217,7 +1296,94 @@ fn replay_watcher_paths_arriving_during_targeted_sync_retain_boundary() {
         .expect("deferred replay sync");
     assert_eq!(pending.journal_checkpoint_event_id, Some(21));
     assert_eq!(pending.watcher_continuity_proof, Some(proof));
+    assert!(!pending.proofless_evidence_seen);
     assert!(!pending.audit_required);
+}
+
+#[test]
+fn proof_then_proofless_watcher_paths_during_targeted_sync_require_audit() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 131)
+        .expect("source scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+    assert!(workflow.mark_targeted_sync_started(&source_id, 14));
+
+    for (path, journal_checkpoint_event_id, watcher_continuity_proof) in [
+        ("proof.wav", Some(41), Some(replay_proof(41))),
+        ("proofless.wav", None, None),
+    ] {
+        assert!(matches!(
+            workflow.plan_filesystem_change_for_generation(
+                &mut browser,
+                source_id.clone(),
+                &[PathBuf::from(path)],
+                false,
+                true,
+                Some(14),
+                journal_checkpoint_event_id,
+                watcher_continuity_proof,
+            ),
+            SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
+        ));
+    }
+
+    workflow.mark_targeted_sync_finished(&source_id, 14);
+    let pending = workflow
+        .next_pending_targeted_sync()
+        .expect("deferred replay sync");
+    assert!(pending.audit_required);
+    assert!(pending.proofless_evidence_seen);
+    assert_eq!(pending.journal_checkpoint_event_id, None);
+    assert_eq!(pending.watcher_continuity_proof, None);
+}
+
+#[test]
+fn proofless_then_proof_watcher_paths_during_targeted_sync_require_audit() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 132)
+        .expect("source scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+    assert!(workflow.mark_targeted_sync_started(&source_id, 15));
+
+    for (path, journal_checkpoint_event_id, watcher_continuity_proof) in [
+        ("proofless.wav", None, None),
+        ("proof.wav", Some(42), Some(replay_proof(42))),
+    ] {
+        assert!(matches!(
+            workflow.plan_filesystem_change_for_generation(
+                &mut browser,
+                source_id.clone(),
+                &[PathBuf::from(path)],
+                false,
+                true,
+                Some(15),
+                journal_checkpoint_event_id,
+                watcher_continuity_proof,
+            ),
+            SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
+        ));
+    }
+
+    workflow.mark_targeted_sync_finished(&source_id, 15);
+    let pending = workflow
+        .next_pending_targeted_sync()
+        .expect("deferred replay sync");
+    assert!(pending.audit_required);
+    assert!(pending.proofless_evidence_seen);
+    assert_eq!(pending.journal_checkpoint_event_id, None);
+    assert_eq!(pending.watcher_continuity_proof, None);
 }
 
 #[test]

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -4,11 +4,24 @@ use super::*;
 use crate::native_app::sample_library::folder_browser::scan::{
     FolderScanProgress, FolderScanRequest, scan_source_with_progress,
 };
+use crate::native_app::sample_library::source_watcher::{WatcherBackend, WatcherContinuityProof};
 
 fn temp_dir_with_wav() -> tempfile::TempDir {
     let root = tempfile::tempdir().expect("source root");
     fs::write(root.path().join("sample.wav"), [0_u8; 8]).expect("write sample");
     root
+}
+
+fn replay_proof(end_event_id: u64) -> WatcherContinuityProof {
+    WatcherContinuityProof {
+        root_identity: String::from("root-a"),
+        backend: WatcherBackend::Fsevents,
+        backend_device: 10,
+        watcher_generation: 4,
+        replay_coverage_start_event_id: end_event_id.saturating_sub(1),
+        replay_coverage_end_event_id: end_event_id,
+        acknowledged_end_event_id: end_event_id,
+    }
 }
 
 #[test]
@@ -1114,13 +1127,22 @@ fn watcher_paths_arriving_during_full_scan_coalesce_for_one_followup_sync() {
     let source_id = request.source_id.clone();
     workflow.start_scan(&request);
 
-    for paths in [
+    let proof = replay_proof(11);
+    for (index, paths) in [
         vec![PathBuf::from("sample.wav")],
         vec![
             PathBuf::from("sample.wav"),
             PathBuf::from("nested/extra.wav"),
         ],
-    ] {
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let (journal_checkpoint_event_id, watcher_continuity_proof) = if index == 0 {
+            (Some(11), Some(proof.clone()))
+        } else {
+            (None, None)
+        };
         assert!(matches!(
             workflow.plan_filesystem_change_for_generation(
                 &mut browser,
@@ -1129,6 +1151,8 @@ fn watcher_paths_arriving_during_full_scan_coalesce_for_one_followup_sync() {
                 false,
                 true,
                 Some(7),
+                journal_checkpoint_event_id,
+                watcher_continuity_proof,
             ),
             SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
         ));
@@ -1145,6 +1169,9 @@ fn watcher_paths_arriving_during_full_scan_coalesce_for_one_followup_sync() {
         .expect("one targeted followup");
     assert_eq!(pending.source_id, source_id);
     assert_eq!(pending.lifecycle_generation, Some(7));
+    assert_eq!(pending.journal_checkpoint_event_id, Some(11));
+    assert_eq!(pending.watcher_continuity_proof, Some(proof));
+    assert!(!pending.audit_required);
     assert_eq!(
         pending.paths,
         vec![
@@ -1153,6 +1180,83 @@ fn watcher_paths_arriving_during_full_scan_coalesce_for_one_followup_sync() {
         ]
     );
     assert!(workflow.next_pending_targeted_sync().is_none());
+}
+
+#[test]
+fn replay_watcher_paths_arriving_during_targeted_sync_retain_boundary() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 127)
+        .expect("source scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+    assert!(workflow.mark_targeted_sync_started(&source_id, 9));
+
+    let proof = replay_proof(21);
+    assert!(matches!(
+        workflow.plan_filesystem_change_for_generation(
+            &mut browser,
+            source_id.clone(),
+            &[PathBuf::from("sample.wav")],
+            false,
+            true,
+            Some(9),
+            Some(21),
+            Some(proof.clone()),
+        ),
+        SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
+    ));
+
+    workflow.mark_targeted_sync_finished(&source_id, 9);
+    let pending = workflow
+        .next_pending_targeted_sync()
+        .expect("deferred replay sync");
+    assert_eq!(pending.journal_checkpoint_event_id, Some(21));
+    assert_eq!(pending.watcher_continuity_proof, Some(proof));
+    assert!(!pending.audit_required);
+}
+
+#[test]
+fn incompatible_replay_boundaries_arriving_during_targeted_sync_require_audit() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 128)
+        .expect("source scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+    assert!(workflow.mark_targeted_sync_started(&source_id, 10));
+
+    for (event_id, path) in [(31, "first.wav"), (32, "second.wav")] {
+        assert!(matches!(
+            workflow.plan_filesystem_change_for_generation(
+                &mut browser,
+                source_id.clone(),
+                &[PathBuf::from(path)],
+                false,
+                true,
+                Some(10),
+                Some(event_id),
+                Some(replay_proof(event_id)),
+            ),
+            SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
+        ));
+    }
+
+    workflow.mark_targeted_sync_finished(&source_id, 10);
+    let pending = workflow
+        .next_pending_targeted_sync()
+        .expect("deferred replay sync");
+    assert!(pending.audit_required);
+    assert_eq!(pending.journal_checkpoint_event_id, None);
+    assert_eq!(pending.watcher_continuity_proof, None);
 }
 
 #[test]
@@ -1181,6 +1285,8 @@ fn pending_full_scan_subsumes_watcher_paths_before_execution() {
             false,
             true,
             Some(9),
+            None,
+            None,
         ),
         SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
     ));
@@ -1209,6 +1315,8 @@ fn full_fallback_waits_for_active_targeted_sync_and_supersedes_queued_paths() {
             false,
             true,
             Some(11),
+            None,
+            None,
         ),
         SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
     ));
@@ -1250,6 +1358,8 @@ fn source_retirement_purges_targeted_sync_causal_state() {
             false,
             true,
             Some(13),
+            None,
+            None,
         ),
         SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
     ));

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -451,6 +451,7 @@ impl NativeAppState {
                     target: "wavecrate::source_processing",
                     source_id = pending.source_id,
                     queue_age_ms = pending.enqueued_at.elapsed().as_millis(),
+                    proofless_evidence_seen = pending.proofless_evidence_seen,
                     outcome = "targeted_sync_audit_required",
                     "Queued watcher replay evidence could not be preserved safely"
                 );

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -71,6 +71,8 @@ impl NativeAppState {
             overflowed,
             source_root_available,
             lifecycle_generation,
+            journal_checkpoint_event_id,
+            watcher_continuity_proof.clone(),
         ) {
             SourceFilesystemChangePlan::IgnoredSourceMissing { source_id } => {
                 self.background
@@ -438,6 +440,22 @@ impl NativeAppState {
                 );
                 continue;
             }
+            if pending.audit_required {
+                self.background
+                    .source_processing
+                    .request_source_manifest_audit(
+                        &pending.source_id,
+                        "deferred_watcher_replay_continuity_conflict",
+                    );
+                tracing::warn!(
+                    target: "wavecrate::source_processing",
+                    source_id = pending.source_id,
+                    queue_age_ms = pending.enqueued_at.elapsed().as_millis(),
+                    outcome = "targeted_sync_audit_required",
+                    "Queued watcher replay evidence could not be preserved safely"
+                );
+                break;
+            }
             let changed_count = pending.paths.len();
             tracing::info!(
                 target: "wavecrate::source_processing",
@@ -452,8 +470,8 @@ impl NativeAppState {
                 pending.source_id,
                 pending.paths,
                 changed_count,
-                None,
-                None,
+                pending.journal_checkpoint_event_id,
+                pending.watcher_continuity_proof,
                 context,
             );
             break;
@@ -599,6 +617,8 @@ impl NativeAppState {
                 false,
                 true,
                 Some(expected_lifecycle_generation),
+                journal_checkpoint_event_id,
+                watcher_continuity_proof.clone(),
             );
             return;
         }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -14,7 +14,9 @@ use crate::native_app::sample_library::source_prep::{
     CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
     SourcePrepIntents, SourcePriorityIntent,
 };
-use crate::native_app::sample_library::source_watcher::{CheckpointCause, RevisionBoundCheckpoint};
+use crate::native_app::sample_library::source_watcher::{
+    CheckpointCause, RevisionBoundCheckpoint, WatcherContinuityProof,
+};
 use crate::native_app::source_processing::{
     ExternalScanHandoff, manifest_delta_requires_browser_refresh,
 };
@@ -54,6 +56,7 @@ impl NativeAppState {
         overflowed: bool,
         source_root_available: bool,
         journal_checkpoint_event_id: Option<u64>,
+        watcher_continuity_proof: Option<WatcherContinuityProof>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let started_at = Instant::now();
@@ -98,6 +101,7 @@ impl NativeAppState {
                     paths,
                     changed_count,
                     journal_checkpoint_event_id,
+                    watcher_continuity_proof,
                     context,
                 );
                 emit_gui_action(
@@ -139,6 +143,7 @@ impl NativeAppState {
         let source_id = result.source_id;
         let root_identity = result.root_identity;
         let journal_checkpoint_event_id = result.journal_checkpoint_event_id;
+        let watcher_continuity_proof = result.watcher_continuity_proof;
         self.library
             .mark_targeted_source_sync_finished(&source_id, result.lifecycle_generation);
         if self.background.source_lifecycle_generations.get(&source_id)
@@ -201,8 +206,12 @@ impl NativeAppState {
                     );
                 }
                 if !result.cancelled && projection_accepted && incomplete_error.is_none() {
-                    match (root_identity, journal_checkpoint_event_id) {
-                        (Some(root_identity), Some(event_id)) => self
+                    match (
+                        root_identity,
+                        journal_checkpoint_event_id,
+                        watcher_continuity_proof,
+                    ) {
+                        (Some(root_identity), Some(event_id), Some(proof)) => self
                             .background
                             .source_processing
                             .budget_handle()
@@ -213,8 +222,22 @@ impl NativeAppState {
                                 root_identity,
                                 event_id,
                                 cause: CheckpointCause::TargetedReplay,
+                                continuity_proof: Some(proof),
                             }),
-                        (None, _) => {
+                        (Some(root_identity), Some(event_id), None) => self
+                            .background
+                            .source_processing
+                            .budget_handle()
+                            .submit_watcher_checkpoint(RevisionBoundCheckpoint {
+                                source_id: source_id.clone(),
+                                lifecycle_generation: result.lifecycle_generation,
+                                source_revision: delta.revision,
+                                root_identity,
+                                event_id,
+                                cause: CheckpointCause::TargetedReplay,
+                                continuity_proof: None,
+                            }),
+                        (None, _, _) => {
                             incomplete_error = Some(String::from(
                                 "targeted filesystem sync completed without worker-captured source root identity",
                             ));
@@ -226,7 +249,7 @@ impl NativeAppState {
                                 "Refusing targeted watcher checkpoint without worker-captured root identity"
                             );
                         }
-                        (Some(_), None) => tracing::debug!(
+                        (Some(_), None, _) => tracing::debug!(
                             source_id = %source_id,
                             revision = delta.revision,
                             "Skipping targeted watcher checkpoint because replay event identity is unavailable"
@@ -430,6 +453,7 @@ impl NativeAppState {
                 pending.paths,
                 changed_count,
                 None,
+                None,
                 context,
             );
             break;
@@ -534,6 +558,7 @@ impl NativeAppState {
         paths: Vec<PathBuf>,
         changed_count: usize,
         journal_checkpoint_event_id: Option<u64>,
+        watcher_continuity_proof: Option<WatcherContinuityProof>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         if paths.is_empty() {
@@ -589,6 +614,7 @@ impl NativeAppState {
                         changed_count,
                         root_identity: capture_source_root_identity(&root),
                         journal_checkpoint_event_id,
+                        watcher_continuity_proof,
                         cancelled: true,
                         result: Err(String::from("Source filesystem sync canceled")),
                     };
@@ -616,6 +642,7 @@ impl NativeAppState {
                 );
                 result.root_identity = root_identity;
                 result.journal_checkpoint_event_id = journal_checkpoint_event_id;
+                result.watcher_continuity_proof = watcher_continuity_proof;
                 let projection_ticket = match &mut result.result {
                     Ok(success)
                         if !result.cancelled
@@ -783,6 +810,7 @@ mod tests {
             changed_count: 1,
             root_identity: None,
             journal_checkpoint_event_id: Some(73),
+            watcher_continuity_proof: None,
             cancelled: false,
             result: Ok(SourceFilesystemSyncSuccess {
                 renames_reconciled: 0,
@@ -832,6 +860,7 @@ mod tests {
             changed_count: 1,
             root_identity,
             journal_checkpoint_event_id: Some(73),
+            watcher_continuity_proof: None,
             cancelled: false,
             result: Ok(SourceFilesystemSyncSuccess {
                 renames_reconciled: 0,

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -38,6 +38,7 @@ pub(in crate::native_app) fn recover_source_filesystem_sync(
             changed_count,
             root_identity: None,
             journal_checkpoint_event_id: None,
+            watcher_continuity_proof: None,
             cancelled: false,
             result: Err(String::from(
                 "Source filesystem sync worker stopped unexpectedly",
@@ -115,6 +116,7 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
         changed_count,
         root_identity,
         journal_checkpoint_event_id: None,
+        watcher_continuity_proof: None,
         cancelled: cancel.load(Ordering::Acquire),
         result,
     }

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -25,7 +25,6 @@ fn doubled_duration(current: Duration, maximum: Duration) -> Duration {
 }
 
 pub(in crate::native_app) use handle::GuiSourceWatcherHandle;
-#[cfg(test)]
 pub(in crate::native_app) use journal::WatcherBackend;
 pub(in crate::native_app) use journal::{
     CheckpointAdvanceOutcome, CheckpointCause, RevisionBoundCheckpoint, WatcherContinuityProof,

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -25,9 +25,11 @@ fn doubled_duration(current: Duration, maximum: Duration) -> Duration {
 }
 
 pub(in crate::native_app) use handle::GuiSourceWatcherHandle;
+#[cfg(test)]
+pub(in crate::native_app) use journal::WatcherBackend;
 pub(in crate::native_app) use journal::{
-    CheckpointAdvanceOutcome, CheckpointCause, RevisionBoundCheckpoint,
-    write_revision_bound_checkpoint,
+    CheckpointAdvanceOutcome, CheckpointCause, RevisionBoundCheckpoint, WatcherContinuityProof,
+    targeted_replay_request_has_valid_proof, write_revision_bound_checkpoint,
 };
 
 #[cfg(test)]

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -831,6 +831,7 @@ fn run_source_watcher(
                 overflowed: event.overflowed,
                 source_root_available: event.source_root_available,
                 journal_checkpoint_event_id: None,
+                watcher_continuity_proof: None,
             });
         }
     }
@@ -911,10 +912,10 @@ fn publish_closed_app_journal_recovery(
     {
         match recovery {
             #[cfg(target_os = "macos")]
-            JournalRecovery::Changes { paths, event_id } if paths.is_empty() => {
+            JournalRecovery::Changes { paths, proof } if paths.is_empty() => {
                 tracing::info!(
                     source_id = source.id.as_str(),
-                    event_id,
+                    replay_end_event_id = proof.replay_coverage_end_event_id,
                     "Empty closed-application source watcher replay requires a bounded manifest audit"
                 );
                 if defer_audit_barriers {
@@ -932,10 +933,14 @@ fn publish_closed_app_journal_recovery(
                 }
             }
             #[cfg(target_os = "macos")]
-            JournalRecovery::Changes { paths, event_id } => {
+            JournalRecovery::Changes { paths, proof } => {
                 tracing::info!(
                     source_id = source.id.as_str(),
                     path_count = paths.len(),
+                    replay_start_event_id = proof.replay_coverage_start_event_id,
+                    replay_end_event_id = proof.replay_coverage_end_event_id,
+                    backend_device = proof.backend_device,
+                    watcher_generation = proof.watcher_generation,
                     "Replaying closed-application source watcher changes"
                 );
                 let _ = message_tx.send(GuiMessage::SourceFilesystemChanged {
@@ -943,7 +948,8 @@ fn publish_closed_app_journal_recovery(
                     paths,
                     overflowed: false,
                     source_root_available: true,
-                    journal_checkpoint_event_id: Some(event_id),
+                    journal_checkpoint_event_id: Some(proof.acknowledged_end_event_id),
+                    watcher_continuity_proof: Some(proof),
                 });
             }
             JournalRecovery::FullAudit { reason } => {

--- a/src/native_app/sample_library/source_watcher/journal.rs
+++ b/src/native_app/sample_library/source_watcher/journal.rs
@@ -25,7 +25,8 @@ use wavecrate_library::{
     sample_sources::db::META_SOURCE_WATCHER_CHECKPOINT,
 };
 
-const CHECKPOINT_FORMAT_VERSION: u32 = 2;
+const V2_CHECKPOINT_FORMAT_VERSION: u32 = 2;
+const CHECKPOINT_FORMAT_VERSION: u32 = 3;
 const LEGACY_CHECKPOINT_FIELDS: [&str; 2] = ["root_identity", "event_id"];
 const V2_CHECKPOINT_FIELDS: [&str; 7] = [
     "root_identity",
@@ -36,12 +37,44 @@ const V2_CHECKPOINT_FIELDS: [&str; 7] = [
     "source_revision",
     "cause",
 ];
+const V3_CHECKPOINT_FIELDS: [&str; 8] = [
+    "root_identity",
+    "event_id",
+    "format_version",
+    "source_id",
+    "lifecycle_generation",
+    "source_revision",
+    "cause",
+    "continuity_proof",
+];
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(in crate::native_app) enum CheckpointCause {
     TargetedReplay,
     CompletedFallbackAudit,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::native_app) enum WatcherBackend {
+    Fsevents,
+}
+
+/// Evidence that a macOS replay covered one contiguous FSEvents cursor window.
+///
+/// `watcher_generation` is allocated by this process for each replay stream. It is deliberately
+/// not derived from an FSEventStream pointer or any other address-like value.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(in crate::native_app) struct WatcherContinuityProof {
+    pub(in crate::native_app) root_identity: String,
+    pub(in crate::native_app) backend: WatcherBackend,
+    pub(in crate::native_app) backend_device: u64,
+    pub(in crate::native_app) watcher_generation: u64,
+    pub(in crate::native_app) replay_coverage_start_event_id: u64,
+    pub(in crate::native_app) replay_coverage_end_event_id: u64,
+    pub(in crate::native_app) acknowledged_end_event_id: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -52,6 +85,7 @@ pub(in crate::native_app) struct RevisionBoundCheckpoint {
     pub(in crate::native_app) root_identity: String,
     pub(in crate::native_app) event_id: u64,
     pub(in crate::native_app) cause: CheckpointCause,
+    pub(in crate::native_app) continuity_proof: Option<WatcherContinuityProof>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -78,6 +112,8 @@ struct SourceWatcherCheckpoint {
     source_revision: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     cause: Option<CheckpointCause>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    continuity_proof: Option<WatcherContinuityProof>,
 }
 
 impl SourceWatcherCheckpoint {
@@ -90,24 +126,31 @@ impl SourceWatcherCheckpoint {
             lifecycle_generation: None,
             source_revision: None,
             cause: None,
+            continuity_proof: None,
         }
     }
 
     fn from_revision_bound(checkpoint: &RevisionBoundCheckpoint) -> Self {
+        let format_version = if checkpoint.continuity_proof.is_some() {
+            CHECKPOINT_FORMAT_VERSION
+        } else {
+            V2_CHECKPOINT_FORMAT_VERSION
+        };
         Self {
             root_identity: checkpoint.root_identity.clone(),
             event_id: checkpoint.event_id,
-            format_version: Some(CHECKPOINT_FORMAT_VERSION),
+            format_version: Some(format_version),
             source_id: Some(checkpoint.source_id.clone()),
             lifecycle_generation: Some(checkpoint.lifecycle_generation),
             source_revision: Some(checkpoint.source_revision),
             cause: Some(checkpoint.cause),
+            continuity_proof: checkpoint.continuity_proof.clone(),
         }
     }
 
     fn revision_bound(&self) -> Option<RevisionBoundCheckpoint> {
         let (
-            Some(CHECKPOINT_FORMAT_VERSION),
+            Some(format_version),
             Some(source_id),
             Some(lifecycle_generation),
             Some(source_revision),
@@ -122,6 +165,11 @@ impl SourceWatcherCheckpoint {
         else {
             return None;
         };
+        if format_version != V2_CHECKPOINT_FORMAT_VERSION
+            && (format_version != CHECKPOINT_FORMAT_VERSION || self.continuity_proof.is_none())
+        {
+            return None;
+        }
         Some(RevisionBoundCheckpoint {
             source_id,
             lifecycle_generation,
@@ -129,6 +177,7 @@ impl SourceWatcherCheckpoint {
             root_identity: self.root_identity.clone(),
             event_id: self.event_id,
             cause,
+            continuity_proof: self.continuity_proof.clone(),
         })
     }
 }
@@ -211,10 +260,14 @@ fn parse_checkpoint(value: &str) -> Result<SourceWatcherCheckpoint, String> {
         ));
     }
 
-    if !has_exact_checkpoint_fields(&object, &V2_CHECKPOINT_FIELDS) {
+    let format_version = if has_exact_checkpoint_fields(&object, &V2_CHECKPOINT_FIELDS) {
+        V2_CHECKPOINT_FORMAT_VERSION
+    } else if has_exact_checkpoint_fields(&object, &V3_CHECKPOINT_FIELDS) {
+        CHECKPOINT_FORMAT_VERSION
+    } else {
         return Err("watcher checkpoint has an unsupported field shape".to_string());
-    }
-    if checkpoint_u64(&object, "format_version")? != u64::from(CHECKPOINT_FORMAT_VERSION) {
+    };
+    if checkpoint_u64(&object, "format_version")? != u64::from(format_version) {
         return Err("watcher checkpoint has an unsupported format version".to_string());
     }
 
@@ -225,15 +278,63 @@ fn parse_checkpoint(value: &str) -> Result<SourceWatcherCheckpoint, String> {
             .ok_or_else(|| "watcher checkpoint is missing cause".to_string())?,
     )
     .map_err(|error| format!("checkpoint cause is invalid: {error}"))?;
+    let continuity_proof = if format_version == CHECKPOINT_FORMAT_VERSION {
+        Some(
+            serde_json::from_value(
+                object
+                    .get("continuity_proof")
+                    .cloned()
+                    .ok_or_else(|| "watcher checkpoint is missing continuity proof".to_string())?,
+            )
+            .map_err(|error| format!("continuity proof is invalid: {error}"))?,
+        )
+    } else {
+        None
+    };
     Ok(SourceWatcherCheckpoint {
         root_identity: checkpoint_string(&object, "root_identity")?,
         event_id: checkpoint_u64(&object, "event_id")?,
-        format_version: Some(CHECKPOINT_FORMAT_VERSION),
+        format_version: Some(format_version),
         source_id: Some(checkpoint_string(&object, "source_id")?),
         lifecycle_generation: Some(checkpoint_u64(&object, "lifecycle_generation")?),
         source_revision: Some(checkpoint_u64(&object, "source_revision")?),
         cause: Some(cause),
+        continuity_proof,
     })
+}
+
+fn continuity_proof_is_well_formed(
+    proof: &WatcherContinuityProof,
+    expected_root_identity: &str,
+    expected_acknowledged_end: u64,
+) -> bool {
+    !proof.root_identity.is_empty()
+        && proof.root_identity == expected_root_identity
+        && proof.backend == WatcherBackend::Fsevents
+        && proof.backend_device != 0
+        && proof.watcher_generation != 0
+        && proof.replay_coverage_start_event_id <= proof.replay_coverage_end_event_id
+        && proof.replay_coverage_end_event_id == proof.acknowledged_end_event_id
+        && proof.acknowledged_end_event_id == expected_acknowledged_end
+}
+
+fn same_continuity_identity(left: &WatcherContinuityProof, right: &WatcherContinuityProof) -> bool {
+    left.root_identity == right.root_identity
+        && left.backend == right.backend
+        && left.backend_device == right.backend_device
+        && left.watcher_generation == right.watcher_generation
+}
+
+/// Validate the self-contained portion of a targeted replay request before the owner opens a
+/// source database. The durable decision still compares the proof with the prior acknowledged
+/// checkpoint under the source writer gate.
+pub(in crate::native_app) fn targeted_replay_request_has_valid_proof(
+    requested: &RevisionBoundCheckpoint,
+) -> bool {
+    requested.cause == CheckpointCause::TargetedReplay
+        && requested.continuity_proof.as_ref().is_some_and(|proof| {
+            continuity_proof_is_well_formed(proof, &requested.root_identity, requested.event_id)
+        })
 }
 
 fn decide_checkpoint_advance(
@@ -253,6 +354,9 @@ fn decide_checkpoint_advance(
     }
 
     if requested.cause == CheckpointCause::CompletedFallbackAudit {
+        if requested.continuity_proof.is_some() {
+            return CheckpointAdvanceOutcome::AuditRequired;
+        }
         let Some(current) = current else {
             // A completed source-wide audit is the authority that establishes the first
             // revision-bound cursor after a missing checkpoint.
@@ -269,8 +373,45 @@ fn decide_checkpoint_advance(
             // closed before the pure decision.
             return CheckpointAdvanceOutcome::Applied;
         }
+        let Some(current) = current.revision_bound() else {
+            return CheckpointAdvanceOutcome::AuditRequired;
+        };
+        if current.source_id != requested.source_id
+            || current.source_revision > current_source_revision
+            || current.root_identity != requested.root_identity
+            || current.event_id > requested.event_id
+        {
+            return CheckpointAdvanceOutcome::AuditRequired;
+        }
+        if let Some(current_proof) = current.continuity_proof.as_ref()
+            && !continuity_proof_is_well_formed(
+                current_proof,
+                &current.root_identity,
+                current.event_id,
+            )
+        {
+            return CheckpointAdvanceOutcome::AuditRequired;
+        }
+        if current == *requested {
+            return CheckpointAdvanceOutcome::AlreadyApplied;
+        }
+        return if current.event_id == requested.event_id {
+            CheckpointAdvanceOutcome::Superseded
+        } else {
+            CheckpointAdvanceOutcome::Applied
+        };
     }
 
+    let Some(requested_proof) = requested.continuity_proof.as_ref() else {
+        return CheckpointAdvanceOutcome::AuditRequired;
+    };
+    if !continuity_proof_is_well_formed(
+        requested_proof,
+        &requested.root_identity,
+        requested.event_id,
+    ) {
+        return CheckpointAdvanceOutcome::AuditRequired;
+    }
     let Some(current) = current else {
         return CheckpointAdvanceOutcome::AuditRequired;
     };
@@ -284,6 +425,25 @@ fn decide_checkpoint_advance(
     {
         return CheckpointAdvanceOutcome::AuditRequired;
     }
+    let Some(current_proof) = current.continuity_proof.as_ref() else {
+        if current.cause != CheckpointCause::CompletedFallbackAudit
+            || requested_proof.replay_coverage_start_event_id != current.event_id
+        {
+            return CheckpointAdvanceOutcome::AuditRequired;
+        }
+        return if requested.event_id > current.event_id {
+            CheckpointAdvanceOutcome::Applied
+        } else if requested.event_id == current.event_id {
+            CheckpointAdvanceOutcome::Superseded
+        } else {
+            CheckpointAdvanceOutcome::AuditRequired
+        };
+    };
+    if !continuity_proof_is_well_formed(current_proof, &current.root_identity, current.event_id)
+        || !same_continuity_identity(current_proof, requested_proof)
+    {
+        return CheckpointAdvanceOutcome::AuditRequired;
+    }
     if current == *requested {
         return CheckpointAdvanceOutcome::AlreadyApplied;
     }
@@ -291,9 +451,18 @@ fn decide_checkpoint_advance(
         return CheckpointAdvanceOutcome::AuditRequired;
     }
     if requested.event_id > current.event_id {
+        if requested_proof.replay_coverage_start_event_id != current.event_id {
+            return CheckpointAdvanceOutcome::AuditRequired;
+        }
         return CheckpointAdvanceOutcome::Applied;
     }
-    CheckpointAdvanceOutcome::Superseded
+    if requested_proof.replay_coverage_start_event_id
+        == current_proof.replay_coverage_start_event_id
+    {
+        CheckpointAdvanceOutcome::Superseded
+    } else {
+        CheckpointAdvanceOutcome::AuditRequired
+    }
 }
 
 /// Apply a revision-bound watcher checkpoint from the source-processing owner.
@@ -428,6 +597,7 @@ impl AuditBarrier {
             root_identity: self.0.root_identity,
             event_id: self.0.event_id,
             cause: CheckpointCause::CompletedFallbackAudit,
+            continuity_proof: None,
         }
     }
 }
@@ -437,7 +607,7 @@ pub(super) enum JournalRecovery {
     #[cfg(target_os = "macos")]
     Changes {
         paths: Vec<PathBuf>,
-        event_id: u64,
+        proof: WatcherContinuityProof,
     },
     FullAudit {
         reason: &'static str,
@@ -463,7 +633,7 @@ pub(super) fn recover_sources(
 fn classify_replayed_paths(
     source: &SampleSource,
     paths: Vec<PathBuf>,
-    event_id: u64,
+    proof: WatcherContinuityProof,
 ) -> JournalRecovery {
     let paths = paths
         .into_iter()
@@ -478,7 +648,7 @@ fn classify_replayed_paths(
             reason: "journal_replay_empty_paths",
         }
     } else {
-        JournalRecovery::Changes { paths, event_id }
+        JournalRecovery::Changes { paths, proof }
     }
 }
 
@@ -525,8 +695,8 @@ fn recover_source(source: &SampleSource, native_watcher: bool) -> JournalRecover
 
     #[cfg(target_os = "macos")]
     {
-        match replay_fsevents(&source.root, checkpoint.event_id) {
-            Ok((paths, event_id)) => classify_replayed_paths(source, paths, event_id),
+        match replay_fsevents(&source.root, root_identity, checkpoint.event_id) {
+            Ok((paths, proof)) => classify_replayed_paths(source, paths, proof),
             Err(reason) => JournalRecovery::FullAudit { reason },
         }
     }
@@ -624,8 +794,23 @@ fn store_checkpoint(
 }
 
 #[cfg(target_os = "macos")]
-fn replay_fsevents(root: &Path, event_id: u64) -> Result<(Vec<PathBuf>, u64), &'static str> {
-    macos::replay(root, event_id).map(|replay| (replay.paths, replay.event_id))
+fn replay_fsevents(
+    root: &Path,
+    root_identity: String,
+    event_id: u64,
+) -> Result<(Vec<PathBuf>, WatcherContinuityProof), &'static str> {
+    macos::replay(root, event_id).map(|replay| {
+        let proof = WatcherContinuityProof {
+            root_identity,
+            backend: WatcherBackend::Fsevents,
+            backend_device: replay.backend_device,
+            watcher_generation: replay.watcher_generation,
+            replay_coverage_start_event_id: replay.replay_start_event_id,
+            replay_coverage_end_event_id: replay.replay_end_event_id,
+            acknowledged_end_event_id: replay.replay_end_event_id,
+        };
+        (replay.paths, proof)
+    })
 }
 
 #[cfg(target_os = "macos")]
@@ -635,7 +820,7 @@ mod macos {
     use std::{
         ffi::{CStr, c_void},
         ptr,
-        sync::{Mutex, mpsc},
+        sync::{Mutex, OnceLock, atomic::AtomicU64, mpsc},
         time::Duration,
     };
 
@@ -652,14 +837,30 @@ mod macos {
     #[derive(Default)]
     struct HistoryState {
         paths: Vec<PathBuf>,
+        replay_start_event_id: u64,
         history_done: bool,
         history_lost: bool,
         latest_event_id: u64,
     }
 
+    impl HistoryState {
+        fn new(replay_start_event_id: u64) -> Self {
+            Self {
+                paths: Vec::new(),
+                replay_start_event_id,
+                history_done: false,
+                history_lost: false,
+                latest_event_id: replay_start_event_id,
+            }
+        }
+    }
+
     pub(super) struct HistoryReplay {
         pub(super) paths: Vec<PathBuf>,
-        pub(super) event_id: u64,
+        pub(super) replay_start_event_id: u64,
+        pub(super) replay_end_event_id: u64,
+        pub(super) backend_device: u64,
+        pub(super) watcher_generation: u64,
     }
 
     struct HistoryContext {
@@ -678,6 +879,12 @@ mod macos {
     // history worker that created them.
     unsafe impl Send for RunLoopHandle {}
 
+    fn next_watcher_generation() -> u64 {
+        static NEXT_WATCHER_GENERATION: OnceLock<AtomicU64> = OnceLock::new();
+        let counter = NEXT_WATCHER_GENERATION.get_or_init(|| AtomicU64::new(1));
+        counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
     #[link(name = "CoreFoundation", kind = "framework")]
     unsafe extern "C" {
         fn CFRetain(cf: cf::CFRef) -> cf::CFRef;
@@ -687,10 +894,16 @@ mod macos {
         let (result_tx, result_rx) = mpsc::sync_channel(1);
         let (run_loop_tx, run_loop_rx) = mpsc::sync_channel(1);
         let root = root.to_path_buf();
+        let watcher_generation = next_watcher_generation();
         let worker = std::thread::Builder::new()
             .name("wavecrate-fsevents-history".to_string())
             .spawn(move || {
-                let _ = result_tx.send(replay_on_run_loop(&root, event_id, run_loop_tx));
+                let _ = result_tx.send(replay_on_run_loop(
+                    &root,
+                    event_id,
+                    watcher_generation,
+                    run_loop_tx,
+                ));
             })
             .map_err(|_| "watcher_history_thread_unavailable")?;
         let run_loop = match run_loop_rx.recv_timeout(HISTORY_TIMEOUT) {
@@ -725,12 +938,13 @@ mod macos {
     fn replay_on_run_loop(
         root: &Path,
         event_id: u64,
+        watcher_generation: u64,
         run_loop_tx: mpsc::SyncSender<RunLoopHandle>,
     ) -> Result<HistoryReplay, &'static str> {
         let (ready_tx, ready_rx) = mpsc::channel();
         let context = Box::new(HistoryContext {
             root: root.to_path_buf(),
-            state: Mutex::new(HistoryState::default()),
+            state: Mutex::new(HistoryState::new(event_id)),
             ready_tx,
         });
         let context = Box::into_raw(context);
@@ -739,6 +953,19 @@ mod macos {
             Err(error) => {
                 unsafe { drop(Box::from_raw(context)) };
                 return Err(error);
+            }
+        };
+        let backend_device = match u64::try_from(unsafe {
+            fs::FSEventStreamGetDeviceBeingWatched(stream as fs::ConstFSEventStreamRef)
+        }) {
+            Ok(device) if device != 0 => device,
+            _ => {
+                unsafe {
+                    fs::FSEventStreamInvalidate(stream);
+                    fs::FSEventStreamRelease(stream);
+                    drop(Box::from_raw(context));
+                }
+                return Err("watcher_history_device_unavailable");
             }
         };
         let run_loop = unsafe { cf::CFRunLoopGetCurrent() };
@@ -784,7 +1011,10 @@ mod macos {
         state.paths.dedup();
         Ok(HistoryReplay {
             paths: state.paths,
-            event_id: state.latest_event_id.max(event_id),
+            replay_start_event_id: state.replay_start_event_id,
+            replay_end_event_id: state.latest_event_id.max(event_id),
+            backend_device,
+            watcher_generation,
         })
     }
 
@@ -875,6 +1105,23 @@ mod tests {
     use wavecrate::sample_sources::SourceId;
     use wavecrate_library::sample_sources::SourceDatabase;
 
+    fn continuity_proof(
+        root_identity: &str,
+        watcher_generation: u64,
+        start: u64,
+        end: u64,
+    ) -> WatcherContinuityProof {
+        WatcherContinuityProof {
+            root_identity: root_identity.to_string(),
+            backend: WatcherBackend::Fsevents,
+            backend_device: 10,
+            watcher_generation,
+            replay_coverage_start_event_id: start,
+            replay_coverage_end_event_id: end,
+            acknowledged_end_event_id: end,
+        }
+    }
+
     fn revision_bound_checkpoint(event_id: u64) -> RevisionBoundCheckpoint {
         RevisionBoundCheckpoint {
             source_id: "source-a".to_string(),
@@ -883,6 +1130,12 @@ mod tests {
             root_identity: "root-a".to_string(),
             event_id,
             cause: CheckpointCause::TargetedReplay,
+            continuity_proof: Some(continuity_proof(
+                "root-a",
+                4,
+                event_id.saturating_sub(1),
+                event_id,
+            )),
         }
     }
 
@@ -903,7 +1156,7 @@ mod tests {
         );
 
         assert_eq!(
-            classify_replayed_paths(&source, Vec::new(), 11),
+            classify_replayed_paths(&source, Vec::new(), continuity_proof("root-a", 4, 10, 11)),
             JournalRecovery::FullAudit {
                 reason: "journal_replay_empty_paths",
             }
@@ -919,11 +1172,12 @@ mod tests {
             directory.path().to_path_buf(),
         );
 
+        let proof = continuity_proof("root-a", 4, 10, 11);
         assert_eq!(
-            classify_replayed_paths(&source, vec![source.root.join("kick.wav")], 11,),
+            classify_replayed_paths(&source, vec![source.root.join("kick.wav")], proof.clone(),),
             JournalRecovery::Changes {
                 paths: vec![PathBuf::from("kick.wav")],
-                event_id: 11,
+                proof,
             }
         );
     }
@@ -977,6 +1231,16 @@ mod tests {
         }"#;
 
         assert!(parse_checkpoint(json).is_err());
+    }
+
+    #[test]
+    fn unknown_continuity_proof_fields_fail_closed() {
+        let checkpoint =
+            SourceWatcherCheckpoint::from_revision_bound(&revision_bound_checkpoint(7));
+        let mut value = serde_json::to_value(checkpoint).expect("checkpoint JSON value");
+        value["continuity_proof"]["unexpected"] = serde_json::json!("evidence");
+
+        assert!(parse_checkpoint(&value.to_string()).is_err());
     }
 
     #[test]
@@ -1078,7 +1342,8 @@ mod tests {
         let checkpoint = SourceWatcherCheckpoint::from_revision_bound(&expected);
         let json = serde_json::to_string(&checkpoint).expect("revision-bound checkpoint JSON");
 
-        assert!(json.contains(r#""format_version":2"#));
+        assert!(json.contains(r#""format_version":3"#));
+        assert!(json.contains(r#""backend":"fsevents""#));
         assert!(json.contains(r#""cause":"targeted_replay""#));
         assert_eq!(
             parse_checkpoint(&json)
@@ -1163,6 +1428,62 @@ mod tests {
     }
 
     #[test]
+    fn targeted_replay_requires_contiguous_matching_proof_evidence() {
+        let current_request = revision_bound_checkpoint(7);
+        let current = SourceWatcherCheckpoint::from_revision_bound(&current_request);
+
+        let mut missing_proof = revision_bound_checkpoint(8);
+        missing_proof.continuity_proof = None;
+        assert_eq!(
+            decide(Some(&current), &missing_proof),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let mut restarted = revision_bound_checkpoint(8);
+        restarted
+            .continuity_proof
+            .as_mut()
+            .expect("continuity proof")
+            .watcher_generation = 5;
+        assert_eq!(
+            decide(Some(&current), &restarted),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let mut different_device = revision_bound_checkpoint(8);
+        different_device
+            .continuity_proof
+            .as_mut()
+            .expect("continuity proof")
+            .backend_device = 11;
+        assert_eq!(
+            decide(Some(&current), &different_device),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let mut gap = revision_bound_checkpoint(8);
+        gap.continuity_proof
+            .as_mut()
+            .expect("continuity proof")
+            .replay_coverage_start_event_id = 6;
+        assert_eq!(
+            decide(Some(&current), &gap),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let mut regressed = revision_bound_checkpoint(6);
+        regressed
+            .continuity_proof
+            .as_mut()
+            .expect("continuity proof")
+            .replay_coverage_start_event_id = 5;
+        assert_eq!(
+            decide(Some(&current), &regressed),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+    }
+
+    #[test]
     fn historical_v2_baseline_allows_revision_and_lifecycle_advance() {
         let mut historical = revision_bound_checkpoint(7);
         historical.lifecycle_generation = 3;
@@ -1176,6 +1497,7 @@ mod tests {
 
         let mut equal_event_request = revision_bound_checkpoint(7);
         equal_event_request.cause = CheckpointCause::CompletedFallbackAudit;
+        equal_event_request.continuity_proof = None;
         assert_eq!(
             decide(Some(&historical), &equal_event_request),
             CheckpointAdvanceOutcome::Superseded
@@ -1208,6 +1530,7 @@ mod tests {
     fn completed_fallback_audit_establishes_or_upgrades_a_valid_cursor() {
         let mut requested = revision_bound_checkpoint(8);
         requested.cause = CheckpointCause::CompletedFallbackAudit;
+        requested.continuity_proof = None;
         let legacy = SourceWatcherCheckpoint::legacy("root-a".to_string(), 7);
 
         assert_eq!(decide(None, &requested), CheckpointAdvanceOutcome::Applied);
@@ -1228,9 +1551,60 @@ mod tests {
     }
 
     #[test]
+    fn completed_fallback_baseline_admits_the_next_targeted_proof_only_from_its_cursor() {
+        let mut fallback = revision_bound_checkpoint(7);
+        fallback.cause = CheckpointCause::CompletedFallbackAudit;
+        fallback.continuity_proof = None;
+        let current = SourceWatcherCheckpoint::from_revision_bound(&fallback);
+
+        assert_eq!(
+            decide(Some(&current), &revision_bound_checkpoint(8)),
+            CheckpointAdvanceOutcome::Applied
+        );
+
+        let mut gap = revision_bound_checkpoint(8);
+        gap.continuity_proof
+            .as_mut()
+            .expect("continuity proof")
+            .replay_coverage_start_event_id = 6;
+        assert_eq!(
+            decide(Some(&current), &gap),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+
+        let mut proofless_target = revision_bound_checkpoint(8);
+        proofless_target.continuity_proof = None;
+        assert_eq!(
+            decide(Some(&current), &proofless_target),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+    }
+
+    #[test]
+    fn completed_fallback_does_not_overwrite_a_malformed_proof() {
+        let mut malformed = revision_bound_checkpoint(7);
+        malformed
+            .continuity_proof
+            .as_mut()
+            .expect("continuity proof")
+            .acknowledged_end_event_id = 6;
+        let current = SourceWatcherCheckpoint::from_revision_bound(&malformed);
+
+        let mut fallback = revision_bound_checkpoint(8);
+        fallback.cause = CheckpointCause::CompletedFallbackAudit;
+        fallback.continuity_proof = None;
+
+        assert_eq!(
+            decide(Some(&current), &fallback),
+            CheckpointAdvanceOutcome::AuditRequired
+        );
+    }
+
+    #[test]
     fn completed_fallback_audit_never_regresses_or_crosses_root_identity() {
         let mut requested = revision_bound_checkpoint(8);
         requested.cause = CheckpointCause::CompletedFallbackAudit;
+        requested.continuity_proof = None;
 
         let mut newer = SourceWatcherCheckpoint::legacy("root-a".to_string(), 9);
         assert_eq!(
@@ -1259,6 +1633,12 @@ mod tests {
             root_identity: root_identity.to_string(),
             event_id,
             cause: CheckpointCause::TargetedReplay,
+            continuity_proof: Some(continuity_proof(
+                root_identity,
+                4,
+                event_id.saturating_sub(1),
+                event_id,
+            )),
         }
     }
 
@@ -1539,6 +1919,7 @@ mod tests {
             }
             let mut requested = owner_checkpoint(source_id, 4, 0, "root-a", 8);
             requested.cause = CheckpointCause::CompletedFallbackAudit;
+            requested.continuity_proof = None;
 
             assert_eq!(
                 write_revision_bound_checkpoint(&source, &requested, 4, "root-a"),

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -138,6 +138,7 @@ impl NativeAppState {
                 overflowed,
                 source_root_available,
                 journal_checkpoint_event_id,
+                watcher_continuity_proof,
             } => {
                 self.refresh_source_after_filesystem_change(
                     source_id,
@@ -145,6 +146,7 @@ impl NativeAppState {
                     overflowed,
                     source_root_available,
                     journal_checkpoint_event_id,
+                    watcher_continuity_proof,
                     context,
                 );
             }

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -649,6 +649,7 @@ fn source_completions_from_previous_readded_epoch_are_ignored() {
             changed_count: 1,
             root_identity: None,
             journal_checkpoint_event_id: None,
+            watcher_continuity_proof: None,
             cancelled: true,
             result: Err(String::from("old epoch cancelled")),
         }),

--- a/src/native_app/source_processing/supervisor/watcher_checkpoint.rs
+++ b/src/native_app/source_processing/supervisor/watcher_checkpoint.rs
@@ -3,7 +3,8 @@ use super::{
     source_descriptors_match,
 };
 use crate::native_app::sample_library::source_watcher::{
-    CheckpointAdvanceOutcome, RevisionBoundCheckpoint, write_revision_bound_checkpoint,
+    CheckpointAdvanceOutcome, CheckpointCause, RevisionBoundCheckpoint,
+    targeted_replay_request_has_valid_proof, write_revision_bound_checkpoint,
 };
 use wavecrate_library::filesystem_identity::stable_filesystem_identity;
 
@@ -27,6 +28,21 @@ fn process_watcher_checkpoint(shared: &Arc<Shared>, request: RevisionBoundCheckp
         );
         return;
     };
+    if request.cause == CheckpointCause::TargetedReplay
+        && !targeted_replay_request_has_valid_proof(&request)
+    {
+        tracing::debug!(
+            source_id = request.source_id.as_str(),
+            event_id = request.event_id,
+            "Rejecting targeted watcher checkpoint without a well-formed continuity proof"
+        );
+        request_source_manifest_audit(
+            shared.as_ref(),
+            request.source_id.as_str(),
+            "watcher_checkpoint_proof_missing_or_malformed",
+        );
+        return;
+    }
     let outcome = {
         let _writer = shared.database_writer.lock(DatabasePhase::Publish);
         let Some(current_source) = configured_source_for_request(shared, &request) else {
@@ -147,7 +163,9 @@ fn live_root_identity(source: &SampleSource) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::native_app::sample_library::source_watcher::CheckpointCause;
+    use crate::native_app::sample_library::source_watcher::{
+        CheckpointCause, WatcherBackend, WatcherContinuityProof,
+    };
     use crate::native_app::source_processing::SourceProcessingSupervisor;
     use std::{
         sync::atomic::Ordering,
@@ -174,9 +192,18 @@ mod tests {
             source_id: source.id.as_str().to_string(),
             lifecycle_generation,
             source_revision: 0,
-            root_identity,
+            root_identity: root_identity.clone(),
             event_id: 8,
             cause: CheckpointCause::TargetedReplay,
+            continuity_proof: Some(WatcherContinuityProof {
+                root_identity: root_identity.clone(),
+                backend: WatcherBackend::Fsevents,
+                backend_device: 10,
+                watcher_generation: 1,
+                replay_coverage_start_event_id: 7,
+                replay_coverage_end_event_id: 8,
+                acknowledged_end_event_id: 8,
+            }),
         }
     }
 
@@ -186,11 +213,20 @@ mod tests {
             &serde_json::json!({
                 "root_identity": root_identity,
                 "event_id": 7,
-                "format_version": 2,
+                "format_version": 3,
                 "source_id": source.id.as_str(),
                 "lifecycle_generation": lifecycle_generation,
                 "source_revision": 0,
-                "cause": "targeted_replay"
+                "cause": "targeted_replay",
+                "continuity_proof": {
+                    "root_identity": root_identity,
+                    "backend": "fsevents",
+                    "backend_device": 10,
+                    "watcher_generation": 1,
+                    "replay_coverage_start_event_id": 6,
+                    "replay_coverage_end_event_id": 7,
+                    "acknowledged_end_event_id": 7
+                }
             })
             .to_string(),
         );
@@ -227,6 +263,7 @@ mod tests {
             root_identity: "root-a".to_string(),
             event_id: 1,
             cause: CheckpointCause::TargetedReplay,
+            continuity_proof: None,
         };
 
         handle.submit_watcher_checkpoint(request);
@@ -268,6 +305,95 @@ mod tests {
             checkpoint_bytes(&source).expect("checkpoint bytes"),
             committed
         );
+    }
+
+    #[test]
+    fn queue_rejects_stale_watcher_generation_and_preserves_checkpoint_bytes() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = source(directory.path(), "source-a");
+        let shared = Arc::new(Shared::new(vec![source.clone()], None));
+        let lifecycle_generation = shared.control().source_lifecycle_generations["source-a"];
+        let root_identity = root_identity(&source);
+        seed_checkpoint(&source, lifecycle_generation, &root_identity);
+        let before = checkpoint_bytes(&source).expect("seeded checkpoint");
+        let mut stale = request(&source, lifecycle_generation, root_identity);
+        stale
+            .continuity_proof
+            .as_mut()
+            .expect("continuity proof")
+            .watcher_generation = 2;
+
+        let handle = super::super::SourceProcessingBudgetHandle {
+            shared: Arc::clone(&shared),
+        };
+        handle.submit_watcher_checkpoint(stale);
+        process_pending_watcher_checkpoints(&shared);
+
+        assert!(
+            shared
+                .control()
+                .force_manifest_audit_sources
+                .contains(source.id.as_str())
+        );
+        assert_eq!(checkpoint_bytes(&source).as_deref(), Some(before.as_str()));
+    }
+
+    #[test]
+    fn queue_rejects_proofless_targeted_request_at_owner_admission() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = source(directory.path(), "source-a");
+        let shared = Arc::new(Shared::new(vec![source.clone()], None));
+        let lifecycle_generation = shared.control().source_lifecycle_generations["source-a"];
+        let root_identity = root_identity(&source);
+        let mut proofless = request(&source, lifecycle_generation, root_identity);
+        proofless.continuity_proof = None;
+
+        let handle = super::super::SourceProcessingBudgetHandle {
+            shared: Arc::clone(&shared),
+        };
+        handle.submit_watcher_checkpoint(proofless);
+        process_pending_watcher_checkpoints(&shared);
+
+        assert!(
+            shared
+                .control()
+                .force_manifest_audit_sources
+                .contains(source.id.as_str())
+        );
+        assert_eq!(checkpoint_bytes(&source), None);
+    }
+
+    #[test]
+    fn queue_admits_targeted_proof_after_completed_audit_baseline() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = source(directory.path(), "source-a");
+        let shared = Arc::new(Shared::new(vec![source.clone()], None));
+        let lifecycle_generation = shared.control().source_lifecycle_generations["source-a"];
+        let root_identity = root_identity(&source);
+        let baseline = serde_json::json!({
+            "root_identity": root_identity,
+            "event_id": 7,
+            "format_version": 2,
+            "source_id": source.id.as_str(),
+            "lifecycle_generation": lifecycle_generation,
+            "source_revision": 0,
+            "cause": "completed_fallback_audit"
+        });
+        seed_checkpoint_value(&source, &baseline.to_string());
+
+        let handle = super::super::SourceProcessingBudgetHandle {
+            shared: Arc::clone(&shared),
+        };
+        handle.submit_watcher_checkpoint(request(&source, lifecycle_generation, root_identity));
+        process_pending_watcher_checkpoints(&shared);
+
+        let checkpoint = serde_json::from_str::<serde_json::Value>(
+            &checkpoint_bytes(&source).expect("targeted checkpoint"),
+        )
+        .expect("targeted checkpoint JSON");
+        assert_eq!(checkpoint["format_version"], 3);
+        assert_eq!(checkpoint["event_id"], 8);
+        assert_eq!(checkpoint["continuity_proof"]["watcher_generation"], 1);
     }
 
     #[test]

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -262,6 +262,7 @@ fn source_filesystem_change_queues_refresh_without_clearing_loaded_tree() {
             overflowed: true,
             source_root_available: true,
             journal_checkpoint_event_id: None,
+            watcher_continuity_proof: None,
         },
         &mut context,
     );
@@ -317,6 +318,7 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
             overflowed: false,
             source_root_available: true,
             journal_checkpoint_event_id: None,
+            watcher_continuity_proof: None,
         },
         &mut context,
     );

--- a/src/native_app/tests/config_sources/scan_handoff.rs
+++ b/src/native_app/tests/config_sources/scan_handoff.rs
@@ -101,6 +101,7 @@ fn foreground_scan_terminal_release_admits_coalesced_watcher_paths() {
         false,
         true,
         None,
+        None,
         &mut context,
     );
     assert!(
@@ -254,6 +255,7 @@ fn source_filesystem_change_during_scan_is_refreshed_after_scan_finishes() {
         true,
         true,
         None,
+        None,
         &mut context,
     );
 
@@ -264,6 +266,7 @@ fn source_filesystem_change_during_scan_is_refreshed_after_scan_finishes() {
             overflowed: true,
             source_root_available: true,
             journal_checkpoint_event_id: None,
+            watcher_continuity_proof: None,
         },
         &mut context,
     );


### PR DESCRIPTION
## Goal

Align Phase 3 watcher replay with the I/O architecture target by carrying typed continuity evidence into the source-processing owner before advancing the durable watcher checkpoint.

## Scope and non-goals

- Add a versioned WatcherContinuityProof containing root identity, FSEvents device identity, process-owned watcher generation, replay coverage start/end, and acknowledged end.
- Thread proof from macOS FSEvents replay through filesystem sync completion into source-processing checkpoint admission.
- Preserve legacy/V2 readability, fallback-audit baseline behavior, and fail-closed byte preservation for malformed, unknown, stale, gapped, restarted, mismatched, or proofless evidence.
- Preserve replay proof/cursor across deferred full-scan and targeted-sync boundaries; any mixed proof-bearing/proofless deferred evidence requests the existing source-scoped manifest audit.
- No Finder normalization, schema migration, UI redesign, or live-watcher behavior change beyond the typed admission fence.

## Definition of Done

- Targeted replay advances only with a well-formed proof matching source/root/revision/lifecycle and the prior acknowledged cursor.
- Deferred replay retains its proof/cursor through one compatible coalesced sync; incompatible or mixed evidence never publishes prooflessly and instead requests the scoped manifest audit.
- Completed fallback audits can establish a proofless V2 baseline; the next valid targeted proof starts at that cursor.
- Rejected evidence remains durable and requests the scoped manifest audit.
- Existing idempotency and non-macOS conservative behavior remain intact.

## Validation

All commands below were run at the exact pushed head 5b3e98ae55066248991675c20c85b43578ba03cf in an isolated validation pair using the declared Radiant revision 13ae1f524313a5257fee6691679799a1aca99d32.

- rustfmt --edition 2024 --check — passed
- git diff --check — passed
- cargo check --locked --bin wavecrate — passed
- cargo test --locked --lib native_app::app::state::source_scan_workflow — 43 passed
- cargo test --locked --lib native_app::sample_library::folder_scan_actions::filesystem_refresh — 17 passed
- cargo test --locked --lib native_app::sample_library::source_watcher — 68 passed
- cargo test --locked --lib native_app::source_processing::supervisor::watcher_checkpoint — 8 passed

## Known limitations

- Focused tests do not exercise a live FSEvents stream against a real source; native runtime acceptance remains user-owned.

User approval is required before merge.