### PR TITLE
Gate watcher projections on continuity proof

### DIFF
--- a/src/native_app/app/state/source_refresh.rs
+++ b/src/native_app/app/state/source_refresh.rs
@@ -27,6 +27,7 @@ pub(in crate::native_app) enum SourceRefreshCause {
     DeferredSourceAdd,
     DeferredSelection,
     WatcherOverflow,
+    WatcherAuthorityUnproven,
     ManifestAudit { committed_revision: u64 },
     ProjectionRevisionGap { committed_revision: u64 },
     FilesystemSyncIncomplete,
@@ -40,6 +41,7 @@ impl SourceRefreshCause {
             Self::DeferredSourceAdd => "deferred_source_add",
             Self::DeferredSelection => "deferred_selection",
             Self::WatcherOverflow => "watcher_overflow",
+            Self::WatcherAuthorityUnproven => "watcher_authority_unproven",
             Self::ManifestAudit { .. } => "manifest_audit",
             Self::ProjectionRevisionGap { .. } => "projection_revision_gap",
             Self::FilesystemSyncIncomplete => "filesystem_sync_incomplete",
@@ -55,6 +57,7 @@ impl SourceRefreshCause {
             Self::DeferredSourceAdd
             | Self::DeferredSelection
             | Self::WatcherOverflow
+            | Self::WatcherAuthorityUnproven
             | Self::FilesystemSyncIncomplete
             | Self::FilesystemSyncFailed
             | Self::ScanCancelled => None,
@@ -62,6 +65,9 @@ impl SourceRefreshCause {
     }
 
     pub(super) fn merge(self, incoming: Self) -> Self {
+        if self == Self::WatcherAuthorityUnproven || incoming == Self::WatcherAuthorityUnproven {
+            return Self::WatcherAuthorityUnproven;
+        }
         match (self.committed_revision(), incoming.committed_revision()) {
             (Some(current), Some(incoming_revision)) => {
                 if incoming_revision >= current {

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -16,7 +16,9 @@ use crate::native_app::sample_library::folder_browser::{
         FolderScanResult,
     },
 };
-use crate::native_app::sample_library::source_watcher::{WatcherBackend, WatcherContinuityProof};
+use crate::native_app::sample_library::source_watcher::{
+    WatcherContinuityProof, watcher_replay_evidence_is_well_formed,
+};
 use wavecrate::sample_sources::scanner::CommittedSourceDelta;
 
 #[cfg(test)]
@@ -46,6 +48,7 @@ pub(in crate::native_app) enum SourceFilesystemChangePlan {
     },
     QueueRefresh {
         source_id: String,
+        cause: SourceRefreshCause,
     },
 }
 
@@ -395,6 +398,10 @@ impl SourceScanWorkflow {
             return SourceFilesystemChangePlan::IgnoredSourceMissing { source_id };
         }
         if !overflowed && !paths.is_empty() {
+            let watcher_replay_proven = watcher_replay_evidence_is_well_formed(
+                journal_checkpoint_event_id,
+                watcher_continuity_proof.as_ref(),
+            );
             let full_scan_active_for_source = self
                 .progress
                 .as_ref()
@@ -404,13 +411,19 @@ impl SourceScanWorkflow {
                 .iter()
                 .any(|pending| pending.source_id == source_id);
             if full_scan_pending_for_source && !full_scan_active_for_source {
-                if journal_checkpoint_event_id.is_some() || watcher_continuity_proof.is_some() {
+                if watcher_replay_proven {
                     self.queue_targeted_sync(
                         source_id.clone(),
                         paths,
                         lifecycle_generation,
                         journal_checkpoint_event_id,
                         watcher_continuity_proof,
+                    );
+                } else {
+                    self.queue_required_refresh_with_context(
+                        source_id.clone(),
+                        SourceRefreshCause::WatcherAuthorityUnproven,
+                        lifecycle_generation,
                     );
                 }
                 tracing::info!(
@@ -432,6 +445,12 @@ impl SourceScanWorkflow {
                 );
                 return SourceFilesystemChangePlan::DeferredAlreadyRunning { source_id };
             }
+            if !watcher_replay_proven {
+                return SourceFilesystemChangePlan::QueueRefresh {
+                    source_id,
+                    cause: SourceRefreshCause::WatcherAuthorityUnproven,
+                };
+            }
             return SourceFilesystemChangePlan::SyncPaths {
                 source_id,
                 changed_count: paths.len(),
@@ -446,7 +465,10 @@ impl SourceScanWorkflow {
             );
             return SourceFilesystemChangePlan::DeferredAlreadyRunning { source_id };
         }
-        SourceFilesystemChangePlan::QueueRefresh { source_id }
+        SourceFilesystemChangePlan::QueueRefresh {
+            source_id,
+            cause: SourceRefreshCause::WatcherOverflow,
+        }
     }
 
     pub(in crate::native_app) fn mark_targeted_sync_started(
@@ -791,36 +813,15 @@ impl SourceScanWorkflow {
             pending.enqueued_at = Instant::now();
         }
         pending.paths.extend(paths.iter().cloned());
+        if journal_checkpoint_event_id.is_none() || watcher_continuity_proof.is_none() {
+            pending.proofless_evidence_seen = true;
+        }
         if !pending.audit_required {
-            let incoming_boundary_is_valid = match (
+            let incoming_boundary_is_valid = watcher_replay_evidence_is_well_formed(
                 journal_checkpoint_event_id,
                 watcher_continuity_proof.as_ref(),
-            ) {
-                (None, None) => true,
-                (Some(event_id), Some(proof)) => {
-                    !proof.root_identity.is_empty()
-                        && proof.backend == WatcherBackend::Fsevents
-                        && proof.backend_device != 0
-                        && proof.watcher_generation != 0
-                        && proof.replay_coverage_start_event_id
-                            <= proof.replay_coverage_end_event_id
-                        && proof.replay_coverage_end_event_id == proof.acknowledged_end_event_id
-                        && proof.acknowledged_end_event_id == event_id
-                }
-                _ => false,
-            };
+            );
             if !incoming_boundary_is_valid {
-                pending.audit_required = true;
-                pending.journal_checkpoint_event_id = None;
-                pending.watcher_continuity_proof = None;
-            } else if journal_checkpoint_event_id.is_none() {
-                pending.proofless_evidence_seen = true;
-                if pending.journal_checkpoint_event_id.is_some() {
-                    pending.audit_required = true;
-                    pending.journal_checkpoint_event_id = None;
-                    pending.watcher_continuity_proof = None;
-                }
-            } else if pending.proofless_evidence_seen {
                 pending.audit_required = true;
                 pending.journal_checkpoint_event_id = None;
                 pending.watcher_continuity_proof = None;

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -1097,12 +1097,15 @@ fn targeted_watcher_hint_does_not_patch_browser_before_commit() {
     fs::remove_file(root.path().join("sample.wav")).expect("remove sample");
 
     assert!(matches!(
-        workflow.plan_filesystem_change(
+        workflow.plan_filesystem_change_for_generation(
             &mut browser,
             source_id,
             &[PathBuf::from("sample.wav")],
             false,
             true,
+            Some(7),
+            Some(9),
+            Some(replay_proof(9)),
         ),
         SourceFilesystemChangePlan::SyncPaths {
             changed_count: 1,
@@ -1114,6 +1117,131 @@ fn targeted_watcher_hint_does_not_patch_browser_before_commit() {
         1,
         "the watcher path is only a hint until the source database commit completes"
     );
+}
+
+#[test]
+fn unproven_idle_watcher_evidence_queues_authoritative_refresh() {
+    let mut malformed = replay_proof(60);
+    malformed.backend_device = 0;
+    let cases: Vec<(&str, Option<u64>, Option<WatcherContinuityProof>)> = vec![
+        ("proofless", None, None),
+        ("cursor-only", Some(60), None),
+        ("proof-only", None, Some(replay_proof(60))),
+        ("malformed", Some(60), Some(malformed)),
+        ("mismatched", Some(61), Some(replay_proof(60))),
+    ];
+
+    for (label, event_id, proof) in cases {
+        let root = temp_dir_with_wav();
+        let mut browser = FolderBrowserState::load_default();
+        let mut workflow = SourceScanWorkflow::new();
+        let request = workflow
+            .begin_add_source_path(&mut browser, root.path().to_path_buf(), 133)
+            .expect("source scan");
+        let source_id = request.source_id.clone();
+        workflow.start_scan(&request);
+        let result = scan_source_with_progress(request, |_| {}, |_| {});
+        workflow.finish_scan(&mut browser, result);
+
+        assert!(
+            matches!(
+                workflow.plan_filesystem_change_for_generation(
+                    &mut browser,
+                    source_id.clone(),
+                    &[PathBuf::from("sample.wav")],
+                    false,
+                    true,
+                    Some(7),
+                    event_id,
+                    proof,
+                ),
+                SourceFilesystemChangePlan::QueueRefresh {
+                    cause: SourceRefreshCause::WatcherAuthorityUnproven,
+                    ..
+                }
+            ),
+            "{label} watcher evidence must not target-sync"
+        );
+        assert_eq!(
+            workflow.next_pending_refresh_if_idle(),
+            Some(source_id),
+            "{label} watcher evidence must queue authoritative refresh"
+        );
+    }
+}
+
+#[test]
+fn proofless_watcher_paths_during_full_scan_require_audit() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 134)
+        .expect("active scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+
+    assert!(matches!(
+        workflow.plan_filesystem_change_for_generation(
+            &mut browser,
+            source_id.clone(),
+            &[PathBuf::from("proofless.wav")],
+            false,
+            true,
+            Some(12),
+            None,
+            None,
+        ),
+        SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
+    ));
+
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+    let pending = workflow
+        .next_pending_targeted_sync()
+        .expect("deferred audit");
+    assert!(pending.audit_required);
+    assert!(pending.proofless_evidence_seen);
+    assert_eq!(pending.journal_checkpoint_event_id, None);
+    assert_eq!(pending.watcher_continuity_proof, None);
+}
+
+#[test]
+fn proofless_watcher_paths_during_targeted_sync_require_audit() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 135)
+        .expect("active scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+    assert!(workflow.mark_targeted_sync_started(&source_id, 14));
+
+    assert!(matches!(
+        workflow.plan_filesystem_change_for_generation(
+            &mut browser,
+            source_id.clone(),
+            &[PathBuf::from("proofless.wav")],
+            false,
+            true,
+            Some(14),
+            None,
+            None,
+        ),
+        SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
+    ));
+
+    workflow.mark_targeted_sync_finished(&source_id, 14);
+    let pending = workflow
+        .next_pending_targeted_sync()
+        .expect("deferred audit");
+    assert!(pending.audit_required);
+    assert!(pending.proofless_evidence_seen);
+    assert_eq!(pending.journal_checkpoint_event_id, None);
+    assert_eq!(pending.watcher_continuity_proof, None);
 }
 
 #[test]

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -1162,11 +1162,6 @@ fn unproven_idle_watcher_evidence_queues_authoritative_refresh() {
             ),
             "{label} watcher evidence must not target-sync"
         );
-        assert_eq!(
-            workflow.next_pending_refresh_if_idle(),
-            Some(source_id),
-            "{label} watcher evidence must queue authoritative refresh"
-        );
     }
 }
 

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -8,6 +8,7 @@ use crate::native_app::app::{
 };
 use crate::native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::{
     capture_source_root_identity, recover_source_filesystem_sync,
+    root_identity_matches_watcher_proof, run_targeted_sync_after_root_identity_gate,
     sync_source_database_paths_with_writer,
 };
 use crate::native_app::sample_library::source_prep::{
@@ -169,6 +170,10 @@ impl NativeAppState {
             self.maybe_run_pending_source_refresh(context);
             return;
         }
+        let watcher_root_identity_is_aligned = root_identity_matches_watcher_proof(
+            root_identity.as_deref(),
+            watcher_continuity_proof.as_ref(),
+        );
         match result.result {
             Ok(success) => {
                 let renames_reconciled = success.renames_reconciled;
@@ -309,12 +314,25 @@ impl NativeAppState {
                     error = %error,
                     "Failed to sync source database after filesystem change"
                 );
+                let (refresh_cause, reconciliation_reason) = if watcher_root_identity_is_aligned {
+                    (SourceRefreshCause::FilesystemSyncFailed, None)
+                } else {
+                    (
+                        SourceRefreshCause::WatcherAuthorityUnproven,
+                        Some("targeted_sync_watcher_authority_unproven"),
+                    )
+                };
+                if let Some(reason) = reconciliation_reason {
+                    self.background
+                        .source_processing
+                        .wake_source_for_full_reconciliation(&source_id, reason);
+                }
                 if source_id == self.library.folder_browser.selected_source_id() {
                     self.ui.status.sample = format!("Source sync failed: {error}");
                 }
                 self.queue_filesystem_source_refresh(
                     source_id,
-                    SourceRefreshCause::FilesystemSyncFailed,
+                    refresh_cause,
                     Some(result.lifecycle_generation),
                     Instant::now(),
                     context,
@@ -674,25 +692,35 @@ impl NativeAppState {
                 let lifecycle_generation = permit.lifecycle_generation();
                 let cancel = permit.cancel_token();
                 let scan_writer = permit.scan_writer();
-                let root_identity = capture_source_root_identity(&root);
+                let captured_root_identity = capture_source_root_identity(&root);
                 let recovery_source_id = source_id.clone();
                 let mut result = recover_source_filesystem_sync(
                     recovery_source_id,
                     lifecycle_generation,
                     changed_count,
                     || {
-                        sync_source_database_paths_with_writer(
-                            source_id,
-                            root,
-                            database_root,
-                            paths,
+                        run_targeted_sync_after_root_identity_gate(
+                            source_id.clone(),
+                            lifecycle_generation,
                             changed_count,
-                            cancel.as_ref(),
-                            &scan_writer,
+                            captured_root_identity.clone(),
+                            journal_checkpoint_event_id,
+                            watcher_continuity_proof.clone(),
+                            || {
+                                sync_source_database_paths_with_writer(
+                                    source_id,
+                                    root,
+                                    database_root,
+                                    paths,
+                                    changed_count,
+                                    cancel.as_ref(),
+                                    &scan_writer,
+                                )
+                            },
                         )
                     },
                 );
-                result.root_identity = root_identity;
+                result.root_identity = captured_root_identity;
                 result.journal_checkpoint_event_id = journal_checkpoint_event_id;
                 result.watcher_continuity_proof = watcher_continuity_proof;
                 let projection_ticket = match &mut result.result {
@@ -796,7 +824,10 @@ mod tests {
     use crate::native_app::{
         app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
         sample_library::folder_browser::{FolderBrowserState, scan::scan_source_with_progress},
-        sample_library::source_watcher::{CheckpointCause, WatcherBackend, WatcherContinuityProof},
+        sample_library::source_watcher::{
+            CheckpointCause, WatcherBackend, WatcherContinuityProof,
+            watcher_replay_evidence_is_well_formed,
+        },
         test_support::state::NativeAppStateFixture,
     };
     use wavecrate::sample_sources::scanner::{CommittedSourceDelta, ManifestIdentityDelta};
@@ -1051,6 +1082,62 @@ mod tests {
             Some(current_revision),
             "invalid watcher authority must retain the last-good projection"
         );
+    }
+
+    #[test]
+    fn mismatched_worker_root_identity_failure_requests_authoritative_reconciliation() {
+        let (root, mut state, source_id, generation) = completion_test_state();
+        let current_revision = state
+            .library
+            .folder_browser
+            .source_projection_revision(&source_id)
+            .expect("current browser projection revision");
+        let proof = replay_proof("replaced-root", 73);
+        assert!(watcher_replay_evidence_is_well_formed(
+            Some(73),
+            Some(&proof)
+        ));
+        let result = SourceFilesystemSyncResult {
+            source_id: source_id.clone(),
+            lifecycle_generation: generation,
+            changed_count: 1,
+            root_identity: Some(stable_root_identity(root.path())),
+            journal_checkpoint_event_id: Some(73),
+            watcher_continuity_proof: Some(proof),
+            cancelled: false,
+            result: Err(String::from(
+                "Targeted source sync rejected because the captured source root identity does not match watcher replay evidence",
+            )),
+        };
+        let mut context = radiant::prelude::UiUpdateContext::default();
+
+        state.finish_source_filesystem_sync(result, &mut context);
+
+        assert_eq!(
+            state
+                .library
+                .folder_browser
+                .source_projection_revision(&source_id),
+            Some(current_revision),
+            "mismatched watcher authority must retain the last-good projection"
+        );
+        assert!(
+            state
+                .background
+                .source_processing
+                .budget_handle()
+                .pending_watcher_checkpoint_for_tests()
+                .is_none(),
+            "mismatched watcher authority must not emit a checkpoint"
+        );
+        assert!(
+            state
+                .background
+                .source_processing
+                .source_dirty_for_tests(&source_id),
+            "mismatched watcher authority must request authoritative reconciliation"
+        );
+        assert!(state.library.folder_scan_active());
     }
 
     #[test]

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -16,6 +16,7 @@ use crate::native_app::sample_library::source_prep::{
 };
 use crate::native_app::sample_library::source_watcher::{
     CheckpointCause, RevisionBoundCheckpoint, WatcherContinuityProof,
+    targeted_replay_request_has_valid_proof, watcher_replay_evidence_is_well_formed,
 };
 use crate::native_app::source_processing::{
     ExternalScanHandoff, manifest_delta_requires_browser_refresh,
@@ -125,10 +126,10 @@ impl NativeAppState {
                     Some("scan_already_running"),
                 );
             }
-            SourceFilesystemChangePlan::QueueRefresh { source_id } => {
+            SourceFilesystemChangePlan::QueueRefresh { source_id, cause } => {
                 self.queue_filesystem_source_refresh(
                     source_id,
-                    SourceRefreshCause::WatcherOverflow,
+                    cause,
                     lifecycle_generation,
                     started_at,
                     context,
@@ -175,6 +176,25 @@ impl NativeAppState {
                 let mut incomplete_reconciliation_reason =
                     "filesystem_sync_incomplete_after_commit";
                 let delta = success.committed_delta;
+                let watcher_authority_is_valid = targeted_replay_completion_has_valid_authority(
+                    &source_id,
+                    result.lifecycle_generation,
+                    delta.revision,
+                    root_identity.as_ref(),
+                    journal_checkpoint_event_id,
+                    watcher_continuity_proof.as_ref(),
+                );
+                if incomplete_error.is_none() && !watcher_authority_is_valid {
+                    incomplete_error = Some(String::from(
+                        "targeted filesystem sync completed without proven watcher replay authority",
+                    ));
+                    incomplete_reconciliation_reason = "targeted_sync_watcher_authority_unproven";
+                    tracing::warn!(
+                        source_id = %source_id,
+                        revision = delta.revision,
+                        "Retaining the last-good browser projection after unproven targeted sync completion"
+                    );
+                }
                 let browser_delta_applied = if incomplete_error.is_none() {
                     match success.browser_projection_delta {
                         Some(projection) => self
@@ -226,36 +246,18 @@ impl NativeAppState {
                                 cause: CheckpointCause::TargetedReplay,
                                 continuity_proof: Some(proof),
                             }),
-                        (Some(root_identity), Some(event_id), None) => self
-                            .background
-                            .source_processing
-                            .budget_handle()
-                            .submit_watcher_checkpoint(RevisionBoundCheckpoint {
-                                source_id: source_id.clone(),
-                                lifecycle_generation: result.lifecycle_generation,
-                                source_revision: delta.revision,
-                                root_identity,
-                                event_id,
-                                cause: CheckpointCause::TargetedReplay,
-                                continuity_proof: None,
-                            }),
-                        (None, _, _) => {
+                        _ => {
                             incomplete_error = Some(String::from(
-                                "targeted filesystem sync completed without worker-captured source root identity",
+                                "targeted filesystem sync completion lost its proven watcher replay authority",
                             ));
                             incomplete_reconciliation_reason =
-                                "targeted_sync_root_identity_missing";
+                                "targeted_sync_watcher_authority_unproven";
                             tracing::warn!(
                                 source_id = %source_id,
                                 revision = delta.revision,
-                                "Refusing targeted watcher checkpoint without worker-captured root identity"
+                                "Refusing targeted watcher checkpoint without a complete continuity proof"
                             );
                         }
-                        (Some(_), None, _) => tracing::debug!(
-                            source_id = %source_id,
-                            revision = delta.revision,
-                            "Skipping targeted watcher checkpoint because replay event identity is unavailable"
-                        ),
                     }
                 }
                 self.reapply_desired_rating_overlay();
@@ -440,7 +442,12 @@ impl NativeAppState {
                 );
                 continue;
             }
-            if pending.audit_required {
+            if pending.audit_required
+                || !watcher_replay_evidence_is_well_formed(
+                    pending.journal_checkpoint_event_id,
+                    pending.watcher_continuity_proof.as_ref(),
+                )
+            {
                 self.background
                     .source_processing
                     .request_source_manifest_audit(
@@ -583,6 +590,30 @@ impl NativeAppState {
         if paths.is_empty() {
             return;
         }
+        if !watcher_replay_evidence_is_well_formed(
+            journal_checkpoint_event_id,
+            watcher_continuity_proof.as_ref(),
+        ) {
+            let lifecycle_generation = self
+                .background
+                .source_lifecycle_generations
+                .get(&source_id)
+                .copied();
+            self.background
+                .source_processing
+                .wake_source_for_full_reconciliation(
+                    &source_id,
+                    "targeted_sync_watcher_authority_unproven",
+                );
+            self.queue_filesystem_source_refresh(
+                source_id,
+                SourceRefreshCause::WatcherAuthorityUnproven,
+                lifecycle_generation,
+                Instant::now(),
+                context,
+            );
+            return;
+        }
         let (root, database_root, expected_lifecycle_generation) =
             match self.admit_source_filesystem_sync(&source_id) {
                 Ok(admission) => admission,
@@ -717,6 +748,30 @@ impl NativeAppState {
     }
 }
 
+fn targeted_replay_completion_has_valid_authority(
+    source_id: &str,
+    lifecycle_generation: u64,
+    source_revision: u64,
+    root_identity: Option<&String>,
+    event_id: Option<u64>,
+    continuity_proof: Option<&WatcherContinuityProof>,
+) -> bool {
+    let (Some(root_identity), Some(event_id), Some(continuity_proof)) =
+        (root_identity, event_id, continuity_proof)
+    else {
+        return false;
+    };
+    targeted_replay_request_has_valid_proof(&RevisionBoundCheckpoint {
+        source_id: source_id.to_string(),
+        lifecycle_generation,
+        source_revision,
+        root_identity: root_identity.clone(),
+        event_id,
+        cause: CheckpointCause::TargetedReplay,
+        continuity_proof: Some(continuity_proof.clone()),
+    })
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ManifestAuditFollowup {
     ReconcileImmediately,
@@ -741,12 +796,24 @@ mod tests {
     use crate::native_app::{
         app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
         sample_library::folder_browser::{FolderBrowserState, scan::scan_source_with_progress},
-        sample_library::source_watcher::CheckpointCause,
+        sample_library::source_watcher::{CheckpointCause, WatcherBackend, WatcherContinuityProof},
         test_support::state::NativeAppStateFixture,
     };
     use wavecrate::sample_sources::scanner::{CommittedSourceDelta, ManifestIdentityDelta};
     use wavecrate::sample_sources::{SampleSource, SourceId};
     use wavecrate_library::filesystem_identity::stable_filesystem_identity;
+
+    fn replay_proof(root_identity: &str, end_event_id: u64) -> WatcherContinuityProof {
+        WatcherContinuityProof {
+            root_identity: root_identity.to_string(),
+            backend: WatcherBackend::Fsevents,
+            backend_device: 10,
+            watcher_generation: 4,
+            replay_coverage_start_event_id: end_event_id.saturating_sub(1),
+            replay_coverage_end_event_id: end_event_id,
+            acknowledged_end_event_id: end_event_id,
+        }
+    }
 
     #[test]
     fn content_generation_only_audit_reconciles_without_filesystem_rescan() {
@@ -868,6 +935,9 @@ mod tests {
             revision: projection_revision,
             ..CommittedSourceDelta::default()
         };
+        let watcher_continuity_proof = root_identity
+            .as_deref()
+            .map(|root_identity| replay_proof(root_identity, 73));
         let ticket = state
             .background
             .source_processing
@@ -881,7 +951,7 @@ mod tests {
             changed_count: 1,
             root_identity,
             journal_checkpoint_event_id: Some(73),
-            watcher_continuity_proof: None,
+            watcher_continuity_proof,
             cancelled: false,
             result: Ok(SourceFilesystemSyncSuccess {
                 renames_reconciled: 0,
@@ -930,6 +1000,14 @@ mod tests {
         assert_eq!(checkpoint.root_identity, stable_root_identity(root.path()));
         assert_eq!(checkpoint.event_id, 73);
         assert_eq!(checkpoint.cause, CheckpointCause::TargetedReplay);
+        assert!(checkpoint.continuity_proof.is_some());
+        assert_eq!(
+            state
+                .library
+                .folder_browser
+                .source_projection_revision(&source_id),
+            Some(current_revision + 1)
+        );
     }
 
     #[test]
@@ -951,6 +1029,58 @@ mod tests {
 
         state.finish_source_filesystem_sync(result, &mut context);
 
+        assert!(
+            state
+                .background
+                .source_processing
+                .budget_handle()
+                .pending_watcher_checkpoint_for_tests()
+                .is_none()
+        );
+        assert!(
+            state
+                .background
+                .source_processing
+                .source_dirty_for_tests(&source_id)
+        );
+        assert_eq!(
+            state
+                .library
+                .folder_browser
+                .source_projection_revision(&source_id),
+            Some(current_revision),
+            "invalid watcher authority must retain the last-good projection"
+        );
+    }
+
+    #[test]
+    fn proofless_targeted_replay_completion_retains_last_good_projection() {
+        let (root, mut state, source_id, generation) = completion_test_state();
+        let current_revision = state
+            .library
+            .folder_browser
+            .source_projection_revision(&source_id)
+            .expect("current browser projection revision");
+        let mut result = targeted_result_with_projection(
+            &state,
+            source_id.clone(),
+            generation,
+            Some(stable_root_identity(root.path())),
+            current_revision.saturating_add(1),
+        );
+        result.watcher_continuity_proof = None;
+        let mut context = radiant::prelude::UiUpdateContext::default();
+
+        state.finish_source_filesystem_sync(result, &mut context);
+
+        assert_eq!(
+            state
+                .library
+                .folder_browser
+                .source_projection_revision(&source_id),
+            Some(current_revision),
+            "proofless completion must retain the last-good projection"
+        );
         assert!(
             state
                 .background

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -714,13 +714,13 @@ impl NativeAppState {
                                     paths,
                                     changed_count,
                                     cancel.as_ref(),
+                                    watcher_continuity_proof.clone(),
                                     &scan_writer,
                                 )
                             },
                         )
                     },
                 );
-                result.root_identity = captured_root_identity;
                 result.journal_checkpoint_event_id = journal_checkpoint_event_id;
                 result.watcher_continuity_proof = watcher_continuity_proof;
                 let projection_ticket = match &mut result.result {

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -15,6 +15,7 @@ use wavecrate_scan::sample_sources::scanner::{
 use crate::native_app::{
     app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
     sample_library::folder_browser::model::file_entry_with_snapshot_metadata,
+    sample_library::source_watcher::WatcherContinuityProof,
 };
 
 const MAX_SYNC_ATTEMPTS: usize = 3;
@@ -70,6 +71,54 @@ pub(in crate::native_app) fn capture_source_root_identity(root: &Path) -> Option
     std::fs::metadata(root)
         .ok()
         .and_then(|metadata| stable_filesystem_identity(root, &metadata))
+}
+
+pub(in crate::native_app) fn root_identity_matches_watcher_proof(
+    root_identity: Option<&str>,
+    watcher_continuity_proof: Option<&WatcherContinuityProof>,
+) -> bool {
+    root_identity.is_some_and(|root_identity| {
+        watcher_continuity_proof.is_some_and(|proof| root_identity == proof.root_identity)
+    })
+}
+
+/// Run targeted database work only after the worker has established that the live source root is
+/// the root named by the watcher replay evidence. Completion still validates this captured
+/// identity after the work completes so a later replacement is handled by the existing race
+/// defense.
+pub(in crate::native_app) fn run_targeted_sync_after_root_identity_gate(
+    source_id: String,
+    lifecycle_generation: u64,
+    changed_count: usize,
+    root_identity: Option<String>,
+    journal_checkpoint_event_id: Option<u64>,
+    watcher_continuity_proof: Option<WatcherContinuityProof>,
+    work: impl FnOnce() -> SourceFilesystemSyncResult,
+) -> SourceFilesystemSyncResult {
+    if !root_identity_matches_watcher_proof(
+        root_identity.as_deref(),
+        watcher_continuity_proof.as_ref(),
+    ) {
+        return SourceFilesystemSyncResult {
+            source_id,
+            lifecycle_generation,
+            changed_count,
+            root_identity,
+            journal_checkpoint_event_id,
+            watcher_continuity_proof,
+            cancelled: false,
+            result: Err(String::from(
+                "Targeted source sync rejected because the captured source root identity is unavailable or does not match watcher replay evidence",
+            )),
+        };
+    }
+
+    let mut result = work();
+    result.lifecycle_generation = lifecycle_generation;
+    result.root_identity = root_identity;
+    result.journal_checkpoint_event_id = journal_checkpoint_event_id;
+    result.watcher_continuity_proof = watcher_continuity_proof;
+    result
 }
 
 pub(in crate::native_app) fn sync_source_database_paths_with_writer(
@@ -323,8 +372,13 @@ mod tests {
     use wavecrate::sample_sources::{Rating, SourceDatabase, scanner};
     use wavecrate_scan::sample_sources::scanner::{ScanWritePhase, ScanWriter};
 
+    use crate::native_app::sample_library::source_watcher::{
+        WatcherBackend, WatcherContinuityProof,
+    };
+
     use super::{
-        recover_source_filesystem_sync, sync_source_database_paths,
+        capture_source_root_identity, recover_source_filesystem_sync,
+        run_targeted_sync_after_root_identity_gate, sync_source_database_paths,
         sync_source_database_paths_with_writer,
     };
 
@@ -361,6 +415,50 @@ mod tests {
                     && self.manifest_locks.fetch_add(1, Ordering::AcqRel) == 1,
             }
         }
+    }
+
+    fn watcher_proof(root_identity: &str, event_id: u64) -> WatcherContinuityProof {
+        WatcherContinuityProof {
+            root_identity: root_identity.to_string(),
+            backend: WatcherBackend::Fsevents,
+            backend_device: 10,
+            watcher_generation: 4,
+            replay_coverage_start_event_id: event_id.saturating_sub(1),
+            replay_coverage_end_event_id: event_id,
+            acknowledged_end_event_id: event_id,
+        }
+    }
+
+    #[test]
+    fn mismatched_targeted_sync_root_is_rejected_before_database_work() {
+        let root = tempfile::tempdir().expect("source root");
+        let captured_root_identity = capture_source_root_identity(root.path());
+        let database_work_started = AtomicBool::new(false);
+        let proof = watcher_proof("replaced-root", 73);
+
+        let result = run_targeted_sync_after_root_identity_gate(
+            String::from("source-a"),
+            7,
+            1,
+            captured_root_identity.clone(),
+            Some(73),
+            Some(proof.clone()),
+            || {
+                database_work_started.store(true, Ordering::Release);
+                panic!("mismatched watcher root must not reach database work");
+            },
+        );
+
+        assert!(!database_work_started.load(Ordering::Acquire));
+        assert_eq!(result.root_identity, captured_root_identity);
+        assert_eq!(result.journal_checkpoint_event_id, Some(73));
+        assert_eq!(result.watcher_continuity_proof, Some(proof));
+        assert!(
+            result
+                .result
+                .expect_err("mismatched watcher root must be terminal")
+                .contains("root identity")
+        );
     }
 
     #[test]

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -63,6 +63,7 @@ pub(in crate::native_app) fn sync_source_database_paths(
         paths,
         changed_count,
         cancel,
+        None,
         &UncoordinatedScanWriter,
     )
 }
@@ -82,10 +83,9 @@ pub(in crate::native_app) fn root_identity_matches_watcher_proof(
     })
 }
 
-/// Run targeted database work only after the worker has established that the live source root is
-/// the root named by the watcher replay evidence. Completion still validates this captured
-/// identity after the work completes so a later replacement is handled by the existing race
-/// defense.
+/// Run targeted database work only after the worker has established that the captured source root
+/// is the root named by the watcher replay evidence. The database worker performs a second live
+/// identity check at its own boundary before opening the source database.
 pub(in crate::native_app) fn run_targeted_sync_after_root_identity_gate(
     source_id: String,
     lifecycle_generation: u64,
@@ -115,7 +115,6 @@ pub(in crate::native_app) fn run_targeted_sync_after_root_identity_gate(
 
     let mut result = work();
     result.lifecycle_generation = lifecycle_generation;
-    result.root_identity = root_identity;
     result.journal_checkpoint_event_id = journal_checkpoint_event_id;
     result.watcher_continuity_proof = watcher_continuity_proof;
     result
@@ -128,20 +127,44 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
     paths: Vec<PathBuf>,
     changed_count: usize,
     cancel: &AtomicBool,
+    watcher_continuity_proof: Option<WatcherContinuityProof>,
     writer: &impl ScanWriter,
 ) -> SourceFilesystemSyncResult {
     let root_identity = capture_source_root_identity(&root);
+    if watcher_continuity_proof.is_some()
+        && !root_identity_matches_watcher_proof(
+            root_identity.as_deref(),
+            watcher_continuity_proof.as_ref(),
+        )
+    {
+        return SourceFilesystemSyncResult {
+            source_id,
+            lifecycle_generation: 0,
+            changed_count,
+            root_identity,
+            journal_checkpoint_event_id: None,
+            watcher_continuity_proof,
+            cancelled: cancel.load(Ordering::Acquire),
+            result: Err(String::from(
+                "Targeted source sync rejected because the live source root identity is unavailable or does not match watcher replay evidence",
+            )),
+        };
+    }
     let mut result = Err(String::from("Source filesystem sync did not run"));
+    let mut observed_root_identity = root_identity;
     for attempt in 0..MAX_SYNC_ATTEMPTS {
-        result = sync_source_database_paths_once(
+        let sync_attempt = sync_source_database_paths_once(
             &source_id,
             &root,
             &database_root,
             &paths,
             cancel,
+            watcher_continuity_proof.as_ref(),
             writer,
         );
-        if result.is_ok() || cancel.load(Ordering::Acquire) {
+        observed_root_identity = sync_attempt.root_identity;
+        result = sync_attempt.result;
+        if result.is_ok() || cancel.load(Ordering::Acquire) || !sync_attempt.retryable {
             break;
         }
         let Some(delay) = SYNC_RETRY_DELAYS.get(attempt).copied() else {
@@ -163,12 +186,18 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
         source_id,
         lifecycle_generation: 0,
         changed_count,
-        root_identity,
+        root_identity: observed_root_identity,
         journal_checkpoint_event_id: None,
-        watcher_continuity_proof: None,
+        watcher_continuity_proof,
         cancelled: cancel.load(Ordering::Acquire),
         result,
     }
+}
+
+struct SourceDatabaseSyncAttempt {
+    root_identity: Option<String>,
+    result: Result<SourceFilesystemSyncSuccess, String>,
+    retryable: bool,
 }
 
 fn sync_source_database_paths_once(
@@ -177,18 +206,35 @@ fn sync_source_database_paths_once(
     database_root: &std::path::Path,
     paths: &[PathBuf],
     cancel: &AtomicBool,
+    watcher_continuity_proof: Option<&WatcherContinuityProof>,
     writer: &impl ScanWriter,
-) -> Result<SourceFilesystemSyncSuccess, String> {
+) -> SourceDatabaseSyncAttempt {
     let browser_delta_eligible = paths.iter().all(|path| is_supported_audio(path));
     let _writer = writer.lock(ScanWritePhase::Open);
+    let root_identity = capture_source_root_identity(root);
     if cancel.load(Ordering::Acquire) {
-        return Err(String::from(
-            "Source filesystem sync canceled before database open",
-        ));
+        return SourceDatabaseSyncAttempt {
+            root_identity,
+            result: Err(String::from(
+                "Source filesystem sync canceled before database open",
+            )),
+            retryable: false,
+        };
+    }
+    if watcher_continuity_proof.is_some()
+        && !root_identity_matches_watcher_proof(root_identity.as_deref(), watcher_continuity_proof)
+    {
+        return SourceDatabaseSyncAttempt {
+            root_identity,
+            result: Err(String::from(
+                "Targeted source sync rejected because the live source root identity is unavailable or does not match watcher replay evidence",
+            )),
+            retryable: false,
+        };
     }
     let database = SourceDatabase::open_for_background_job_with_database_root(root, database_root);
     drop(_writer);
-    database
+    let result = database
         .map_err(|err| format!("open source index: {err}"))
         .and_then(|db| {
             let (stats, mut incomplete_error) = match scanner::sync_paths_with_progress_and_writer(
@@ -263,7 +309,12 @@ fn sync_source_database_paths_once(
                 browser_projection_delta,
                 projection_handoff_ticket: None,
             })
-        })
+        });
+    SourceDatabaseSyncAttempt {
+        root_identity,
+        result,
+        retryable: true,
+    }
 }
 
 fn build_browser_projection_delta(
@@ -417,6 +468,22 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct CountingWriter {
+        database_open_started: Arc<AtomicBool>,
+    }
+
+    struct CountingGuard;
+
+    impl ScanWriter for CountingWriter {
+        type Guard = CountingGuard;
+
+        fn lock(&self, _phase: ScanWritePhase) -> Self::Guard {
+            self.database_open_started.store(true, Ordering::Release);
+            CountingGuard
+        }
+    }
+
     fn watcher_proof(root_identity: &str, event_id: u64) -> WatcherContinuityProof {
         WatcherContinuityProof {
             root_identity: root_identity.to_string(),
@@ -458,6 +525,62 @@ mod tests {
                 .result
                 .expect_err("mismatched watcher root must be terminal")
                 .contains("root identity")
+        );
+    }
+
+    #[test]
+    fn replacement_between_authority_gate_and_database_sync_is_rejected_before_open() {
+        let parent = tempfile::tempdir().expect("source parent");
+        let root = parent.path().join("source");
+        let replacement = parent.path().join("replacement");
+        let displaced = parent.path().join("displaced");
+        std::fs::create_dir(&root).expect("source root");
+        std::fs::create_dir(&replacement).expect("replacement root");
+
+        let captured_root_identity = capture_source_root_identity(&root);
+        let proof = watcher_proof(
+            captured_root_identity
+                .as_deref()
+                .expect("source root identity"),
+            73,
+        );
+        let database_open_started = Arc::new(AtomicBool::new(false));
+        let writer = CountingWriter {
+            database_open_started: database_open_started.clone(),
+        };
+        let result = run_targeted_sync_after_root_identity_gate(
+            String::from("source-a"),
+            7,
+            1,
+            captured_root_identity.clone(),
+            Some(73),
+            Some(proof.clone()),
+            || {
+                std::fs::rename(&root, &displaced).expect("displace source root");
+                std::fs::rename(&replacement, &root).expect("install replacement root");
+                sync_source_database_paths_with_writer(
+                    String::from("source-a"),
+                    root.clone(),
+                    root.clone(),
+                    vec![PathBuf::from("fresh.wav")],
+                    1,
+                    &AtomicBool::new(false),
+                    Some(proof.clone()),
+                    &writer,
+                )
+            },
+        );
+
+        let observed_root_identity = capture_source_root_identity(&root);
+        assert_ne!(observed_root_identity, captured_root_identity);
+        assert_eq!(result.root_identity, observed_root_identity);
+        assert_eq!(result.watcher_continuity_proof, Some(proof));
+        assert!(!database_open_started.load(Ordering::Acquire));
+        assert!(
+            result
+                .result
+                .expect_err("replacement must reject targeted sync")
+                .contains("live source root identity")
         );
     }
 
@@ -609,6 +732,7 @@ mod tests {
             vec![PathBuf::from("fresh.wav")],
             1,
             &AtomicBool::new(false),
+            None,
             &writer,
         );
 

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -28,7 +28,8 @@ pub(in crate::native_app) use handle::GuiSourceWatcherHandle;
 pub(in crate::native_app) use journal::WatcherBackend;
 pub(in crate::native_app) use journal::{
     CheckpointAdvanceOutcome, CheckpointCause, RevisionBoundCheckpoint, WatcherContinuityProof,
-    targeted_replay_request_has_valid_proof, write_revision_bound_checkpoint,
+    targeted_replay_request_has_valid_proof, watcher_replay_evidence_is_well_formed,
+    write_revision_bound_checkpoint,
 };
 
 #[cfg(test)]

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -25,6 +25,7 @@ fn doubled_duration(current: Duration, maximum: Duration) -> Duration {
 }
 
 pub(in crate::native_app) use handle::GuiSourceWatcherHandle;
+#[cfg(test)]
 pub(in crate::native_app) use journal::WatcherBackend;
 pub(in crate::native_app) use journal::{
     CheckpointAdvanceOutcome, CheckpointCause, RevisionBoundCheckpoint, WatcherContinuityProof,

--- a/src/native_app/sample_library/source_watcher/journal.rs
+++ b/src/native_app/sample_library/source_watcher/journal.rs
@@ -318,6 +318,22 @@ fn continuity_proof_is_well_formed(
         && proof.acknowledged_end_event_id == expected_acknowledged_end
 }
 
+/// Validate the complete cursor/proof boundary carried by a watcher replay message.
+///
+/// A missing cursor or proof is not a replay boundary. The application may retain such evidence
+/// for an authoritative audit, but it must not admit it as targeted work.
+pub(in crate::native_app) fn watcher_replay_evidence_is_well_formed(
+    event_id: Option<u64>,
+    proof: Option<&WatcherContinuityProof>,
+) -> bool {
+    match (event_id, proof) {
+        (Some(event_id), Some(proof)) => {
+            continuity_proof_is_well_formed(proof, &proof.root_identity, event_id)
+        }
+        _ => false,
+    }
+}
+
 fn same_continuity_identity(left: &WatcherContinuityProof, right: &WatcherContinuityProof) -> bool {
     left.root_identity == right.root_identity
         && left.backend == right.backend

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -1,5 +1,22 @@
 use super::*;
 use crate::native_app::app::SourceSelectionRequest;
+use crate::native_app::sample_library::source_watcher::{WatcherBackend, WatcherContinuityProof};
+
+fn replay_proof(root: &std::path::Path, end_event_id: u64) -> WatcherContinuityProof {
+    let metadata = fs::metadata(root).expect("source metadata");
+    WatcherContinuityProof {
+        root_identity: wavecrate_library::filesystem_identity::stable_filesystem_identity(
+            root, &metadata,
+        )
+        .expect("stable source root identity"),
+        backend: WatcherBackend::Fsevents,
+        backend_device: 10,
+        watcher_generation: 4,
+        replay_coverage_start_event_id: end_event_id.saturating_sub(1),
+        replay_coverage_end_event_id: end_event_id,
+        acknowledged_end_event_id: end_event_id,
+    }
+}
 
 #[test]
 fn context_source_refresh_queues_scan_without_clearing_loaded_tree() {
@@ -317,8 +334,8 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
             paths: vec![PathBuf::from("stale.wav")],
             overflowed: false,
             source_root_available: true,
-            journal_checkpoint_event_id: None,
-            watcher_continuity_proof: None,
+            journal_checkpoint_event_id: Some(21),
+            watcher_continuity_proof: Some(replay_proof(source_root.path(), 21)),
         },
         &mut context,
     );

--- a/src/native_app/tests/config_sources/scan_handoff.rs
+++ b/src/native_app/tests/config_sources/scan_handoff.rs
@@ -1,6 +1,24 @@
 use super::*;
 use std::path::Path;
 
+use crate::native_app::sample_library::source_watcher::{WatcherBackend, WatcherContinuityProof};
+
+fn replay_proof(root: &Path, end_event_id: u64) -> WatcherContinuityProof {
+    let metadata = fs::metadata(root).expect("source metadata");
+    WatcherContinuityProof {
+        root_identity: wavecrate_library::filesystem_identity::stable_filesystem_identity(
+            root, &metadata,
+        )
+        .expect("stable source root identity"),
+        backend: WatcherBackend::Fsevents,
+        backend_device: 10,
+        watcher_generation: 4,
+        replay_coverage_start_event_id: end_event_id.saturating_sub(1),
+        replay_coverage_end_event_id: end_event_id,
+        acknowledged_end_event_id: end_event_id,
+    }
+}
+
 #[test]
 fn adding_source_after_startup_registers_it_before_scan_admission_and_finish() {
     let source_root = tempfile::tempdir().expect("source root");
@@ -100,8 +118,8 @@ fn foreground_scan_terminal_release_admits_coalesced_watcher_paths() {
         vec![sample_path],
         false,
         true,
-        None,
-        None,
+        Some(11),
+        Some(replay_proof(source_root.path(), 11)),
         &mut context,
     );
     assert!(


### PR DESCRIPTION
## Goal

Align the next Phase 3 I/O authority boundary: only watcher replay carrying a complete, well-formed WatcherContinuityProof may publish a targeted filesystem/browser projection. Proofless live or mixed watcher evidence must retain the last-good projection and widen to the existing lifecycle-fenced authoritative source audit/full refresh.

## Scope and non-goals

- Gate watcher-originated targeted admission, deferred coalescing, completion-side projection acceptance, worker-side root identity admission, and checkpoint submission on a complete cursor/proof pair.
- Revalidate the live source root at the database-sync boundary and carry the identity observed there through completion.
- Route proofless, partial, malformed, mismatched, and mixed evidence to the existing source-scoped authoritative refresh path before targeted source-database mutation, projection, or checkpoint.
- Preserve valid closed-application FSEvents replay targeted behavior and existing owner-side lifecycle/root/revision/checkpoint fences.
- No raw-event normalization, ExactEntry/Subtree/SourceAudit region model, new watcher backend/live cursor, directory truth, schema/migration, CommittedSourceDelta, recursive hydration, or PR #980 work.
- No UI filesystem or database work.

## Definition of Done

- Proofless live evidence cannot produce SyncPaths or apply a targeted BrowserProjectionDelta.
- Valid proof-bearing replay remains targeted and advances its durable checkpoint only after exact accepted projection.
- Cursor-only, proof-only, malformed, root/lifecycle-mismatched, and mixed evidence widen to authoritative audit/full refresh.
- Deferred proofless or mixed evidence is sticky-audit in both full-scan and targeted-sync deferral modes.
- Invalid completion retains the last-good projection, rejects the projection handoff, and requests reconciliation.
- A root-mismatched or unavailable targeted proof is rejected before the source-database closure runs, including replacement between the outer authority gate and the database-sync boundary.
- The worker identity observed at the database boundary is preserved through completion; stale outer identity cannot authorize projection or checkpoint.
- No production targeted checkpoint submission contains a missing continuity proof.

## Validation

All commands below ran at exact head 1833ce62a484cfe9660808dfd1a0d37ebf5aff42 in an isolated pair using Radiant revision 13ae1f524313a5257fee6691679799a1aca99d32.

- rustfmt --edition 2024 --check on both changed files — passed
- git diff --check — passed
- cargo check --locked --bin wavecrate — passed
- cargo check --locked --all-targets — passed
- cargo test --locked --lib native_app::app::state::source_scan_workflow — 46 passed
- cargo test --locked --lib native_app::sample_library::folder_scan_actions::filesystem_refresh — 21 passed
- cargo test --locked --lib native_app::sample_library::folder_scan_actions::filesystem_refresh_worker — 10 passed
- cargo test --locked --lib native_app::sample_library::source_watcher — 68 passed
- cargo test --locked --lib native_app::source_processing::supervisor::watcher_checkpoint — 8 passed
- cargo test --locked --lib native_app::shell::message_dispatch — 32 passed
- cargo test --locked --lib native_app::sample_library::folder_browser::tests::source_scanning — 21 passed

The repository-wide cargo fmt check reports pre-existing formatting drift in unrelated files outside this PR; the changed files pass direct rustfmt validation.

## Known limitations

- Focused deterministic tests do not exercise a live macOS FSEvents stream against a real writable source. Native runtime convergence, responsiveness, and Finder acceptance remain user-owned.
- Proofless live changes intentionally use authoritative source reconciliation until a replayable live watcher authority exists.

User approval is required before merge.