### PR TITLE
Add pure Finder reconciliation model

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -10,6 +10,8 @@ pub mod db;
 pub mod library;
 /// Durable source-readiness and convergence coordination contracts.
 pub mod readiness;
+/// Backend-neutral Finder observation reconciliation contracts.
+pub mod reconciliation;
 mod source_entry;
 
 pub use audio_support::{

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
@@ -1,0 +1,20 @@
+//! Pure, backend-neutral Finder observation modeling and normalization.
+
+mod model;
+mod normalize;
+
+#[cfg(test)]
+mod tests;
+
+pub use model::{
+    BackendStreamIdentity, CaptureBoundary, DurablePriorAcknowledgement, ObservationUncertainty,
+    Proof, RawEnvelopeCounter, RawEnvelopeError, RawEnvelopeLimit, RawEventKind, RawObservation,
+    RawObservationAccounting, RawObservationEnvelope, RawObservationLimits, RawObservationMetadata,
+    RawObservationProvenance, RawObservedPath, RawPathHint, RawPathRole, ReplayCoverage,
+    RootIdentity, RootRelativePath, RootRelativePathError, WatcherContinuityProof,
+    WatcherGeneration,
+};
+pub use normalize::{
+    NormalizationReason, NormalizedObservation, ReconciliationScope, ReconciliationScopeKind,
+    normalize_observation,
+};

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/model.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/model.rs
@@ -1,0 +1,1132 @@
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::ops::{BitOr, BitOrAssign};
+use std::path::{Component, Path, PathBuf};
+
+use crate::sample_sources::SourceId;
+
+/// Which envelope budget was exceeded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RawEnvelopeLimit {
+    /// The number of raw observations.
+    EventCount,
+    /// The sum of native path spelling bytes.
+    PathBytes,
+    /// The sum of encoded observation metadata bytes.
+    MetadataBytes,
+}
+
+impl RawEnvelopeLimit {
+    fn label(self) -> &'static str {
+        match self {
+            Self::EventCount => "event count",
+            Self::PathBytes => "path bytes",
+            Self::MetadataBytes => "metadata bytes",
+        }
+    }
+}
+
+/// Which checked accounting counter overflowed while building an envelope.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RawEnvelopeCounter {
+    /// The event-count accumulator.
+    EventCount,
+    /// The native path-byte accumulator.
+    PathBytes,
+    /// The metadata-byte accumulator.
+    MetadataBytes,
+    /// A capture sequence boundary increment.
+    Sequence,
+}
+
+impl RawEnvelopeCounter {
+    fn label(self) -> &'static str {
+        match self {
+            Self::EventCount => "event count",
+            Self::PathBytes => "path bytes",
+            Self::MetadataBytes => "metadata bytes",
+            Self::Sequence => "capture sequence",
+        }
+    }
+}
+
+/// Errors returned by checked reconciliation model constructors.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RawEnvelopeError {
+    /// The envelope must retain at least one raw observation.
+    EmptyEnvelope,
+    /// An event limit of zero cannot admit a non-empty envelope.
+    ZeroEventLimit,
+    /// A bounded accounting counter exceeded its configured limit.
+    LimitExceeded {
+        /// Counter that exceeded its limit.
+        limit: RawEnvelopeLimit,
+        /// Exact observed value.
+        actual: usize,
+        /// Configured maximum.
+        maximum: usize,
+    },
+    /// A checked accounting operation overflowed `usize` or a sequence increment overflowed `u64`.
+    ArithmeticOverflow {
+        /// Counter whose checked operation overflowed.
+        counter: RawEnvelopeCounter,
+    },
+    /// Capture sequence boundaries were supplied in reverse order.
+    InvalidCaptureBoundary,
+    /// A continuity proof was requested without a physical root identity.
+    MissingRootIdentity,
+    /// A continuity proof was requested without a backend stream identity.
+    MissingBackendStreamIdentity,
+    /// A continuity proof was requested without a durable prior acknowledgement.
+    MissingPriorAcknowledgement,
+    /// A continuity proof was requested without replay coverage.
+    MissingReplayCoverage,
+    /// Replay coverage did not describe a contiguous interval after the acknowledgement.
+    GappedReplayCoverage,
+    /// Replay coverage did not end at the envelope's capture boundary.
+    CoverageBoundaryMismatch,
+    /// A proof's source, root, stream, or generation did not match its envelope provenance.
+    ProofMismatch,
+}
+
+impl fmt::Display for RawEnvelopeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyEnvelope => formatter.write_str("raw observation envelope is empty"),
+            Self::ZeroEventLimit => formatter.write_str("raw observation event limit is zero"),
+            Self::LimitExceeded {
+                limit,
+                actual,
+                maximum,
+            } => write!(
+                formatter,
+                "raw observation {} limit exceeded: {} > {}",
+                limit.label(),
+                actual,
+                maximum
+            ),
+            Self::ArithmeticOverflow { counter } => {
+                write!(
+                    formatter,
+                    "raw observation {} accounting overflowed",
+                    counter.label()
+                )
+            }
+            Self::InvalidCaptureBoundary => {
+                formatter.write_str("capture sequence boundaries are not ordered")
+            }
+            Self::MissingRootIdentity => {
+                formatter.write_str("continuity proof requires a physical root identity")
+            }
+            Self::MissingBackendStreamIdentity => {
+                formatter.write_str("continuity proof requires a backend stream identity")
+            }
+            Self::MissingPriorAcknowledgement => {
+                formatter.write_str("continuity proof requires a durable prior acknowledgement")
+            }
+            Self::MissingReplayCoverage => {
+                formatter.write_str("continuity proof requires replay coverage")
+            }
+            Self::GappedReplayCoverage => {
+                formatter.write_str("replay coverage is not contiguous after the acknowledgement")
+            }
+            Self::CoverageBoundaryMismatch => {
+                formatter.write_str("replay coverage does not match the capture boundary")
+            }
+            Self::ProofMismatch => {
+                formatter.write_str("continuity proof does not match provenance")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RawEnvelopeError {}
+
+/// Why a root-relative path cannot be admitted as a dispatchable path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RootRelativePathError {
+    /// The path has no native spelling.
+    Empty,
+    /// The path is absolute.
+    Absolute,
+    /// The path is rooted without a relative root identity.
+    Rooted,
+    /// The path contains a parent traversal component.
+    ParentTraversal,
+    /// The path contains a platform prefix such as a drive or UNC prefix.
+    PlatformPrefix,
+    /// The path contains only `.` components and therefore names the root rather than an entry.
+    NoNormalComponent,
+}
+
+impl fmt::Display for RootRelativePathError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::Empty => "path is empty",
+            Self::Absolute => "path is absolute",
+            Self::Rooted => "path is rooted",
+            Self::ParentTraversal => "path contains parent traversal",
+            Self::PlatformPrefix => "path contains a platform prefix",
+            Self::NoNormalComponent => "path has no normal component",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for RootRelativePathError {}
+
+/// Opaque physical identity for a configured source root.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RootIdentity(Vec<u8>);
+
+impl RootIdentity {
+    /// Construct an opaque root identity from backend-supplied bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the backend-supplied identity bytes without decoding them.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Opaque identity for one backend watcher stream.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BackendStreamIdentity(Vec<u8>);
+
+impl BackendStreamIdentity {
+    /// Construct an opaque backend stream identity from backend-supplied bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the backend-supplied stream identity bytes without decoding them.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Monotonic watcher generation supplied by admission/lifecycle ownership.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct WatcherGeneration(u64);
+
+impl WatcherGeneration {
+    /// Construct a watcher generation value.
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Return the generation number.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Capture-time and optional sequence boundaries supplied by the observing process.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CaptureBoundary {
+    captured_at: u64,
+    first_sequence: Option<u64>,
+    last_sequence: Option<u64>,
+}
+
+impl CaptureBoundary {
+    /// Construct a capture boundary without consulting a clock.
+    pub fn try_new(
+        captured_at: u64,
+        first_sequence: Option<u64>,
+        last_sequence: Option<u64>,
+    ) -> Result<Self, RawEnvelopeError> {
+        if let (Some(first), Some(last)) = (first_sequence, last_sequence)
+            && first > last
+        {
+            return Err(RawEnvelopeError::InvalidCaptureBoundary);
+        }
+        Ok(Self {
+            captured_at,
+            first_sequence,
+            last_sequence,
+        })
+    }
+
+    /// Return the process-supplied capture timestamp or opaque capture marker.
+    pub const fn captured_at(self) -> u64 {
+        self.captured_at
+    }
+
+    /// Return the first optional sequence admitted by this capture.
+    pub const fn first_sequence(self) -> Option<u64> {
+        self.first_sequence
+    }
+
+    /// Return the last optional sequence admitted by this capture.
+    pub const fn last_sequence(self) -> Option<u64> {
+        self.last_sequence
+    }
+}
+
+/// Origin metadata for one bounded raw observation envelope.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawObservationProvenance {
+    source_id: SourceId,
+    root_identity: Option<RootIdentity>,
+    backend_stream_identity: Option<BackendStreamIdentity>,
+    watcher_generation: WatcherGeneration,
+    capture_boundary: CaptureBoundary,
+}
+
+impl RawObservationProvenance {
+    /// Bind provenance to one source, optional physical root, backend stream, generation, and capture boundary.
+    pub fn new(
+        source_id: SourceId,
+        root_identity: Option<RootIdentity>,
+        backend_stream_identity: Option<BackendStreamIdentity>,
+        watcher_generation: WatcherGeneration,
+        capture_boundary: CaptureBoundary,
+    ) -> Self {
+        Self {
+            source_id,
+            root_identity,
+            backend_stream_identity,
+            watcher_generation,
+            capture_boundary,
+        }
+    }
+
+    /// Borrow the associated source identifier.
+    pub fn source_id(&self) -> &SourceId {
+        &self.source_id
+    }
+
+    /// Borrow the physical root identity when the backend supplied one.
+    pub fn root_identity(&self) -> Option<&RootIdentity> {
+        self.root_identity.as_ref()
+    }
+
+    /// Borrow the backend stream identity when the backend supplied one.
+    pub fn backend_stream_identity(&self) -> Option<&BackendStreamIdentity> {
+        self.backend_stream_identity.as_ref()
+    }
+
+    /// Return the watcher generation that admitted this envelope.
+    pub const fn watcher_generation(&self) -> WatcherGeneration {
+        self.watcher_generation
+    }
+
+    /// Return the observing process's capture boundary.
+    pub const fn capture_boundary(&self) -> CaptureBoundary {
+        self.capture_boundary
+    }
+}
+
+/// Backend-neutral kind of one raw watcher observation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RawEventKind {
+    /// A path was observed as newly created.
+    Create,
+    /// A path was observed as modified.
+    Modify,
+    /// A path was observed as deleted.
+    Delete,
+    /// A source path was observed moving to a destination path.
+    Rename,
+    /// A source path was observed copied to a destination path.
+    Copy,
+    /// The physical or configured source root changed.
+    RootChanged,
+    /// The backend reported that coverage or delivery overflowed.
+    Overflow,
+    /// The backend reported an error.
+    Error,
+    /// The backend delivered an event shape this model does not interpret as supported.
+    Unsupported,
+}
+
+/// Role of one raw path within its event record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RawPathRole {
+    /// A generic event subject.
+    Subject,
+    /// The source endpoint of a rename.
+    RenameSource,
+    /// The destination endpoint of a rename.
+    RenameDestination,
+    /// The source endpoint of a copy.
+    CopySource,
+    /// The destination endpoint of a copy.
+    CopyDestination,
+}
+
+/// Backend hint attached to one observed path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RawPathHint {
+    /// The path is known or hinted to be a directory.
+    Directory,
+    /// The path identifies an empty-folder notification.
+    EmptyFolder,
+    /// The path is a link/reparse-point entry and must remain entry-level.
+    Symlink,
+    /// The path was observed absent or otherwise not classifiable as an entry.
+    Absent,
+    /// The path's current entry type is explicitly uncertain.
+    Unknown,
+    /// The event subject is the physical source root itself.
+    Root,
+}
+
+/// Lossless native spelling and role for one observed path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawObservedPath {
+    path: PathBuf,
+    role: RawPathRole,
+    hint: Option<RawPathHint>,
+}
+
+impl RawObservedPath {
+    /// Construct a raw path without validating or rewriting its native spelling.
+    pub fn new(path: PathBuf, role: RawPathRole) -> Self {
+        Self {
+            path,
+            role,
+            hint: None,
+        }
+    }
+
+    /// Attach a backend entry-type or root hint while retaining the original path.
+    pub fn with_hint(mut self, hint: RawPathHint) -> Self {
+        self.hint = Some(hint);
+        self
+    }
+
+    /// Borrow the original native path spelling.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Return the role assigned by the backend adapter.
+    pub const fn role(&self) -> RawPathRole {
+        self.role
+    }
+
+    /// Return the optional backend hint.
+    pub const fn hint(&self) -> Option<RawPathHint> {
+        self.hint
+    }
+
+    fn encoded_metadata_bytes(&self) -> Result<usize, RawEnvelopeError> {
+        let hint_bytes = usize::from(self.hint.is_some());
+        1usize
+            .checked_add(hint_bytes)
+            .ok_or(RawEnvelopeError::ArithmeticOverflow {
+                counter: RawEnvelopeCounter::MetadataBytes,
+            })
+    }
+}
+
+/// Explicit uncertainty carried by raw evidence.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct ObservationUncertainty(u16);
+
+impl ObservationUncertainty {
+    /// Uncertainty about backend delivery ordering.
+    pub const ORDERING: Self = Self(1 << 0);
+    /// Uncertainty about whether all affected paths were delivered.
+    pub const PATH_COVERAGE: Self = Self(1 << 1);
+    /// Uncertainty about continuity with the prior backend boundary.
+    pub const CONTINUITY: Self = Self(1 << 2);
+    /// An affected parent may be missing or inaccessible.
+    pub const MISSING_PARENT: Self = Self(1 << 3);
+    /// The backend reported overflow or loss of delivery capacity.
+    pub const OVERFLOW: Self = Self(1 << 4);
+    /// The backend reported an error affecting observation completeness.
+    pub const BACKEND_ERROR: Self = Self(1 << 5);
+
+    /// Construct an empty uncertainty set.
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Construct an uncertainty set from raw bits.
+    pub const fn from_bits(bits: u16) -> Self {
+        Self(bits)
+    }
+
+    /// Return the raw uncertainty bits.
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+
+    /// Return whether no uncertainty bits are set.
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Return whether every bit in `other` is present.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+impl BitOr for ObservationUncertainty {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for ObservationUncertainty {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// Optional backend metadata retained on one raw observation.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RawObservationMetadata {
+    flags: u64,
+    rename_cookie: Option<u64>,
+    event_id: Option<u64>,
+    cursor: Option<Vec<u8>>,
+    detail: Option<OsString>,
+}
+
+impl RawObservationMetadata {
+    /// Construct empty optional metadata.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Retain backend flags when they are present.
+    pub fn with_flags(mut self, flags: u64) -> Self {
+        self.flags = flags;
+        self
+    }
+
+    /// Retain a backend rename cookie.
+    pub fn with_rename_cookie(mut self, rename_cookie: u64) -> Self {
+        self.rename_cookie = Some(rename_cookie);
+        self
+    }
+
+    /// Retain a backend event identifier.
+    pub fn with_event_id(mut self, event_id: u64) -> Self {
+        self.event_id = Some(event_id);
+        self
+    }
+
+    /// Retain opaque backend cursor bytes without decoding or rewriting them.
+    pub fn with_cursor(mut self, cursor: Vec<u8>) -> Self {
+        self.cursor = Some(cursor);
+        self
+    }
+
+    /// Retain native backend error or diagnostic detail.
+    pub fn with_detail(mut self, detail: OsString) -> Self {
+        self.detail = Some(detail);
+        self
+    }
+
+    /// Return backend flags, with zero meaning no flags were retained.
+    pub const fn flags(&self) -> u64 {
+        self.flags
+    }
+
+    /// Return the optional rename cookie.
+    pub const fn rename_cookie(&self) -> Option<u64> {
+        self.rename_cookie
+    }
+
+    /// Return the optional backend event identifier.
+    pub const fn event_id(&self) -> Option<u64> {
+        self.event_id
+    }
+
+    /// Borrow opaque backend cursor bytes.
+    pub fn cursor(&self) -> Option<&[u8]> {
+        self.cursor.as_deref()
+    }
+
+    /// Borrow native backend detail.
+    pub fn detail(&self) -> Option<&OsStr> {
+        self.detail.as_deref()
+    }
+
+    fn encoded_metadata_bytes(&self) -> Result<usize, RawEnvelopeError> {
+        let flags_bytes = if self.flags == 0 {
+            0
+        } else {
+            std::mem::size_of::<u64>()
+        };
+        let rename_cookie_bytes = if self.rename_cookie.is_some() {
+            std::mem::size_of::<u64>()
+        } else {
+            0
+        };
+        let event_id_bytes = if self.event_id.is_some() {
+            std::mem::size_of::<u64>()
+        } else {
+            0
+        };
+        let cursor_bytes = self.cursor.as_ref().map_or(0, Vec::len);
+        let detail_bytes = self
+            .detail
+            .as_ref()
+            .map_or(0, |detail| detail.as_os_str().as_encoded_bytes().len());
+
+        flags_bytes
+            .checked_add(rename_cookie_bytes)
+            .and_then(|value| value.checked_add(event_id_bytes))
+            .and_then(|value| value.checked_add(cursor_bytes))
+            .and_then(|value| value.checked_add(detail_bytes))
+            .ok_or(RawEnvelopeError::ArithmeticOverflow {
+                counter: RawEnvelopeCounter::MetadataBytes,
+            })
+    }
+}
+
+/// One ordered raw backend observation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawObservation {
+    kind: RawEventKind,
+    paths: Vec<RawObservedPath>,
+    metadata: RawObservationMetadata,
+    uncertainty: ObservationUncertainty,
+}
+
+impl RawObservation {
+    /// Construct one raw observation while retaining path order and duplicates.
+    pub fn new(kind: RawEventKind, paths: Vec<RawObservedPath>) -> Self {
+        Self {
+            kind,
+            paths,
+            metadata: RawObservationMetadata::default(),
+            uncertainty: ObservationUncertainty::empty(),
+        }
+    }
+
+    /// Attach optional backend metadata.
+    pub fn with_metadata(mut self, metadata: RawObservationMetadata) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
+    /// Attach explicit uncertainty bits.
+    pub fn with_uncertainty(mut self, uncertainty: ObservationUncertainty) -> Self {
+        self.uncertainty = uncertainty;
+        self
+    }
+
+    /// Return the backend-neutral event kind.
+    pub const fn kind(&self) -> RawEventKind {
+        self.kind
+    }
+
+    /// Borrow paths in their original backend delivery order.
+    pub fn paths(&self) -> &[RawObservedPath] {
+        &self.paths
+    }
+
+    /// Borrow optional backend metadata.
+    pub const fn metadata(&self) -> &RawObservationMetadata {
+        &self.metadata
+    }
+
+    /// Return explicit uncertainty bits.
+    pub const fn uncertainty(&self) -> ObservationUncertainty {
+        self.uncertainty
+    }
+
+    fn accounting(&self) -> Result<(usize, usize), RawEnvelopeError> {
+        let mut path_bytes = 0usize;
+        // The event kind is one byte in the bounded backend-neutral encoding.
+        let mut metadata_bytes = 1usize
+            .checked_add(self.metadata.encoded_metadata_bytes()?)
+            .ok_or(RawEnvelopeError::ArithmeticOverflow {
+                counter: RawEnvelopeCounter::MetadataBytes,
+            })?;
+        if !self.uncertainty.is_empty() {
+            metadata_bytes = metadata_bytes
+                .checked_add(std::mem::size_of::<u16>())
+                .ok_or(RawEnvelopeError::ArithmeticOverflow {
+                    counter: RawEnvelopeCounter::MetadataBytes,
+                })?;
+        }
+
+        for path in &self.paths {
+            path_bytes = path_bytes
+                .checked_add(path.path.as_os_str().as_encoded_bytes().len())
+                .ok_or(RawEnvelopeError::ArithmeticOverflow {
+                    counter: RawEnvelopeCounter::PathBytes,
+                })?;
+            metadata_bytes = metadata_bytes
+                .checked_add(path.encoded_metadata_bytes()?)
+                .ok_or(RawEnvelopeError::ArithmeticOverflow {
+                    counter: RawEnvelopeCounter::MetadataBytes,
+                })?;
+        }
+
+        Ok((path_bytes, metadata_bytes))
+    }
+}
+
+/// Exact accounting for the contents of one raw envelope.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RawObservationAccounting {
+    event_count: usize,
+    path_bytes: usize,
+    metadata_bytes: usize,
+}
+
+impl RawObservationAccounting {
+    /// Return the number of raw observations.
+    pub const fn event_count(self) -> usize {
+        self.event_count
+    }
+
+    /// Return the sum of native path spelling bytes.
+    pub const fn path_bytes(self) -> usize {
+        self.path_bytes
+    }
+
+    /// Return the sum of encoded metadata bytes.
+    pub const fn metadata_bytes(self) -> usize {
+        self.metadata_bytes
+    }
+
+    /// Return path plus metadata bytes with checked arithmetic.
+    pub fn total_bytes(self) -> Result<usize, RawEnvelopeError> {
+        self.path_bytes.checked_add(self.metadata_bytes).ok_or(
+            RawEnvelopeError::ArithmeticOverflow {
+                counter: RawEnvelopeCounter::MetadataBytes,
+            },
+        )
+    }
+}
+
+/// Limits used to admit one bounded, non-empty raw observation envelope.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RawObservationLimits {
+    max_events: usize,
+    max_path_bytes: usize,
+    max_metadata_bytes: usize,
+}
+
+impl RawObservationLimits {
+    /// Construct limits; the event limit must be nonzero while byte limits may be zero for marker-only budgets.
+    pub const fn new(
+        max_events: usize,
+        max_path_bytes: usize,
+        max_metadata_bytes: usize,
+    ) -> Result<Self, RawEnvelopeError> {
+        if max_events == 0 {
+            return Err(RawEnvelopeError::ZeroEventLimit);
+        }
+        Ok(Self {
+            max_events,
+            max_path_bytes,
+            max_metadata_bytes,
+        })
+    }
+
+    /// Return the maximum number of raw observations.
+    pub const fn max_events(self) -> usize {
+        self.max_events
+    }
+
+    /// Return the maximum native path spelling bytes.
+    pub const fn max_path_bytes(self) -> usize {
+        self.max_path_bytes
+    }
+
+    /// Return the maximum encoded metadata bytes.
+    pub const fn max_metadata_bytes(self) -> usize {
+        self.max_metadata_bytes
+    }
+
+    fn check(self, accounting: RawObservationAccounting) -> Result<(), RawEnvelopeError> {
+        let checks = [
+            (
+                RawEnvelopeLimit::EventCount,
+                accounting.event_count,
+                self.max_events,
+            ),
+            (
+                RawEnvelopeLimit::PathBytes,
+                accounting.path_bytes,
+                self.max_path_bytes,
+            ),
+            (
+                RawEnvelopeLimit::MetadataBytes,
+                accounting.metadata_bytes,
+                self.max_metadata_bytes,
+            ),
+        ];
+        for (limit, actual, maximum) in checks {
+            if actual > maximum {
+                return Err(RawEnvelopeError::LimitExceeded {
+                    limit,
+                    actual,
+                    maximum,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A bounded, ordered, non-empty raw observation envelope.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawObservationEnvelope {
+    provenance: RawObservationProvenance,
+    proof: Proof,
+    observations: Vec<RawObservation>,
+    limits: RawObservationLimits,
+    accounting: RawObservationAccounting,
+}
+
+impl RawObservationEnvelope {
+    /// Admit an envelope with the default `Proof::Unproven` state.
+    pub fn try_new(
+        provenance: RawObservationProvenance,
+        observations: Vec<RawObservation>,
+        limits: RawObservationLimits,
+    ) -> Result<Self, RawEnvelopeError> {
+        Self::try_new_with_proof(provenance, observations, limits, Proof::Unproven)
+    }
+
+    /// Admit an envelope carrying a checked proof without changing the raw evidence.
+    pub fn try_new_with_proof(
+        provenance: RawObservationProvenance,
+        observations: Vec<RawObservation>,
+        limits: RawObservationLimits,
+        proof: Proof,
+    ) -> Result<Self, RawEnvelopeError> {
+        if observations.is_empty() {
+            return Err(RawEnvelopeError::EmptyEnvelope);
+        }
+
+        let mut path_bytes = 0usize;
+        let mut metadata_bytes = 0usize;
+        for observation in &observations {
+            let (observation_path_bytes, observation_metadata_bytes) = observation.accounting()?;
+            path_bytes = path_bytes.checked_add(observation_path_bytes).ok_or(
+                RawEnvelopeError::ArithmeticOverflow {
+                    counter: RawEnvelopeCounter::PathBytes,
+                },
+            )?;
+            metadata_bytes = metadata_bytes
+                .checked_add(observation_metadata_bytes)
+                .ok_or(RawEnvelopeError::ArithmeticOverflow {
+                    counter: RawEnvelopeCounter::MetadataBytes,
+                })?;
+        }
+
+        let accounting = RawObservationAccounting {
+            event_count: observations.len(),
+            path_bytes,
+            metadata_bytes,
+        };
+        limits.check(accounting)?;
+
+        if let Proof::WatcherContinuity(proof) = &proof {
+            proof.validate_against(&provenance)?;
+        }
+
+        Ok(Self {
+            provenance,
+            proof,
+            observations,
+            limits,
+            accounting,
+        })
+    }
+
+    /// Borrow the envelope's origin metadata.
+    pub const fn provenance(&self) -> &RawObservationProvenance {
+        &self.provenance
+    }
+
+    /// Borrow the separate proof state.
+    pub const fn proof(&self) -> &Proof {
+        &self.proof
+    }
+
+    /// Borrow raw observations in backend delivery order.
+    pub fn observations(&self) -> &[RawObservation] {
+        &self.observations
+    }
+
+    /// Return the limits that admitted this envelope.
+    pub const fn limits(&self) -> RawObservationLimits {
+        self.limits
+    }
+
+    /// Return exact event, path-byte, and metadata-byte accounting.
+    pub const fn accounting(&self) -> RawObservationAccounting {
+        self.accounting
+    }
+}
+
+/// Separate proof state for raw watcher evidence.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum Proof {
+    /// No continuity or targeted-authority proof is available.
+    #[default]
+    Unproven,
+    /// A replay adapter supplied a structurally checked continuity proof.
+    WatcherContinuity(WatcherContinuityProof),
+}
+
+impl Proof {
+    /// Return whether this proof state is unproven.
+    pub const fn is_unproven(&self) -> bool {
+        matches!(self, Self::Unproven)
+    }
+
+    /// Borrow the continuity proof when present.
+    pub const fn watcher_continuity(&self) -> Option<&WatcherContinuityProof> {
+        match self {
+            Self::Unproven => None,
+            Self::WatcherContinuity(proof) => Some(proof),
+        }
+    }
+}
+
+/// Durable prior backend acknowledgement used as the start of replay coverage.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DurablePriorAcknowledgement {
+    sequence: u64,
+}
+
+impl DurablePriorAcknowledgement {
+    /// Construct an acknowledgement that has already been durably recorded by the owner.
+    pub const fn new(sequence: u64) -> Self {
+        Self { sequence }
+    }
+
+    /// Return the acknowledged backend sequence.
+    pub const fn sequence(self) -> u64 {
+        self.sequence
+    }
+}
+
+/// Claimed replay interval after a durable acknowledgement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReplayCoverage {
+    after_sequence: u64,
+    through_sequence: u64,
+    contiguous: bool,
+}
+
+impl ReplayCoverage {
+    /// Construct a replay interval and retain whether the adapter proved contiguity.
+    pub const fn try_new(
+        after_sequence: u64,
+        through_sequence: u64,
+        contiguous: bool,
+    ) -> Result<Self, RawEnvelopeError> {
+        if through_sequence < after_sequence {
+            return Err(RawEnvelopeError::GappedReplayCoverage);
+        }
+        Ok(Self {
+            after_sequence,
+            through_sequence,
+            contiguous,
+        })
+    }
+
+    /// Return the sequence immediately before the claimed replay interval.
+    pub const fn after_sequence(self) -> u64 {
+        self.after_sequence
+    }
+
+    /// Return the current batch's inclusive terminal sequence.
+    pub const fn through_sequence(self) -> u64 {
+        self.through_sequence
+    }
+
+    /// Return whether the replay adapter proved the interval gap-free.
+    pub const fn is_contiguous(self) -> bool {
+        self.contiguous
+    }
+}
+
+/// Structurally checked replay continuity proof.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WatcherContinuityProof {
+    source_id: SourceId,
+    root_identity: RootIdentity,
+    backend_stream_identity: BackendStreamIdentity,
+    watcher_generation: WatcherGeneration,
+    prior_acknowledgement: DurablePriorAcknowledgement,
+    replay_coverage: ReplayCoverage,
+}
+
+impl WatcherContinuityProof {
+    /// Construct a proof bound to provenance, durable acknowledgement, and contiguous coverage.
+    pub fn try_new(
+        provenance: &RawObservationProvenance,
+        prior_acknowledgement: Option<DurablePriorAcknowledgement>,
+        replay_coverage: Option<ReplayCoverage>,
+    ) -> Result<Self, RawEnvelopeError> {
+        let root_identity = provenance
+            .root_identity
+            .clone()
+            .ok_or(RawEnvelopeError::MissingRootIdentity)?;
+        let backend_stream_identity = provenance
+            .backend_stream_identity
+            .clone()
+            .ok_or(RawEnvelopeError::MissingBackendStreamIdentity)?;
+        let prior_acknowledgement =
+            prior_acknowledgement.ok_or(RawEnvelopeError::MissingPriorAcknowledgement)?;
+        let replay_coverage = replay_coverage.ok_or(RawEnvelopeError::MissingReplayCoverage)?;
+        let proof = Self {
+            source_id: provenance.source_id.clone(),
+            root_identity,
+            backend_stream_identity,
+            watcher_generation: provenance.watcher_generation,
+            prior_acknowledgement,
+            replay_coverage,
+        };
+        proof.validate_against(provenance)?;
+        Ok(proof)
+    }
+
+    /// Borrow the proof's source identifier.
+    pub fn source_id(&self) -> &SourceId {
+        &self.source_id
+    }
+
+    /// Borrow the proof's physical root identity.
+    pub fn root_identity(&self) -> &RootIdentity {
+        &self.root_identity
+    }
+
+    /// Borrow the proof's backend stream identity.
+    pub fn backend_stream_identity(&self) -> &BackendStreamIdentity {
+        &self.backend_stream_identity
+    }
+
+    /// Return the proof's watcher generation.
+    pub const fn watcher_generation(&self) -> WatcherGeneration {
+        self.watcher_generation
+    }
+
+    /// Return the durable prior acknowledgement.
+    pub const fn prior_acknowledgement(&self) -> DurablePriorAcknowledgement {
+        self.prior_acknowledgement
+    }
+
+    /// Return the claimed contiguous replay interval.
+    pub const fn replay_coverage(&self) -> ReplayCoverage {
+        self.replay_coverage
+    }
+
+    fn validate_against(
+        &self,
+        provenance: &RawObservationProvenance,
+    ) -> Result<(), RawEnvelopeError> {
+        if self.source_id != *provenance.source_id()
+            || Some(&self.root_identity) != provenance.root_identity()
+            || Some(&self.backend_stream_identity) != provenance.backend_stream_identity()
+            || self.watcher_generation != provenance.watcher_generation
+        {
+            return Err(RawEnvelopeError::ProofMismatch);
+        }
+
+        if !self.replay_coverage.is_contiguous()
+            || self.replay_coverage.after_sequence() != self.prior_acknowledgement.sequence()
+            || self.replay_coverage.through_sequence() <= self.prior_acknowledgement.sequence()
+        {
+            return Err(RawEnvelopeError::GappedReplayCoverage);
+        }
+
+        let boundary = provenance.capture_boundary();
+        if boundary.last_sequence() != Some(self.replay_coverage.through_sequence()) {
+            return Err(RawEnvelopeError::CoverageBoundaryMismatch);
+        }
+        if let Some(first_sequence) = boundary.first_sequence() {
+            let expected_first = self.prior_acknowledgement.sequence().checked_add(1).ok_or(
+                RawEnvelopeError::ArithmeticOverflow {
+                    counter: RawEnvelopeCounter::Sequence,
+                },
+            )?;
+            if first_sequence != expected_first {
+                return Err(RawEnvelopeError::GappedReplayCoverage);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Lossless root-relative path validated without rebuilding or normalizing it.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RootRelativePath(PathBuf);
+
+impl RootRelativePath {
+    /// Validate and retain a native path spelling exactly as supplied.
+    pub fn try_from_path(path: PathBuf) -> Result<Self, RootRelativePathError> {
+        if path.as_os_str().is_empty() {
+            return Err(RootRelativePathError::Empty);
+        }
+
+        let mut has_normal_component = false;
+        for component in path.components() {
+            match component {
+                Component::Prefix(_) => return Err(RootRelativePathError::PlatformPrefix),
+                Component::ParentDir => return Err(RootRelativePathError::ParentTraversal),
+                Component::CurDir => {}
+                Component::RootDir => {}
+                Component::Normal(_) => has_normal_component = true,
+            }
+        }
+        if path.is_absolute() {
+            return Err(RootRelativePathError::Absolute);
+        }
+        if path
+            .components()
+            .any(|component| component == Component::RootDir)
+        {
+            return Err(RootRelativePathError::Rooted);
+        }
+        if !has_normal_component {
+            return Err(RootRelativePathError::NoNormalComponent);
+        }
+        Ok(Self(path))
+    }
+
+    /// Borrow the validated native path spelling.
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Consume the validated path without rewriting it.
+    pub fn into_path(self) -> PathBuf {
+        self.0
+    }
+
+    /// Return the nearest valid lexical parent, or `None` at the source root.
+    pub fn parent(&self) -> Option<Self> {
+        self.0
+            .parent()
+            .and_then(|parent| Self::try_from_path(parent.to_path_buf()).ok())
+    }
+}
+
+impl TryFrom<PathBuf> for RootRelativePath {
+    type Error = RootRelativePathError;
+
+    fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
+        Self::try_from_path(path)
+    }
+}
+
+impl TryFrom<&Path> for RootRelativePath {
+    type Error = RootRelativePathError;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        Self::try_from_path(path.to_path_buf())
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/model.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/model.rs
@@ -147,6 +147,8 @@ impl std::error::Error for RawEnvelopeError {}
 pub enum RootRelativePathError {
     /// The path has no native spelling.
     Empty,
+    /// The path's native spelling contains an embedded NUL byte.
+    EmbeddedNul,
     /// The path is absolute.
     Absolute,
     /// The path is rooted without a relative root identity.
@@ -163,6 +165,7 @@ impl fmt::Display for RootRelativePathError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let message = match self {
             Self::Empty => "path is empty",
+            Self::EmbeddedNul => "path contains an embedded NUL byte",
             Self::Absolute => "path is absolute",
             Self::Rooted => "path is rooted",
             Self::ParentTraversal => "path contains parent traversal",
@@ -777,6 +780,24 @@ impl RawObservationLimits {
 }
 
 /// A bounded, ordered, non-empty raw observation envelope.
+///
+/// External consumers construct unproven envelopes through [`Self::try_new`].
+///
+/// ```compile_fail
+/// # use wavecrate_library::sample_sources::reconciliation::{
+/// #     Proof, RawObservation, RawObservationEnvelope, RawObservationLimits,
+/// #     RawObservationProvenance,
+/// # };
+/// # let provenance: RawObservationProvenance = unimplemented!();
+/// # let observations: Vec<RawObservation> = Vec::new();
+/// # let limits: RawObservationLimits = unimplemented!();
+/// let _ = RawObservationEnvelope::try_new_with_proof(
+///     provenance,
+///     observations,
+///     limits,
+///     Proof::Unproven,
+/// );
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RawObservationEnvelope {
     provenance: RawObservationProvenance,
@@ -797,7 +818,9 @@ impl RawObservationEnvelope {
     }
 
     /// Admit an envelope carrying a checked proof without changing the raw evidence.
-    pub fn try_new_with_proof(
+    // This module-private seam is reserved for the later library-owned replay authority.
+    #[allow(dead_code)]
+    pub(in crate::sample_sources::reconciliation) fn try_new_with_proof(
         provenance: RawObservationProvenance,
         observations: Vec<RawObservation>,
         limits: RawObservationLimits,
@@ -902,7 +925,9 @@ pub struct DurablePriorAcknowledgement {
 
 impl DurablePriorAcknowledgement {
     /// Construct an acknowledgement that has already been durably recorded by the owner.
-    pub const fn new(sequence: u64) -> Self {
+    // This module-private seam is reserved for the later library-owned replay authority.
+    #[allow(dead_code)]
+    pub(in crate::sample_sources::reconciliation) const fn new(sequence: u64) -> Self {
         Self { sequence }
     }
 
@@ -922,7 +947,9 @@ pub struct ReplayCoverage {
 
 impl ReplayCoverage {
     /// Construct a replay interval and retain whether the adapter proved contiguity.
-    pub const fn try_new(
+    // This module-private seam is reserved for the later library-owned replay authority.
+    #[allow(dead_code)]
+    pub(in crate::sample_sources::reconciliation) const fn try_new(
         after_sequence: u64,
         through_sequence: u64,
         contiguous: bool,
@@ -966,7 +993,9 @@ pub struct WatcherContinuityProof {
 
 impl WatcherContinuityProof {
     /// Construct a proof bound to provenance, durable acknowledgement, and contiguous coverage.
-    pub fn try_new(
+    // This module-private seam is reserved for the later library-owned replay authority.
+    #[allow(dead_code)]
+    pub(in crate::sample_sources::reconciliation) fn try_new(
         provenance: &RawObservationProvenance,
         prior_acknowledgement: Option<DurablePriorAcknowledgement>,
         replay_coverage: Option<ReplayCoverage>,
@@ -1070,6 +1099,9 @@ impl RootRelativePath {
     pub fn try_from_path(path: PathBuf) -> Result<Self, RootRelativePathError> {
         if path.as_os_str().is_empty() {
             return Err(RootRelativePathError::Empty);
+        }
+        if path.as_os_str().as_encoded_bytes().contains(&0) {
+            return Err(RootRelativePathError::EmbeddedNul);
         }
 
         let mut has_normal_component = false;

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/normalize.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/normalize.rs
@@ -1,0 +1,519 @@
+use std::path::Path;
+
+use super::model::{
+    ObservationUncertainty, Proof, RawEventKind, RawObservation, RawObservationEnvelope,
+    RawPathHint, RawPathRole, RootRelativePath, RootRelativePathError,
+};
+
+/// Monotonic work-scope kind emitted by the pure normalizer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ReconciliationScopeKind {
+    /// Inspect one named entry without claiming its current type or existence.
+    ExactEntry,
+    /// Inspect one named directory and its descendants.
+    Subtree,
+    /// Audit the complete source/root boundary.
+    SourceAudit,
+}
+
+impl ReconciliationScopeKind {
+    /// Return the more conservative of two scope kinds.
+    pub const fn widen(self, other: Self) -> Self {
+        if self as u8 >= other as u8 {
+            self
+        } else {
+            other
+        }
+    }
+}
+
+/// Reason attached to a normalized scope.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NormalizationReason {
+    /// A valid path was retained as an entry-level inspection scope.
+    ExactObservation,
+    /// A directory hint widened a create or modify path to a subtree.
+    DirectoryHint,
+    /// An empty-folder hint widened the directory namespace to a subtree.
+    EmptyFolderHint,
+    /// A valid delete path remained an entry-level inspection scope.
+    DeleteObservation,
+    /// Delete or incomplete evidence widened to the nearest valid parent.
+    MissingParent,
+    /// Delete evidence was absent, directory-shaped, or otherwise uncertain.
+    UncertainDelete,
+    /// One endpoint of a structurally complete rename was retained in order.
+    RenameEndpoint,
+    /// Rename metadata or endpoint classification was incomplete or uncertain.
+    IncompleteRename,
+    /// One endpoint of a structurally complete copy was retained in order.
+    CopyEndpoint,
+    /// Copy metadata or endpoint classification was incomplete or uncertain.
+    IncompleteCopy,
+    /// The observation explicitly concerned the source root.
+    RootChanged,
+    /// The backend reported overflow.
+    Overflow,
+    /// The backend reported an error.
+    BackendError,
+    /// The backend delivered an unsupported event shape.
+    Unsupported,
+    /// The raw path could not be validated as a relative entry path.
+    InvalidPath {
+        /// Native validation failure retained as a diagnostic reason.
+        error: RootRelativePathError,
+    },
+    /// A required path was not supplied for a path-bearing event.
+    MissingPath,
+    /// Explicit raw uncertainty widened the normalized result.
+    ExplicitUncertainty {
+        /// Bits carried by the raw observation.
+        uncertainty: ObservationUncertainty,
+    },
+}
+
+/// One ordered normalized inspection scope.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReconciliationScope {
+    kind: ReconciliationScopeKind,
+    path: Option<RootRelativePath>,
+    role: Option<RawPathRole>,
+    reason: NormalizationReason,
+}
+
+impl ReconciliationScope {
+    fn exact(path: RootRelativePath, role: RawPathRole, reason: NormalizationReason) -> Self {
+        Self {
+            kind: ReconciliationScopeKind::ExactEntry,
+            path: Some(path),
+            role: Some(role),
+            reason,
+        }
+    }
+
+    fn subtree(path: RootRelativePath, role: RawPathRole, reason: NormalizationReason) -> Self {
+        Self {
+            kind: ReconciliationScopeKind::Subtree,
+            path: Some(path),
+            role: Some(role),
+            reason,
+        }
+    }
+
+    fn source_audit(reason: NormalizationReason) -> Self {
+        Self {
+            kind: ReconciliationScopeKind::SourceAudit,
+            path: None,
+            role: None,
+            reason,
+        }
+    }
+
+    /// Return the monotonic scope kind.
+    pub const fn kind(&self) -> ReconciliationScopeKind {
+        self.kind
+    }
+
+    /// Borrow the scope path when this is an exact-entry or subtree scope.
+    pub fn path(&self) -> Option<&RootRelativePath> {
+        self.path.as_ref()
+    }
+
+    /// Return the raw role retained for a path scope.
+    pub const fn role(&self) -> Option<RawPathRole> {
+        self.role
+    }
+
+    /// Return the syntactic normalization reason.
+    pub const fn reason(&self) -> NormalizationReason {
+        self.reason
+    }
+}
+
+/// Raw evidence retained alongside its ordered normalized scopes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NormalizedObservation {
+    envelope: RawObservationEnvelope,
+    scopes: Vec<ReconciliationScope>,
+}
+
+impl NormalizedObservation {
+    /// Borrow the unchanged raw envelope.
+    pub const fn envelope(&self) -> &RawObservationEnvelope {
+        &self.envelope
+    }
+
+    /// Borrow normalized scopes in raw observation and path order.
+    pub fn scopes(&self) -> &[ReconciliationScope] {
+        &self.scopes
+    }
+
+    /// Borrow the unchanged proof carried by the raw envelope.
+    pub const fn proof(&self) -> &Proof {
+        self.envelope.proof()
+    }
+
+    /// Consume the normalized value and return its unchanged raw envelope.
+    pub fn into_envelope(self) -> RawObservationEnvelope {
+        self.envelope
+    }
+}
+
+/// Normalize one bounded raw envelope without I/O, sorting, deduplication, or proof promotion.
+pub fn normalize_observation(envelope: RawObservationEnvelope) -> NormalizedObservation {
+    let mut scopes = Vec::new();
+    for observation in envelope.observations() {
+        normalize_record(observation, &mut scopes);
+    }
+    NormalizedObservation { envelope, scopes }
+}
+
+fn normalize_record(observation: &RawObservation, scopes: &mut Vec<ReconciliationScope>) {
+    match observation.kind() {
+        RawEventKind::Create | RawEventKind::Modify => {
+            normalize_create_or_modify(observation, scopes)
+        }
+        RawEventKind::Delete => normalize_delete(observation, scopes),
+        RawEventKind::Rename => normalize_rename(observation, scopes),
+        RawEventKind::Copy => normalize_copy(observation, scopes),
+        RawEventKind::RootChanged => {
+            scopes.push(ReconciliationScope::source_audit(
+                NormalizationReason::RootChanged,
+            ));
+        }
+        RawEventKind::Overflow => {
+            scopes.push(ReconciliationScope::source_audit(
+                NormalizationReason::Overflow,
+            ));
+        }
+        RawEventKind::Error => {
+            scopes.push(ReconciliationScope::source_audit(
+                NormalizationReason::BackendError,
+            ));
+        }
+        RawEventKind::Unsupported => {
+            scopes.push(ReconciliationScope::source_audit(
+                NormalizationReason::Unsupported,
+            ));
+        }
+    }
+}
+
+fn normalize_create_or_modify(observation: &RawObservation, scopes: &mut Vec<ReconciliationScope>) {
+    if observation.paths().is_empty() {
+        scopes.push(ReconciliationScope::source_audit(
+            NormalizationReason::MissingPath,
+        ));
+    }
+
+    for observed_path in observation.paths() {
+        let Some(path) = validated_path(observed_path.path(), observed_path.hint(), scopes) else {
+            continue;
+        };
+
+        if observed_path.hint() == Some(RawPathHint::Root) {
+            scopes.push(ReconciliationScope::source_audit(
+                NormalizationReason::RootChanged,
+            ));
+            continue;
+        }
+
+        if observation
+            .uncertainty()
+            .contains(ObservationUncertainty::MISSING_PARENT)
+        {
+            push_parent_or_audit(
+                &path,
+                observed_path.role(),
+                NormalizationReason::MissingParent,
+                scopes,
+            );
+            continue;
+        }
+
+        match observed_path.hint() {
+            Some(RawPathHint::Directory | RawPathHint::Unknown) => {
+                scopes.push(ReconciliationScope::subtree(
+                    path,
+                    observed_path.role(),
+                    NormalizationReason::DirectoryHint,
+                ))
+            }
+            Some(RawPathHint::EmptyFolder) => scopes.push(ReconciliationScope::subtree(
+                path,
+                observed_path.role(),
+                NormalizationReason::EmptyFolderHint,
+            )),
+            Some(RawPathHint::Absent) => push_parent_or_audit(
+                &path,
+                observed_path.role(),
+                NormalizationReason::MissingParent,
+                scopes,
+            ),
+            Some(RawPathHint::Symlink) | None => scopes.push(ReconciliationScope::exact(
+                path,
+                observed_path.role(),
+                NormalizationReason::ExactObservation,
+            )),
+            Some(RawPathHint::Root) => unreachable!("root hint handled before classification"),
+        }
+    }
+
+    push_broad_uncertainty(observation, scopes);
+}
+
+fn normalize_delete(observation: &RawObservation, scopes: &mut Vec<ReconciliationScope>) {
+    if observation.paths().is_empty() {
+        scopes.push(ReconciliationScope::source_audit(
+            NormalizationReason::MissingPath,
+        ));
+    }
+
+    for observed_path in observation.paths() {
+        let Some(path) = validated_path(observed_path.path(), observed_path.hint(), scopes) else {
+            continue;
+        };
+
+        if observed_path.hint() == Some(RawPathHint::Root) {
+            scopes.push(ReconciliationScope::source_audit(
+                NormalizationReason::RootChanged,
+            ));
+            continue;
+        }
+
+        let uncertain_parent = observation
+            .uncertainty()
+            .contains(ObservationUncertainty::MISSING_PARENT);
+        let uncertain_hint = matches!(
+            observed_path.hint(),
+            Some(RawPathHint::Directory)
+                | Some(RawPathHint::EmptyFolder)
+                | Some(RawPathHint::Absent)
+                | Some(RawPathHint::Unknown)
+        );
+        if uncertain_parent || uncertain_hint {
+            push_parent_or_audit(
+                &path,
+                observed_path.role(),
+                if uncertain_parent {
+                    NormalizationReason::MissingParent
+                } else {
+                    NormalizationReason::UncertainDelete
+                },
+                scopes,
+            );
+        } else {
+            scopes.push(ReconciliationScope::exact(
+                path,
+                observed_path.role(),
+                NormalizationReason::DeleteObservation,
+            ));
+        }
+    }
+
+    push_broad_uncertainty(observation, scopes);
+}
+
+fn normalize_rename(observation: &RawObservation, scopes: &mut Vec<ReconciliationScope>) {
+    let source_count = observation
+        .paths()
+        .iter()
+        .filter(|path| path.role() == RawPathRole::RenameSource)
+        .count();
+    let destination_count = observation
+        .paths()
+        .iter()
+        .filter(|path| path.role() == RawPathRole::RenameDestination)
+        .count();
+    let complete_shape =
+        source_count == 1 && destination_count == 1 && observation.paths().len() == 2;
+
+    if observation.paths().is_empty() {
+        scopes.push(ReconciliationScope::source_audit(
+            NormalizationReason::IncompleteRename,
+        ));
+    }
+
+    for observed_path in observation.paths() {
+        let Some(path) = validated_path(observed_path.path(), observed_path.hint(), scopes) else {
+            continue;
+        };
+
+        if observed_path.hint() == Some(RawPathHint::Root) {
+            scopes.push(ReconciliationScope::source_audit(
+                NormalizationReason::RootChanged,
+            ));
+            continue;
+        }
+
+        let endpoint_uncertain = matches!(
+            observed_path.hint(),
+            Some(RawPathHint::Directory)
+                | Some(RawPathHint::EmptyFolder)
+                | Some(RawPathHint::Absent)
+                | Some(RawPathHint::Unknown)
+        ) || observation
+            .uncertainty()
+            .contains(ObservationUncertainty::MISSING_PARENT);
+
+        if complete_shape && !endpoint_uncertain {
+            scopes.push(ReconciliationScope::exact(
+                path,
+                observed_path.role(),
+                NormalizationReason::RenameEndpoint,
+            ));
+        } else {
+            push_parent_or_audit(
+                &path,
+                observed_path.role(),
+                NormalizationReason::IncompleteRename,
+                scopes,
+            );
+        }
+    }
+
+    if !complete_shape && observation.paths().is_empty() {
+        return;
+    }
+    if !complete_shape {
+        scopes.push(ReconciliationScope::source_audit(
+            NormalizationReason::IncompleteRename,
+        ));
+    }
+    push_broad_uncertainty(observation, scopes);
+}
+
+fn normalize_copy(observation: &RawObservation, scopes: &mut Vec<ReconciliationScope>) {
+    let explicit_destination_count = observation
+        .paths()
+        .iter()
+        .filter(|path| path.role() == RawPathRole::CopyDestination)
+        .count();
+    let source_count = observation
+        .paths()
+        .iter()
+        .filter(|path| path.role() == RawPathRole::CopySource)
+        .count();
+    let generic_destination_count = if explicit_destination_count == 0 {
+        observation
+            .paths()
+            .iter()
+            .filter(|path| path.role() == RawPathRole::Subject)
+            .count()
+    } else {
+        0
+    };
+    let destination_count = explicit_destination_count + generic_destination_count;
+    let complete_shape = destination_count == 1
+        && source_count <= 1
+        && observation.paths().len() == destination_count + source_count;
+
+    if observation.paths().is_empty() {
+        scopes.push(ReconciliationScope::source_audit(
+            NormalizationReason::IncompleteCopy,
+        ));
+    }
+
+    for observed_path in observation.paths() {
+        let Some(path) = validated_path(observed_path.path(), observed_path.hint(), scopes) else {
+            continue;
+        };
+
+        if observed_path.hint() == Some(RawPathHint::Root) {
+            scopes.push(ReconciliationScope::source_audit(
+                NormalizationReason::RootChanged,
+            ));
+            continue;
+        }
+
+        let endpoint_uncertain = matches!(
+            observed_path.hint(),
+            Some(RawPathHint::Directory)
+                | Some(RawPathHint::EmptyFolder)
+                | Some(RawPathHint::Absent)
+                | Some(RawPathHint::Unknown)
+        ) || observation
+            .uncertainty()
+            .contains(ObservationUncertainty::MISSING_PARENT);
+
+        if complete_shape && !endpoint_uncertain {
+            scopes.push(ReconciliationScope::exact(
+                path,
+                observed_path.role(),
+                NormalizationReason::CopyEndpoint,
+            ));
+        } else {
+            push_parent_or_audit(
+                &path,
+                observed_path.role(),
+                NormalizationReason::IncompleteCopy,
+                scopes,
+            );
+        }
+    }
+
+    if !complete_shape && observation.paths().is_empty() {
+        return;
+    }
+    if !complete_shape {
+        scopes.push(ReconciliationScope::source_audit(
+            NormalizationReason::IncompleteCopy,
+        ));
+    }
+    push_broad_uncertainty(observation, scopes);
+}
+
+fn validated_path(
+    path: &Path,
+    hint: Option<RawPathHint>,
+    scopes: &mut Vec<ReconciliationScope>,
+) -> Option<RootRelativePath> {
+    match RootRelativePath::try_from(path) {
+        Ok(path) => Some(path),
+        Err(error) => {
+            scopes.push(ReconciliationScope::source_audit(
+                NormalizationReason::InvalidPath { error },
+            ));
+            if hint == Some(RawPathHint::Root) {
+                scopes.push(ReconciliationScope::source_audit(
+                    NormalizationReason::RootChanged,
+                ));
+            }
+            None
+        }
+    }
+}
+
+fn push_parent_or_audit(
+    path: &RootRelativePath,
+    role: RawPathRole,
+    reason: NormalizationReason,
+    scopes: &mut Vec<ReconciliationScope>,
+) {
+    if let Some(parent) = path.parent() {
+        scopes.push(ReconciliationScope::subtree(parent, role, reason));
+    } else {
+        scopes.push(ReconciliationScope::source_audit(reason));
+    }
+}
+
+fn push_broad_uncertainty(observation: &RawObservation, scopes: &mut Vec<ReconciliationScope>) {
+    let uncertainty = observation.uncertainty();
+    let known_bits = ObservationUncertainty::ORDERING.bits()
+        | ObservationUncertainty::PATH_COVERAGE.bits()
+        | ObservationUncertainty::CONTINUITY.bits()
+        | ObservationUncertainty::MISSING_PARENT.bits()
+        | ObservationUncertainty::OVERFLOW.bits()
+        | ObservationUncertainty::BACKEND_ERROR.bits();
+    let broad = uncertainty.bits() & !known_bits != 0
+        || uncertainty.contains(ObservationUncertainty::ORDERING)
+        || uncertainty.contains(ObservationUncertainty::PATH_COVERAGE)
+        || uncertainty.contains(ObservationUncertainty::CONTINUITY)
+        || uncertainty.contains(ObservationUncertainty::OVERFLOW)
+        || uncertainty.contains(ObservationUncertainty::BACKEND_ERROR);
+    if broad {
+        scopes.push(ReconciliationScope::source_audit(
+            NormalizationReason::ExplicitUncertainty { uncertainty },
+        ));
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
@@ -1,0 +1,598 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use super::*;
+use crate::sample_sources::SourceId;
+
+fn capture_boundary(first_sequence: Option<u64>, last_sequence: Option<u64>) -> CaptureBoundary {
+    CaptureBoundary::try_new(123, first_sequence, last_sequence).expect("valid capture boundary")
+}
+
+fn provenance(
+    source: &str,
+    root: Option<Vec<u8>>,
+    stream: Option<Vec<u8>>,
+    first_sequence: Option<u64>,
+    last_sequence: Option<u64>,
+) -> RawObservationProvenance {
+    provenance_at_generation(source, root, stream, first_sequence, last_sequence, 7)
+}
+
+fn provenance_at_generation(
+    source: &str,
+    root: Option<Vec<u8>>,
+    stream: Option<Vec<u8>>,
+    first_sequence: Option<u64>,
+    last_sequence: Option<u64>,
+    generation: u64,
+) -> RawObservationProvenance {
+    RawObservationProvenance::new(
+        SourceId::from_string(source),
+        root.map(RootIdentity::from_bytes),
+        stream.map(BackendStreamIdentity::from_bytes),
+        WatcherGeneration::new(generation),
+        capture_boundary(first_sequence, last_sequence),
+    )
+}
+
+fn limits() -> RawObservationLimits {
+    RawObservationLimits::new(64, usize::MAX, usize::MAX).expect("valid limits")
+}
+
+fn path(path: &str, role: RawPathRole) -> RawObservedPath {
+    RawObservedPath::new(PathBuf::from(path), role)
+}
+
+fn envelope(observations: Vec<RawObservation>) -> RawObservationEnvelope {
+    RawObservationEnvelope::try_new(
+        provenance("source-a", Some(vec![1]), Some(vec![2]), None, None),
+        observations,
+        limits(),
+    )
+    .expect("valid raw envelope")
+}
+
+fn normalized(observations: Vec<RawObservation>) -> NormalizedObservation {
+    normalize_observation(envelope(observations))
+}
+
+fn scope_path(scope: &ReconciliationScope) -> Option<&Path> {
+    scope.path().map(RootRelativePath::as_path)
+}
+
+#[test]
+fn limits_are_checked_and_accounting_is_exact_without_truncation() {
+    assert_eq!(
+        RawObservationLimits::new(0, 1, 1),
+        Err(RawEnvelopeError::ZeroEventLimit)
+    );
+    assert_eq!(
+        RawObservationEnvelope::try_new(
+            provenance("source-a", None, None, None, None),
+            Vec::new(),
+            limits(),
+        ),
+        Err(RawEnvelopeError::EmptyEnvelope)
+    );
+
+    let metadata = RawObservationMetadata::new()
+        .with_flags(1)
+        .with_event_id(9)
+        .with_cursor(vec![8, 7])
+        .with_detail(OsString::from("err"));
+    let observations = vec![
+        RawObservation::new(
+            RawEventKind::Create,
+            vec![
+                path("b", RawPathRole::Subject),
+                path("a", RawPathRole::Subject),
+            ],
+        )
+        .with_metadata(metadata),
+        RawObservation::new(RawEventKind::Modify, vec![path("b", RawPathRole::Subject)]),
+    ];
+    let raw = RawObservationEnvelope::try_new(
+        provenance("source-a", None, None, None, None),
+        observations.clone(),
+        limits(),
+    )
+    .expect("bounded observations");
+
+    assert_eq!(raw.accounting().event_count(), 2);
+    assert_eq!(raw.accounting().path_bytes(), 3);
+    assert_eq!(raw.accounting().metadata_bytes(), 26);
+    assert_eq!(raw.accounting().total_bytes(), Ok(29));
+    assert_eq!(raw.observations(), observations.as_slice());
+    assert_eq!(
+        raw.observations()[0]
+            .paths()
+            .iter()
+            .map(|observed| observed.path())
+            .collect::<Vec<_>>(),
+        vec![Path::new("b"), Path::new("a")]
+    );
+
+    let too_few_events =
+        RawObservationLimits::new(1, usize::MAX, usize::MAX).expect("valid event limit");
+    assert_eq!(
+        RawObservationEnvelope::try_new(
+            provenance("source-a", None, None, None, None),
+            observations.clone(),
+            too_few_events,
+        ),
+        Err(RawEnvelopeError::LimitExceeded {
+            limit: RawEnvelopeLimit::EventCount,
+            actual: 2,
+            maximum: 1,
+        })
+    );
+
+    let too_few_paths = RawObservationLimits::new(64, 2, usize::MAX).expect("valid path limit");
+    assert!(matches!(
+        RawObservationEnvelope::try_new(
+            provenance("source-a", None, None, None, None),
+            observations.clone(),
+            too_few_paths,
+        ),
+        Err(RawEnvelopeError::LimitExceeded {
+            limit: RawEnvelopeLimit::PathBytes,
+            actual: 3,
+            maximum: 2,
+        })
+    ));
+
+    let too_few_metadata =
+        RawObservationLimits::new(64, usize::MAX, 25).expect("valid metadata limit");
+    assert!(matches!(
+        RawObservationEnvelope::try_new(
+            provenance("source-a", None, None, None, None),
+            observations,
+            too_few_metadata,
+        ),
+        Err(RawEnvelopeError::LimitExceeded {
+            limit: RawEnvelopeLimit::MetadataBytes,
+            actual: 26,
+            maximum: 25,
+        })
+    ));
+}
+
+#[test]
+fn root_relative_paths_validate_without_rebuilding_native_spelling() {
+    let original = PathBuf::from("folder/./item");
+    let relative = RootRelativePath::try_from_path(original.clone()).expect("valid relative path");
+    assert_eq!(relative.as_path(), original.as_path());
+    assert_eq!(relative.clone().into_path(), original);
+
+    assert_eq!(
+        RootRelativePath::try_from_path(PathBuf::new()),
+        Err(RootRelativePathError::Empty)
+    );
+    assert_eq!(
+        RootRelativePath::try_from_path(PathBuf::from(".")),
+        Err(RootRelativePathError::NoNormalComponent)
+    );
+    assert_eq!(
+        RootRelativePath::try_from_path(PathBuf::from("../escape")),
+        Err(RootRelativePathError::ParentTraversal)
+    );
+    assert_eq!(
+        RootRelativePath::try_from_path(PathBuf::from("folder/../escape")),
+        Err(RootRelativePathError::ParentTraversal)
+    );
+    assert_eq!(
+        RootRelativePath::try_from_path(PathBuf::from("/absolute")),
+        Err(RootRelativePathError::Absolute)
+    );
+
+    #[cfg(windows)]
+    assert_eq!(
+        RootRelativePath::try_from_path(PathBuf::from(r"C:\absolute")),
+        Err(RootRelativePathError::PlatformPrefix)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn root_relative_paths_preserve_non_utf8_native_spelling() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let native = PathBuf::from(OsString::from_vec(vec![b'n', b'a', 0x80]));
+    let relative = RootRelativePath::try_from_path(native.clone()).expect("valid native path");
+    assert_eq!(
+        relative.as_path().as_os_str().as_encoded_bytes(),
+        &[b'n', b'a', 0x80]
+    );
+}
+
+#[test]
+fn create_modify_directory_empty_folder_symlink_and_duplicates_keep_order() {
+    let result = normalized(vec![RawObservation::new(
+        RawEventKind::Create,
+        vec![
+            path("file", RawPathRole::Subject),
+            path("directory", RawPathRole::Subject).with_hint(RawPathHint::Directory),
+            path("empty", RawPathRole::Subject).with_hint(RawPathHint::EmptyFolder),
+            path("link", RawPathRole::Subject).with_hint(RawPathHint::Symlink),
+            path("file", RawPathRole::Subject),
+        ],
+    )]);
+    let scopes = result.scopes();
+
+    assert_eq!(scopes.len(), 5);
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[0]), Some(Path::new("file")));
+    assert_eq!(scopes[1].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[1]), Some(Path::new("directory")));
+    assert_eq!(scopes[2].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[2]), Some(Path::new("empty")));
+    assert_eq!(scopes[3].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[3]), Some(Path::new("link")));
+    assert_eq!(scopes[4].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[4]), Some(Path::new("file")));
+    assert_eq!(scopes[0].role(), Some(RawPathRole::Subject));
+}
+
+#[test]
+fn delete_root_and_missing_parent_evidence_widens_conservatively() {
+    let result = normalized(vec![
+        RawObservation::new(
+            RawEventKind::Delete,
+            vec![path("file", RawPathRole::Subject)],
+        ),
+        RawObservation::new(
+            RawEventKind::Delete,
+            vec![path("folder/file", RawPathRole::Subject).with_hint(RawPathHint::Directory)],
+        ),
+        RawObservation::new(
+            RawEventKind::Delete,
+            vec![path("folder/missing", RawPathRole::Subject).with_hint(RawPathHint::Absent)],
+        ),
+        RawObservation::new(
+            RawEventKind::Delete,
+            vec![path("top", RawPathRole::Subject)],
+        )
+        .with_uncertainty(ObservationUncertainty::MISSING_PARENT),
+        RawObservation::new(
+            RawEventKind::Delete,
+            vec![path("root-marker", RawPathRole::Subject).with_hint(RawPathHint::Root)],
+        ),
+    ]);
+    let scopes = result.scopes();
+
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[0]), Some(Path::new("file")));
+    assert_eq!(scopes[1].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[1]), Some(Path::new("folder")));
+    assert_eq!(scopes[2].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[2]), Some(Path::new("folder")));
+    assert_eq!(scopes[3].kind(), ReconciliationScopeKind::SourceAudit);
+    assert_eq!(scopes[4].kind(), ReconciliationScopeKind::SourceAudit);
+    assert_eq!(scopes.len(), 5);
+}
+
+#[test]
+fn complete_and_incomplete_rename_preserve_endpoint_roles_and_order() {
+    let result = normalized(vec![
+        RawObservation::new(
+            RawEventKind::Rename,
+            vec![
+                path("old/file", RawPathRole::RenameSource),
+                path("new/file", RawPathRole::RenameDestination),
+            ],
+        ),
+        RawObservation::new(
+            RawEventKind::Rename,
+            vec![path("old/only", RawPathRole::RenameSource)],
+        ),
+        RawObservation::new(
+            RawEventKind::Rename,
+            vec![
+                path("old/directory", RawPathRole::RenameSource).with_hint(RawPathHint::Directory),
+                path("new/directory", RawPathRole::RenameDestination),
+            ],
+        ),
+    ]);
+    let scopes = result.scopes();
+
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[0]), Some(Path::new("old/file")));
+    assert_eq!(scopes[0].role(), Some(RawPathRole::RenameSource));
+    assert_eq!(scopes[1].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[1]), Some(Path::new("new/file")));
+    assert_eq!(scopes[1].role(), Some(RawPathRole::RenameDestination));
+    assert_eq!(scopes[2].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[2]), Some(Path::new("old")));
+    assert_eq!(scopes[3].kind(), ReconciliationScopeKind::SourceAudit);
+    assert_eq!(scopes[4].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[4]), Some(Path::new("old")));
+    assert_eq!(scopes[5].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[5]), Some(Path::new("new/directory")));
+}
+
+#[test]
+fn complete_and_uncertain_copy_keep_destination_and_optional_source() {
+    let result = normalized(vec![
+        RawObservation::new(
+            RawEventKind::Copy,
+            vec![
+                path("source/file", RawPathRole::CopySource),
+                path("destination/file", RawPathRole::CopyDestination),
+            ],
+        ),
+        RawObservation::new(
+            RawEventKind::Copy,
+            vec![
+                path("destination/dir", RawPathRole::CopyDestination)
+                    .with_hint(RawPathHint::Directory),
+            ],
+        ),
+        RawObservation::new(
+            RawEventKind::Copy,
+            vec![
+                path("destination/unknown", RawPathRole::CopyDestination)
+                    .with_hint(RawPathHint::Unknown),
+            ],
+        ),
+    ]);
+    let scopes = result.scopes();
+
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[0]), Some(Path::new("source/file")));
+    assert_eq!(scopes[0].role(), Some(RawPathRole::CopySource));
+    assert_eq!(scopes[1].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[1]), Some(Path::new("destination/file")));
+    assert_eq!(scopes[1].role(), Some(RawPathRole::CopyDestination));
+    assert_eq!(scopes[2].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[2]), Some(Path::new("destination")));
+    assert_eq!(scopes[3].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[3]), Some(Path::new("destination")));
+}
+
+#[test]
+fn invalid_paths_unsupported_only_and_mixed_evidence_are_visible() {
+    let result = normalized(vec![
+        RawObservation::new(
+            RawEventKind::Create,
+            vec![
+                path("valid", RawPathRole::Subject),
+                path("../escape", RawPathRole::Subject),
+            ],
+        ),
+        RawObservation::new(RawEventKind::Unsupported, Vec::new()),
+    ]);
+    let scopes = result.scopes();
+
+    assert_eq!(scopes.len(), 3);
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[0]), Some(Path::new("valid")));
+    assert_eq!(scopes[1].kind(), ReconciliationScopeKind::SourceAudit);
+    assert!(matches!(
+        scopes[1].reason(),
+        NormalizationReason::InvalidPath {
+            error: RootRelativePathError::ParentTraversal
+        }
+    ));
+    assert_eq!(scopes[2].kind(), ReconciliationScopeKind::SourceAudit);
+    assert_eq!(scopes[2].reason(), NormalizationReason::Unsupported);
+}
+
+#[test]
+fn root_overflow_and_error_events_widen_to_ordered_audits() {
+    let result = normalized(vec![
+        RawObservation::new(
+            RawEventKind::Create,
+            vec![path("file", RawPathRole::Subject)],
+        ),
+        RawObservation::new(RawEventKind::RootChanged, Vec::new()),
+        RawObservation::new(RawEventKind::Overflow, Vec::new()),
+        RawObservation::new(RawEventKind::Error, Vec::new()),
+        RawObservation::new(RawEventKind::Unsupported, Vec::new()),
+    ]);
+    let scopes = result.scopes();
+
+    assert_eq!(scopes.len(), 5);
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[0]), Some(Path::new("file")));
+    assert_eq!(scopes[1].reason(), NormalizationReason::RootChanged);
+    assert_eq!(scopes[2].reason(), NormalizationReason::Overflow);
+    assert_eq!(scopes[3].reason(), NormalizationReason::BackendError);
+    assert_eq!(scopes[4].reason(), NormalizationReason::Unsupported);
+    assert!(
+        scopes
+            .iter()
+            .skip(1)
+            .all(|scope| scope.kind() == ReconciliationScopeKind::SourceAudit)
+    );
+}
+
+#[test]
+fn broad_uncertainty_adds_audit_without_dropping_supported_scopes() {
+    let result = normalized(vec![
+        RawObservation::new(
+            RawEventKind::Modify,
+            vec![path("folder/file", RawPathRole::Subject)],
+        )
+        .with_uncertainty(
+            ObservationUncertainty::PATH_COVERAGE | ObservationUncertainty::MISSING_PARENT,
+        ),
+    ]);
+    let scopes = result.scopes();
+
+    assert_eq!(scopes.len(), 2);
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[0]), Some(Path::new("folder")));
+    assert_eq!(scopes[1].kind(), ReconciliationScopeKind::SourceAudit);
+    assert!(matches!(
+        scopes[1].reason(),
+        NormalizationReason::ExplicitUncertainty { uncertainty }
+            if uncertainty.contains(ObservationUncertainty::PATH_COVERAGE)
+    ));
+    assert_eq!(
+        ReconciliationScopeKind::ExactEntry.widen(ReconciliationScopeKind::Subtree),
+        ReconciliationScopeKind::Subtree
+    );
+    assert_eq!(
+        ReconciliationScopeKind::Subtree.widen(ReconciliationScopeKind::SourceAudit),
+        ReconciliationScopeKind::SourceAudit
+    );
+}
+
+#[test]
+fn proof_is_unproven_by_default_and_checked_proof_is_preserved_exactly() {
+    let valid_provenance = provenance("source-a", Some(vec![1]), Some(vec![2]), Some(11), Some(12));
+    let observations = vec![RawObservation::new(
+        RawEventKind::Create,
+        vec![path("file", RawPathRole::Subject)],
+    )];
+    let unproven =
+        RawObservationEnvelope::try_new(valid_provenance.clone(), observations.clone(), limits())
+            .expect("unproven envelope");
+    assert_eq!(unproven.proof(), &Proof::Unproven);
+
+    let acknowledgement = DurablePriorAcknowledgement::new(10);
+    let coverage = ReplayCoverage::try_new(10, 12, true).expect("contiguous coverage");
+    let proof =
+        WatcherContinuityProof::try_new(&valid_provenance, Some(acknowledgement), Some(coverage))
+            .expect("valid continuity proof");
+    let proven = RawObservationEnvelope::try_new_with_proof(
+        valid_provenance,
+        observations,
+        limits(),
+        Proof::WatcherContinuity(proof.clone()),
+    )
+    .expect("proven envelope");
+    let normalized = normalize_observation(proven.clone());
+
+    assert_eq!(normalized.proof(), proven.proof());
+    assert_eq!(normalized.envelope(), &proven);
+    assert_eq!(normalized.proof().watcher_continuity(), Some(&proof));
+}
+
+#[test]
+fn continuity_proof_rejects_missing_identity_gaps_and_mismatches() {
+    assert_eq!(
+        CaptureBoundary::try_new(123, Some(12), Some(11)),
+        Err(RawEnvelopeError::InvalidCaptureBoundary)
+    );
+
+    let no_root = provenance("source-a", None, Some(vec![2]), Some(11), Some(12));
+    let coverage = ReplayCoverage::try_new(10, 12, true).expect("coverage");
+    assert_eq!(
+        WatcherContinuityProof::try_new(
+            &no_root,
+            Some(DurablePriorAcknowledgement::new(10)),
+            Some(coverage),
+        ),
+        Err(RawEnvelopeError::MissingRootIdentity)
+    );
+
+    let no_stream = provenance("source-a", Some(vec![1]), None, Some(11), Some(12));
+    assert_eq!(
+        WatcherContinuityProof::try_new(
+            &no_stream,
+            Some(DurablePriorAcknowledgement::new(10)),
+            Some(coverage),
+        ),
+        Err(RawEnvelopeError::MissingBackendStreamIdentity)
+    );
+
+    let valid = provenance("source-a", Some(vec![1]), Some(vec![2]), Some(11), Some(12));
+    assert_eq!(
+        WatcherContinuityProof::try_new(&valid, None, Some(coverage)),
+        Err(RawEnvelopeError::MissingPriorAcknowledgement)
+    );
+    assert_eq!(
+        WatcherContinuityProof::try_new(&valid, Some(DurablePriorAcknowledgement::new(10)), None,),
+        Err(RawEnvelopeError::MissingReplayCoverage)
+    );
+
+    let gapped = ReplayCoverage::try_new(9, 12, true).expect("ordered coverage");
+    assert_eq!(
+        WatcherContinuityProof::try_new(
+            &valid,
+            Some(DurablePriorAcknowledgement::new(10)),
+            Some(gapped),
+        ),
+        Err(RawEnvelopeError::GappedReplayCoverage)
+    );
+    let noncontiguous = ReplayCoverage::try_new(10, 12, false).expect("non-contiguous coverage");
+    assert_eq!(
+        WatcherContinuityProof::try_new(
+            &valid,
+            Some(DurablePriorAcknowledgement::new(10)),
+            Some(noncontiguous),
+        ),
+        Err(RawEnvelopeError::GappedReplayCoverage)
+    );
+    let wrong_boundary = ReplayCoverage::try_new(10, 11, true).expect("wrong boundary");
+    assert_eq!(
+        WatcherContinuityProof::try_new(
+            &valid,
+            Some(DurablePriorAcknowledgement::new(10)),
+            Some(wrong_boundary),
+        ),
+        Err(RawEnvelopeError::CoverageBoundaryMismatch)
+    );
+
+    let proof = WatcherContinuityProof::try_new(
+        &valid,
+        Some(DurablePriorAcknowledgement::new(10)),
+        Some(coverage),
+    )
+    .expect("valid proof");
+    let wrong_envelope_provenance =
+        provenance("source-b", Some(vec![1]), Some(vec![2]), Some(11), Some(12));
+    assert_eq!(
+        RawObservationEnvelope::try_new_with_proof(
+            wrong_envelope_provenance,
+            vec![RawObservation::new(
+                RawEventKind::Create,
+                vec![path("file", RawPathRole::Subject)],
+            )],
+            limits(),
+            Proof::WatcherContinuity(proof.clone()),
+        ),
+        Err(RawEnvelopeError::ProofMismatch)
+    );
+
+    for mismatched_provenance in [
+        provenance_at_generation(
+            "source-a",
+            Some(vec![9]),
+            Some(vec![2]),
+            Some(11),
+            Some(12),
+            7,
+        ),
+        provenance_at_generation(
+            "source-a",
+            Some(vec![1]),
+            Some(vec![9]),
+            Some(11),
+            Some(12),
+            7,
+        ),
+        provenance_at_generation(
+            "source-a",
+            Some(vec![1]),
+            Some(vec![2]),
+            Some(11),
+            Some(12),
+            8,
+        ),
+    ] {
+        assert_eq!(
+            RawObservationEnvelope::try_new_with_proof(
+                mismatched_provenance,
+                vec![RawObservation::new(
+                    RawEventKind::Create,
+                    vec![path("file", RawPathRole::Subject)],
+                )],
+                limits(),
+                Proof::WatcherContinuity(proof.clone()),
+            ),
+            Err(RawEnvelopeError::ProofMismatch)
+        );
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
@@ -206,6 +206,62 @@ fn root_relative_paths_preserve_non_utf8_native_spelling() {
 }
 
 #[test]
+fn root_relative_paths_reject_embedded_nul_before_component_validation() {
+    assert_eq!(
+        RootRelativePath::try_from_path(PathBuf::from("../embedded\0nul")),
+        Err(RootRelativePathError::EmbeddedNul)
+    );
+    assert_eq!(
+        RootRelativePathError::EmbeddedNul.to_string(),
+        "path contains an embedded NUL byte"
+    );
+}
+
+#[test]
+fn embedded_nul_create_and_modify_evidence_is_retained_as_source_audit() {
+    let embedded_nul_path = PathBuf::from("embedded\0nul");
+    let observations = vec![
+        RawObservation::new(
+            RawEventKind::Create,
+            vec![RawObservedPath::new(
+                embedded_nul_path.clone(),
+                RawPathRole::Subject,
+            )],
+        ),
+        RawObservation::new(
+            RawEventKind::Modify,
+            vec![RawObservedPath::new(
+                embedded_nul_path,
+                RawPathRole::Subject,
+            )],
+        ),
+    ];
+    let raw = RawObservationEnvelope::try_new(
+        provenance("source-a", None, None, None, None),
+        observations.clone(),
+        limits(),
+    )
+    .expect("raw embedded-NUL evidence is admissible");
+
+    let normalized = normalize_observation(raw.clone());
+
+    assert_eq!(normalized.scopes().len(), observations.len());
+    assert!(normalized.scopes().iter().all(|scope| {
+        scope.kind() == ReconciliationScopeKind::SourceAudit
+            && scope.path().is_none()
+            && scope.reason()
+                == NormalizationReason::InvalidPath {
+                    error: RootRelativePathError::EmbeddedNul,
+                }
+    }));
+    assert_eq!(normalized.envelope(), &raw);
+    assert_eq!(
+        normalized.envelope().observations(),
+        observations.as_slice()
+    );
+}
+
+#[test]
 fn create_modify_directory_empty_folder_symlink_and_duplicates_keep_order() {
     let result = normalized(vec![RawObservation::new(
         RawEventKind::Create,


### PR DESCRIPTION
## Goal

Implement the first pure library slice of the merged Finder reconciliation contract in `docs/FINDER_RECONCILIATION_DESIGN.md`: a bounded backend-neutral raw observation model and conservative normalizer, before any admission, watcher adapter, workflow, persistence, or checkpoint integration.

## Scope and non-goals

- Add `wavecrate_library::sample_sources::reconciliation` with ordered raw envelopes, lossless root-relative paths, provenance, uncertainty, proof state, checked continuity-proof structure, and pure `ExactEntry`/`Subtree`/`SourceAudit` normalization.
- Preserve raw event/path order and duplicates; retain native path spelling without UTF-8/lossy normalization or reconstruction.
- Enforce event/path/metadata bounds without truncation, coalescing, filesystem I/O, database I/O, watcher APIs, or clocks.
- Cover conservative mappings for create/modify/delete/root-change/rename/copy/directory/empty-folder/symlink/unsupported/error/overflow/missing-parent and invalid paths.
- Add deterministic unit tests for bounds, accounting, losslessness, mappings, widening, proof preservation, proof mismatch rejection, and embedded-NUL invalid-path handling.
- Explicitly out of scope: live notify/FSEvents adapters, admission/lifecycle queues, cancellation/fairness/acknowledgements, `GuiMessage`, `BTreeSet`, scanners, source writer, projection/checkpoint integration, schema/serialization, existing native serialized proof, and runtime behavior changes.

## Definition of Done

- `RawObservationProvenance` is separate from `Proof`; `Proof::Unproven` is the default.
- External consumers can construct only unproven envelopes; continuity-proof constructors and proof-bearing envelope construction remain module-private for later library-owned replay authority.
- `WatcherContinuityProof` requires matching source/root/stream/generation, durable prior acknowledgement, and contiguous replay coverage ending at the capture boundary.
- The normalizer never creates or promotes proof, retains the unchanged envelope, preserves ordered duplicate scopes, and widens uncertainty monotonically.
- Invalid/root-escaping or embedded-NUL evidence cannot become an `ExactEntry` or `Subtree`; unsupported/root/overflow/error evidence remains auditable.
- No watcher, scanner, database, GUI, or persistent-schema code changes are present.

## Validation

- `cargo test -p wavecrate-library --lib reconciliation` — passed, 17 tests.
- `cargo test -p wavecrate-library --doc` — passed.
- `cargo test -p wavecrate-library --lib` — passed, 311 tests.
- `cargo fmt -p wavecrate-library -- --check` — passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p wavecrate-library --no-deps` — passed.
- `git diff --check origin/main HEAD` — passed.
- `cargo clippy -p wavecrate-library --all-targets -- -D warnings` — blocked by three pre-existing warnings in `db/file_ops_journal/reconcile.rs`, `db/open/paths.rs`, and `db/write/manifest_audit.rs`; no unrelated fixes included.
- `cargo fmt --all -- --check` — blocked by pre-existing formatting drift in existing Wavecrate files and the user-owned sibling Radiant checkout.
- `bash scripts/ci.sh smoke --workspace` — blocked before Wavecrate compilation by six existing sibling Radiant errors in `frame_scheduler.rs`/related runtime wiring; no implementation files outside this PR were changed.

## Known limitations

- This PR establishes the in-memory model only. Admission/lifecycle testing is the required second library-only gate before adapters.
- Native macOS acceptance, replay integration, source-writer commit gates, projection, checkpointing, and crash recovery remain later slices.
- User approval is required before merge.

## Next architecture task

After Terra approval and merge, implement the separate backend-neutral admission/lifecycle library slice with synthetic envelopes/acknowledgements and deterministic retained-uncertainty tests.

Current implementation head: `996958fc1bf5fe77a48a706e578ad47aa7ef1f98`.