### PR TITLE
Add bounded live and replay reconciliation adapter

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/reconciliation/adapter.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/adapter.rs
@@ -1,0 +1,401 @@
+//! Library-only live and replay admission over the pure reconciliation boundary.
+//!
+//! Live observations and replay batches that fail continuity validation remain
+//! `Proof::Unproven` and retain a conservative `SourceAudit` marker. A valid
+//! replay may carry only the checked continuity proof; this adapter never
+//! establishes committed source authority.
+
+use std::fmt;
+
+use crate::sample_sources::SourceId;
+
+use super::admission::{AdmissionOutcome, ReconciliationAdmissionSupervisor, UncertaintyReason};
+use super::model::{
+    BackendStreamIdentity, CaptureSequenceEvidence, CaptureSequenceRange,
+    DurablePriorAcknowledgement, Proof, RawEnvelopeError, RawEventKind, RawObservation,
+    RawObservationEnvelope, RawObservationLimits, RawObservationProvenance, ReplayCoverage,
+    RootIdentity, WatcherContinuityProof, WatcherGeneration,
+};
+
+/// An owned, ordered batch supplied to the live or replay adapter.
+///
+/// The adapter retains this exact batch, including raw observation and path order,
+/// when bounded envelope construction fails. Live batches are always admitted as
+/// `Proof::Unproven`; a replay continuity proof does not establish committed
+/// source authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SyntheticObservationBatch {
+    provenance: RawObservationProvenance,
+    observations: Vec<RawObservation>,
+    limits: RawObservationLimits,
+}
+
+impl SyntheticObservationBatch {
+    /// Own a provenance record, ordered raw observations, and their envelope limits.
+    pub fn new(
+        provenance: RawObservationProvenance,
+        observations: Vec<RawObservation>,
+        limits: RawObservationLimits,
+    ) -> Self {
+        Self {
+            provenance,
+            observations,
+            limits,
+        }
+    }
+
+    /// Borrow the batch provenance without changing it.
+    pub const fn provenance(&self) -> &RawObservationProvenance {
+        &self.provenance
+    }
+
+    /// Borrow raw observations in their original backend delivery order.
+    pub fn observations(&self) -> &[RawObservation] {
+        &self.observations
+    }
+
+    /// Return the limits that will be used to construct the raw envelope.
+    pub const fn limits(&self) -> RawObservationLimits {
+        self.limits
+    }
+
+    /// Consume the batch into its owned envelope-construction parts.
+    pub fn into_parts(
+        self,
+    ) -> (
+        RawObservationProvenance,
+        Vec<RawObservation>,
+        RawObservationLimits,
+    ) {
+        (self.provenance, self.observations, self.limits)
+    }
+}
+
+/// A failed adapter envelope construction that retains the original batch.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdapterError {
+    batch: Box<SyntheticObservationBatch>,
+    error: RawEnvelopeError,
+}
+
+impl AdapterError {
+    fn new(batch: SyntheticObservationBatch, error: RawEnvelopeError) -> Self {
+        Self {
+            batch: Box::new(batch),
+            error,
+        }
+    }
+
+    /// Borrow the exact batch that could not be constructed as an envelope.
+    pub const fn batch(&self) -> &SyntheticObservationBatch {
+        &self.batch
+    }
+
+    /// Borrow the checked envelope construction error.
+    pub const fn error(&self) -> &RawEnvelopeError {
+        &self.error
+    }
+
+    /// Consume the error and recover the exact original batch.
+    pub fn into_batch(self) -> SyntheticObservationBatch {
+        *self.batch
+    }
+}
+
+impl fmt::Display for AdapterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "could not construct reconciliation envelope: {}",
+            self.error
+        )
+    }
+}
+
+impl std::error::Error for AdapterError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+/// The adapter-level interpretation of an underlying admission outcome.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AdapterDisposition {
+    /// A live batch was accepted without promoting it beyond `Proof::Unproven`.
+    AdmittedUnproven,
+    /// A replay batch was accepted with a checked watcher-continuity proof.
+    AdmittedWithContinuity,
+    /// An exact recent batch was suppressed without another ticket or marker.
+    DuplicateSuppressed,
+    /// Evidence remains unproven and requires conservative source audit handling.
+    SourceAuditRequired,
+    /// The required uncertainty marker could not be retained within capacity.
+    UncertaintyCapacityExhausted,
+}
+
+/// An adapter disposition together with the unchanged supervisor outcome.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdapterAdmission {
+    disposition: AdapterDisposition,
+    outcome: AdmissionOutcome,
+}
+
+impl AdapterAdmission {
+    fn new(disposition: AdapterDisposition, outcome: AdmissionOutcome) -> Self {
+        Self {
+            disposition,
+            outcome,
+        }
+    }
+
+    /// Return the adapter's typed disposition.
+    pub const fn disposition(&self) -> AdapterDisposition {
+        self.disposition
+    }
+
+    /// Borrow the underlying supervisor admission outcome.
+    pub const fn outcome(&self) -> &AdmissionOutcome {
+        &self.outcome
+    }
+
+    /// Consume the adapter result and return the underlying supervisor outcome.
+    pub fn into_outcome(self) -> AdmissionOutcome {
+        self.outcome
+    }
+}
+
+/// An opaque identity-bound prior used by the replay adapter.
+///
+/// The constructor is crate-restricted because the acknowledgement sequence is
+/// authority supplied by the owning library boundary, not a bare public `u64`.
+/// A continuity proof made from this token still does not establish committed
+/// source authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReplayPriorToken {
+    source_id: SourceId,
+    root_identity: RootIdentity,
+    backend_stream_identity: BackendStreamIdentity,
+    watcher_generation: WatcherGeneration,
+    acknowledged_sequence: u64,
+}
+
+impl ReplayPriorToken {
+    /// Construct an identity-bound prior for crate-owned replay sources and tests.
+    #[allow(dead_code)]
+    pub(crate) fn new(
+        source_id: SourceId,
+        root_identity: RootIdentity,
+        backend_stream_identity: BackendStreamIdentity,
+        watcher_generation: WatcherGeneration,
+        acknowledged_sequence: u64,
+    ) -> Self {
+        Self {
+            source_id,
+            root_identity,
+            backend_stream_identity,
+            watcher_generation,
+            acknowledged_sequence,
+        }
+    }
+
+    /// Borrow the source identity bound to this prior.
+    pub fn source_id(&self) -> &SourceId {
+        &self.source_id
+    }
+
+    /// Borrow the physical root identity bound to this prior.
+    pub fn root_identity(&self) -> &RootIdentity {
+        &self.root_identity
+    }
+
+    /// Borrow the backend stream identity bound to this prior.
+    pub fn backend_stream_identity(&self) -> &BackendStreamIdentity {
+        &self.backend_stream_identity
+    }
+
+    /// Return the watcher generation bound to this prior.
+    pub const fn watcher_generation(&self) -> WatcherGeneration {
+        self.watcher_generation
+    }
+
+    /// Return the acknowledged backend sequence bound to this prior.
+    pub const fn acknowledged_sequence(&self) -> u64 {
+        self.acknowledged_sequence
+    }
+}
+
+#[derive(Clone, Copy)]
+enum AdmissionKind {
+    Live,
+    ValidReplay,
+    InvalidReplay,
+}
+
+/// Borrows an existing admission supervisor for library-only live/replay input.
+pub struct ReconciliationAdapter<'a> {
+    supervisor: &'a mut ReconciliationAdmissionSupervisor,
+}
+
+impl<'a> ReconciliationAdapter<'a> {
+    /// Borrow a supervisor for pure live and replay admission.
+    pub fn new(supervisor: &'a mut ReconciliationAdmissionSupervisor) -> Self {
+        Self { supervisor }
+    }
+
+    /// Admit a live batch as unproven evidence and retain one SourceAudit marker.
+    ///
+    /// This method uses only `Proof::Unproven`. It performs no filesystem or
+    /// database work and does not establish committed source authority.
+    pub fn admit_live(
+        &mut self,
+        batch: SyntheticObservationBatch,
+    ) -> Result<AdapterAdmission, AdapterError> {
+        let envelope = try_unproven_envelope(batch)?;
+        let outcome = self
+            .supervisor
+            .admit_with_required_uncertainty(envelope, UncertaintyReason::LiveUnproven);
+        Ok(AdapterAdmission::new(
+            disposition(AdmissionKind::Live, &outcome),
+            outcome,
+        ))
+    }
+
+    /// Admit replay after validating its identity and contiguous capture claim.
+    ///
+    /// A missing, ambiguous, gapped, mismatched, or uncertain replay is rebuilt
+    /// as `Proof::Unproven` and retained for conservative `SourceAudit`. Only a
+    /// fully validated replay receives `WatcherContinuityProof`; neither branch
+    /// establishes committed source authority.
+    pub fn admit_replay(
+        &mut self,
+        batch: SyntheticObservationBatch,
+        prior: Option<&ReplayPriorToken>,
+        contiguous: bool,
+    ) -> Result<AdapterAdmission, AdapterError> {
+        let (kind, envelope, required_reason) = match prior {
+            None => (
+                AdmissionKind::InvalidReplay,
+                try_unproven_envelope(batch)?,
+                Some(UncertaintyReason::ReplayContinuityMissing),
+            ),
+            Some(prior) => match validate_replay(&batch, Some(prior), contiguous) {
+                Ok(range) => (
+                    AdmissionKind::ValidReplay,
+                    try_replay_envelope(batch, prior, range, contiguous)?,
+                    None,
+                ),
+                Err(reason) => (
+                    AdmissionKind::InvalidReplay,
+                    try_unproven_envelope(batch)?,
+                    Some(reason),
+                ),
+            },
+        };
+        let outcome = match required_reason {
+            Some(reason) => self
+                .supervisor
+                .admit_with_required_uncertainty(envelope, reason),
+            None => self.supervisor.admit(envelope),
+        };
+        Ok(AdapterAdmission::new(disposition(kind, &outcome), outcome))
+    }
+}
+
+fn disposition(kind: AdmissionKind, outcome: &AdmissionOutcome) -> AdapterDisposition {
+    match outcome {
+        AdmissionOutcome::Accepted(_) => match kind {
+            AdmissionKind::Live => AdapterDisposition::AdmittedUnproven,
+            AdmissionKind::ValidReplay => AdapterDisposition::AdmittedWithContinuity,
+            AdmissionKind::InvalidReplay => AdapterDisposition::SourceAuditRequired,
+        },
+        AdmissionOutcome::DuplicateSuppressed(_) => AdapterDisposition::DuplicateSuppressed,
+        AdmissionOutcome::Rejected(_) => AdapterDisposition::SourceAuditRequired,
+        AdmissionOutcome::UncertaintyCapacityExhausted(_) => {
+            AdapterDisposition::UncertaintyCapacityExhausted
+        }
+    }
+}
+
+fn try_unproven_envelope(
+    batch: SyntheticObservationBatch,
+) -> Result<RawObservationEnvelope, AdapterError> {
+    let original = batch.clone();
+    let (provenance, observations, limits) = batch.into_parts();
+    RawObservationEnvelope::try_new(provenance, observations, limits)
+        .map_err(|error| AdapterError::new(original, error))
+}
+
+fn try_replay_envelope(
+    batch: SyntheticObservationBatch,
+    prior: &ReplayPriorToken,
+    range: CaptureSequenceRange,
+    contiguous: bool,
+) -> Result<RawObservationEnvelope, AdapterError> {
+    let original = batch.clone();
+    let provenance = batch.provenance().clone();
+    let acknowledgement = DurablePriorAcknowledgement::new(prior.acknowledged_sequence);
+    let coverage = ReplayCoverage::try_new(prior.acknowledged_sequence, range.last(), contiguous)
+        .map_err(|error| AdapterError::new(original.clone(), error))?;
+    let proof = WatcherContinuityProof::try_new(&provenance, Some(acknowledgement), Some(coverage))
+        .map_err(|error| AdapterError::new(original.clone(), error))?;
+    let (provenance, observations, limits) = batch.into_parts();
+    RawObservationEnvelope::try_new_with_proof(
+        provenance,
+        observations,
+        limits,
+        Proof::WatcherContinuity(proof),
+    )
+    .map_err(|error| AdapterError::new(original, error))
+}
+
+fn validate_replay(
+    batch: &SyntheticObservationBatch,
+    prior: Option<&ReplayPriorToken>,
+    contiguous: bool,
+) -> Result<CaptureSequenceRange, UncertaintyReason> {
+    let Some(prior) = prior else {
+        return Err(UncertaintyReason::ReplayContinuityMissing);
+    };
+    let provenance = batch.provenance();
+    if provenance.root_identity().is_none() || provenance.backend_stream_identity().is_none() {
+        return Err(UncertaintyReason::ReplayContinuityMissing);
+    }
+    if provenance.source_id() != prior.source_id()
+        || provenance.root_identity() != Some(prior.root_identity())
+        || provenance.backend_stream_identity() != Some(prior.backend_stream_identity())
+        || provenance.watcher_generation() != prior.watcher_generation()
+    {
+        return Err(UncertaintyReason::ReplayContinuityMismatch);
+    }
+
+    let range = match provenance.capture_boundary().sequence_evidence() {
+        CaptureSequenceEvidence::Missing => {
+            return Err(UncertaintyReason::ReplayContinuityMissing);
+        }
+        CaptureSequenceEvidence::Ambiguous => {
+            return Err(UncertaintyReason::ReplayContinuityAmbiguous);
+        }
+        CaptureSequenceEvidence::Exact(range) => range,
+    };
+    if !contiguous {
+        return Err(UncertaintyReason::ReplayContinuityGap);
+    }
+    let Some(expected_first) = prior.acknowledged_sequence.checked_add(1) else {
+        return Err(UncertaintyReason::ReplayContinuityGap);
+    };
+    if range.first() != expected_first || range.last() <= prior.acknowledged_sequence {
+        return Err(UncertaintyReason::ReplayContinuityGap);
+    }
+    if batch.observations().iter().any(|observation| {
+        matches!(
+            observation.kind(),
+            RawEventKind::RootChanged
+                | RawEventKind::Overflow
+                | RawEventKind::Error
+                | RawEventKind::Unsupported
+        ) || !observation.uncertainty().is_empty()
+    }) {
+        return Err(UncertaintyReason::ReplayContinuityMismatch);
+    }
+    Ok(range)
+}

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
@@ -210,6 +210,16 @@ pub enum UncertaintyReason {
     AccountingOverflow,
     /// Exact sequence identity was reused with different evidence.
     SequenceConflict,
+    /// A live adapter batch remains deliberately unproven.
+    LiveUnproven,
+    /// Replay continuity could not be established because required prior or identity evidence was missing.
+    ReplayContinuityMissing,
+    /// Replay continuity evidence supplied only one side of its capture sequence range.
+    ReplayContinuityAmbiguous,
+    /// Replay continuity evidence was gapped, non-contiguous, or did not advance the prior.
+    ReplayContinuityGap,
+    /// Replay continuity evidence did not match its identity or contained disqualifying evidence.
+    ReplayContinuityMismatch,
 }
 
 /// A supervisor-assigned watermark range for one retained uncertainty marker.
@@ -821,7 +831,35 @@ impl ReconciliationAdmissionSupervisor {
 
     /// Admit an envelope into the bounded lane queue.
     pub fn admit(&mut self, envelope: RawObservationEnvelope) -> AdmissionOutcome {
-        let envelope_marker_reasons = marker_reasons(&envelope);
+        self.admit_inner(envelope, None)
+    }
+
+    /// Admit an envelope while atomically requiring one adapter-owned uncertainty reason.
+    ///
+    /// This crate-visible path shares every lifecycle, duplicate, queue, accounting,
+    /// and retained-marker fence with [`Self::admit`]. The required reason is
+    /// included before any ticket or usage mutation, while exact duplicate
+    /// suppression remains marker-free.
+    pub(crate) fn admit_with_required_uncertainty(
+        &mut self,
+        envelope: RawObservationEnvelope,
+        reason: UncertaintyReason,
+    ) -> AdmissionOutcome {
+        self.admit_inner(envelope, Some(reason))
+    }
+
+    fn admit_inner(
+        &mut self,
+        envelope: RawObservationEnvelope,
+        required_uncertainty: Option<UncertaintyReason>,
+    ) -> AdmissionOutcome {
+        let remember_marker_only_sequence = required_uncertainty.is_some();
+        let mut envelope_marker_reasons = marker_reasons(&envelope);
+        if let Some(reason) = required_uncertainty {
+            envelope_marker_reasons.push(reason);
+            envelope_marker_reasons.sort_unstable();
+            envelope_marker_reasons.dedup();
+        }
         let source_id = envelope.provenance().source_id().clone();
         let Some(lane) = self.sources.get(&source_id).cloned() else {
             return self.reject_with_marker(
@@ -885,11 +923,19 @@ impl ReconciliationAdmissionSupervisor {
             evidence_reasons.dedup();
         }
         if marker_only(&envelope) {
-            return self.reject_with_reasons(
+            let recent_record =
+                remember_marker_only_sequence.then(|| recent_exact_sequence_record(&envelope));
+            let outcome = self.reject_with_reasons(
                 envelope,
                 marker_rejection_reason(&evidence_reasons),
                 evidence_reasons,
             );
+            if matches!(outcome, AdmissionOutcome::Rejected(_))
+                && let Some(Some(record)) = recent_record
+            {
+                self.remember_recent_sequence(&lane, record);
+            }
+            return outcome;
         }
 
         let usage = Usage::from(envelope.accounting());
@@ -955,12 +1001,6 @@ impl ReconciliationAdmissionSupervisor {
         state.queue.push_back(ticket);
         state.live_tickets += 1;
         state.usage = next_lane_usage;
-        if let Some(record) = recent_record {
-            state.recent_sequences.push_back(record);
-            while state.recent_sequences.len() > self.limits.max_recent_sequences_per_lane {
-                state.recent_sequences.pop_front();
-            }
-        }
         self.global_usage = next_global_usage;
         self.pending.insert(
             ticket,
@@ -972,6 +1012,9 @@ impl ReconciliationAdmissionSupervisor {
                 phase: DispatchPhase::Queued,
             },
         );
+        if let Some(record) = recent_record {
+            self.remember_recent_sequence(&lane, record);
+        }
         if was_empty && self.runnable_set.insert(lane.clone()) {
             self.runnable.push_back(lane);
         }
@@ -1169,6 +1212,18 @@ impl ReconciliationAdmissionSupervisor {
             state.usage = state.usage.subtract(usage);
         }
         self.global_usage = self.global_usage.subtract(usage);
+    }
+
+    fn remember_recent_sequence(
+        &mut self,
+        lane: &AdmissionLaneKey,
+        record: RecentExactSequenceRecord,
+    ) {
+        let state = self.lanes.get_mut(lane).expect("lane checked above");
+        state.recent_sequences.push_back(record);
+        while state.recent_sequences.len() > self.limits.max_recent_sequences_per_lane {
+            state.recent_sequences.pop_front();
+        }
     }
 
     fn shared_used(&self) -> usize {

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
@@ -1,5 +1,6 @@
 //! Pure, backend-neutral Finder observation modeling and normalization.
 
+mod adapter;
 mod admission;
 mod model;
 mod normalize;
@@ -7,6 +8,10 @@ mod normalize;
 #[cfg(test)]
 mod tests;
 
+pub use adapter::{
+    AdapterAdmission, AdapterDisposition, AdapterError, ReconciliationAdapter, ReplayPriorToken,
+    SyntheticObservationBatch,
+};
 pub use admission::{
     AdmissionError, AdmissionLaneKey, AdmissionOutcome, AdmissionRejectReason,
     CommittedAuthoritativeReconciliationAcknowledgement, DispatchPhase, DispatchTicket,

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
@@ -60,6 +60,80 @@ fn scope_path(scope: &ReconciliationScope) -> Option<&Path> {
     scope.path().map(RootRelativePath::as_path)
 }
 
+fn adapter_admission_limits(
+    max_in_flight: usize,
+    max_retained_uncertainties: usize,
+) -> ReconciliationAdmissionLimits {
+    ReconciliationAdmissionLimits::new(
+        1,
+        limits(),
+        limits(),
+        max_in_flight,
+        64,
+        max_retained_uncertainties,
+    )
+    .expect("valid adapter admission limits")
+}
+
+fn adapter_batch(
+    provenance: RawObservationProvenance,
+    observations: Vec<RawObservation>,
+) -> SyntheticObservationBatch {
+    SyntheticObservationBatch::new(provenance, observations, limits())
+}
+
+fn adapter_observation(kind: RawEventKind, name: &str) -> RawObservation {
+    RawObservation::new(kind, vec![path(name, RawPathRole::Subject)])
+}
+
+fn replay_prior(
+    source: &str,
+    root: &[u8],
+    stream: &[u8],
+    generation: u64,
+    acknowledged_sequence: u64,
+) -> ReplayPriorToken {
+    ReplayPriorToken::new(
+        SourceId::from_string(source),
+        RootIdentity::from_bytes(root.to_vec()),
+        BackendStreamIdentity::from_bytes(stream.to_vec()),
+        WatcherGeneration::new(generation),
+        acknowledged_sequence,
+    )
+}
+
+fn adapter_registered(
+    supervisor: &mut ReconciliationAdmissionSupervisor,
+    source: &SourceId,
+    root: &RootIdentity,
+) -> (AdmissionLaneKey, WatcherGeneration) {
+    let (lane, generation) = supervisor
+        .register_lane(source.clone(), root.clone())
+        .expect("register adapter lane");
+    supervisor
+        .begin_capture(&lane, generation)
+        .expect("begin adapter capture");
+    (lane, generation)
+}
+
+fn adapter_capture_provenance(
+    source: &str,
+    root: Option<Vec<u8>>,
+    stream: Option<Vec<u8>>,
+    generation: u64,
+    first_sequence: Option<u64>,
+    last_sequence: Option<u64>,
+) -> RawObservationProvenance {
+    provenance_at_generation(
+        source,
+        root,
+        stream,
+        first_sequence,
+        last_sequence,
+        generation,
+    )
+}
+
 #[test]
 fn capture_sequence_evidence_distinguishes_missing_ambiguous_and_exact() {
     assert_eq!(
@@ -671,4 +745,874 @@ fn continuity_proof_rejects_missing_identity_gaps_and_mismatches() {
             Err(RawEnvelopeError::ProofMismatch)
         );
     }
+}
+
+fn assert_invalid_replay_case(
+    batch: SyntheticObservationBatch,
+    prior: Option<&ReplayPriorToken>,
+    contiguous: bool,
+    expected_reason: UncertaintyReason,
+    expect_dispatch: bool,
+) {
+    let expected_observations = batch.observations().to_vec();
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 4));
+    adapter_registered(&mut supervisor, &source, &root);
+
+    let admission = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_replay(batch, prior, contiguous)
+            .expect("invalid replay envelope remains constructible")
+    };
+    assert_eq!(
+        admission.disposition(),
+        AdapterDisposition::SourceAuditRequired
+    );
+    assert_eq!(supervisor.uncertainties().len(), 1);
+    assert_eq!(
+        supervisor.uncertainties()[0].scope(),
+        ReconciliationScopeKind::SourceAudit
+    );
+    assert!(
+        supervisor.uncertainties()[0]
+            .reasons()
+            .contains(&expected_reason)
+    );
+
+    match admission.outcome() {
+        AdmissionOutcome::Accepted(ticket) => {
+            assert!(
+                expect_dispatch,
+                "expected the invalid replay to be rejected"
+            );
+            let dispatched = supervisor
+                .dispatch_next()
+                .expect("accepted replay dispatch");
+            assert_eq!(dispatched.ticket(), *ticket);
+            assert_eq!(dispatched.normalized().proof(), &Proof::Unproven);
+            assert_eq!(
+                dispatched.normalized().envelope().observations(),
+                expected_observations.as_slice()
+            );
+        }
+        AdmissionOutcome::Rejected(_) => {
+            assert!(!expect_dispatch, "expected the invalid replay to dispatch");
+        }
+        outcome => panic!("unexpected invalid replay outcome: {outcome:?}"),
+    }
+}
+
+#[test]
+fn live_adapter_is_unproven_ordered_and_retains_one_audit_marker() {
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 8));
+    let (_lane, generation) = adapter_registered(&mut supervisor, &source, &root);
+    let observations = vec![
+        adapter_observation(RawEventKind::Create, "first.wav"),
+        adapter_observation(RawEventKind::Modify, "second.wav"),
+    ];
+    let expected_observations = observations.clone();
+    let batch = adapter_batch(
+        adapter_capture_provenance(
+            "source-a",
+            Some(b"root-a".to_vec()),
+            Some(b"stream-a".to_vec()),
+            generation.get(),
+            Some(10),
+            Some(11),
+        ),
+        observations,
+    );
+
+    let admission = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter.admit_live(batch).expect("live admission")
+    };
+    assert_eq!(
+        admission.disposition(),
+        AdapterDisposition::AdmittedUnproven
+    );
+    let ticket = match admission.outcome() {
+        AdmissionOutcome::Accepted(ticket) => *ticket,
+        outcome => panic!("unexpected live outcome: {outcome:?}"),
+    };
+    assert_eq!(supervisor.uncertainties().len(), 1);
+    assert_eq!(
+        supervisor.uncertainties()[0].scope(),
+        ReconciliationScopeKind::SourceAudit
+    );
+    assert_eq!(
+        supervisor.uncertainties()[0].reasons(),
+        &[UncertaintyReason::LiveUnproven]
+    );
+
+    let dispatched = supervisor.dispatch_next().expect("live dispatch");
+    assert_eq!(dispatched.ticket(), ticket);
+    assert_eq!(dispatched.normalized().proof(), &Proof::Unproven);
+    assert_eq!(
+        dispatched.normalized().envelope().observations(),
+        expected_observations.as_slice()
+    );
+}
+
+#[test]
+fn valid_replay_adapter_attaches_exact_continuity_fields_without_adapter_uncertainty() {
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let stream = BackendStreamIdentity::from_bytes(b"stream-a".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 8));
+    let (_lane, generation) = adapter_registered(&mut supervisor, &source, &root);
+    let prior = ReplayPriorToken::new(source.clone(), root.clone(), stream.clone(), generation, 10);
+    let observations = vec![
+        adapter_observation(RawEventKind::Create, "first.wav"),
+        adapter_observation(RawEventKind::Delete, "second.wav"),
+    ];
+    let expected_observations = observations.clone();
+    let admission = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_replay(
+                adapter_batch(
+                    adapter_capture_provenance(
+                        "source-a",
+                        Some(b"root-a".to_vec()),
+                        Some(b"stream-a".to_vec()),
+                        generation.get(),
+                        Some(11),
+                        Some(12),
+                    ),
+                    observations,
+                ),
+                Some(&prior),
+                true,
+            )
+            .expect("valid replay admission")
+    };
+    assert_eq!(
+        admission.disposition(),
+        AdapterDisposition::AdmittedWithContinuity
+    );
+    let ticket = match admission.outcome() {
+        AdmissionOutcome::Accepted(ticket) => *ticket,
+        outcome => panic!("unexpected replay outcome: {outcome:?}"),
+    };
+    assert!(supervisor.uncertainties().is_empty());
+
+    let dispatched = supervisor.dispatch_next().expect("replay dispatch");
+    assert_eq!(dispatched.ticket(), ticket);
+    let proof = dispatched
+        .normalized()
+        .proof()
+        .watcher_continuity()
+        .expect("continuity proof");
+    assert_eq!(proof.source_id(), &source);
+    assert_eq!(proof.root_identity(), &root);
+    assert_eq!(proof.backend_stream_identity(), &stream);
+    assert_eq!(proof.watcher_generation(), generation);
+    assert_eq!(proof.prior_acknowledgement().sequence(), 10);
+    assert_eq!(proof.replay_coverage().after_sequence(), 10);
+    assert_eq!(proof.replay_coverage().through_sequence(), 12);
+    assert!(proof.replay_coverage().is_contiguous());
+    assert_eq!(
+        dispatched.normalized().envelope().observations(),
+        expected_observations.as_slice()
+    );
+}
+
+#[test]
+fn invalid_replay_claims_remain_unproven_and_retain_typed_source_audit_evidence() {
+    let valid_prior = replay_prior("source-a", b"root-a", b"stream-a", 1, 10);
+    let valid_observations = || vec![adapter_observation(RawEventKind::Create, "sample.wav")];
+
+    assert_invalid_replay_case(
+        adapter_batch(
+            adapter_capture_provenance(
+                "source-a",
+                Some(b"root-a".to_vec()),
+                Some(b"stream-a".to_vec()),
+                1,
+                Some(11),
+                Some(12),
+            ),
+            valid_observations(),
+        ),
+        None,
+        true,
+        UncertaintyReason::ReplayContinuityMissing,
+        true,
+    );
+    assert_invalid_replay_case(
+        adapter_batch(
+            adapter_capture_provenance(
+                "source-a",
+                None,
+                Some(b"stream-a".to_vec()),
+                1,
+                Some(11),
+                Some(12),
+            ),
+            valid_observations(),
+        ),
+        Some(&valid_prior),
+        true,
+        UncertaintyReason::ReplayContinuityMissing,
+        false,
+    );
+    assert_invalid_replay_case(
+        adapter_batch(
+            adapter_capture_provenance(
+                "source-a",
+                Some(b"root-a".to_vec()),
+                None,
+                1,
+                Some(11),
+                Some(12),
+            ),
+            valid_observations(),
+        ),
+        Some(&valid_prior),
+        true,
+        UncertaintyReason::ReplayContinuityMissing,
+        true,
+    );
+    for (first_sequence, last_sequence) in [(None, None), (Some(11), None), (None, Some(12))] {
+        let expected_reason = if first_sequence.is_none() && last_sequence.is_none() {
+            UncertaintyReason::ReplayContinuityMissing
+        } else {
+            UncertaintyReason::ReplayContinuityAmbiguous
+        };
+        assert_invalid_replay_case(
+            adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    1,
+                    first_sequence,
+                    last_sequence,
+                ),
+                valid_observations(),
+            ),
+            Some(&valid_prior),
+            true,
+            expected_reason,
+            true,
+        );
+    }
+    for (first_sequence, last_sequence, acknowledged_sequence, contiguous) in [
+        (Some(12), Some(13), 10, true),
+        (Some(11), Some(11), 11, true),
+        (Some(11), Some(12), 10, false),
+    ] {
+        let prior = replay_prior("source-a", b"root-a", b"stream-a", 1, acknowledged_sequence);
+        assert_invalid_replay_case(
+            adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    1,
+                    first_sequence,
+                    last_sequence,
+                ),
+                valid_observations(),
+            ),
+            Some(&prior),
+            contiguous,
+            UncertaintyReason::ReplayContinuityGap,
+            true,
+        );
+    }
+
+    let mismatch_cases = [
+        (
+            adapter_capture_provenance(
+                "source-a",
+                Some(b"root-a".to_vec()),
+                Some(b"stream-a".to_vec()),
+                1,
+                Some(11),
+                Some(12),
+            ),
+            replay_prior("source-b", b"root-a", b"stream-a", 1, 10),
+            true,
+            true,
+        ),
+        (
+            adapter_capture_provenance(
+                "source-a",
+                Some(b"root-a".to_vec()),
+                Some(b"stream-a".to_vec()),
+                1,
+                Some(11),
+                Some(12),
+            ),
+            replay_prior("source-a", b"root-b", b"stream-a", 1, 10),
+            true,
+            true,
+        ),
+        (
+            adapter_capture_provenance(
+                "source-a",
+                Some(b"root-a".to_vec()),
+                Some(b"stream-a".to_vec()),
+                1,
+                Some(11),
+                Some(12),
+            ),
+            replay_prior("source-a", b"root-a", b"stream-b", 1, 10),
+            true,
+            true,
+        ),
+        (
+            adapter_capture_provenance(
+                "source-a",
+                Some(b"root-a".to_vec()),
+                Some(b"stream-a".to_vec()),
+                1,
+                Some(11),
+                Some(12),
+            ),
+            replay_prior("source-a", b"root-a", b"stream-a", 8, 10),
+            true,
+            true,
+        ),
+    ];
+    for (provenance, prior, contiguous, _) in mismatch_cases {
+        assert_invalid_replay_case(
+            adapter_batch(provenance, valid_observations()),
+            Some(&prior),
+            contiguous,
+            UncertaintyReason::ReplayContinuityMismatch,
+            true,
+        );
+    }
+
+    for kind in [
+        RawEventKind::RootChanged,
+        RawEventKind::Overflow,
+        RawEventKind::Error,
+        RawEventKind::Unsupported,
+    ] {
+        assert_invalid_replay_case(
+            adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    1,
+                    Some(11),
+                    Some(12),
+                ),
+                vec![RawObservation::new(kind, Vec::new())],
+            ),
+            Some(&valid_prior),
+            true,
+            UncertaintyReason::ReplayContinuityMismatch,
+            !matches!(
+                kind,
+                RawEventKind::Overflow | RawEventKind::Error | RawEventKind::Unsupported
+            ),
+        );
+    }
+    assert_invalid_replay_case(
+        adapter_batch(
+            adapter_capture_provenance(
+                "source-a",
+                Some(b"root-a".to_vec()),
+                Some(b"stream-a".to_vec()),
+                1,
+                Some(11),
+                Some(12),
+            ),
+            vec![
+                adapter_observation(RawEventKind::Create, "sample.wav")
+                    .with_uncertainty(ObservationUncertainty::CONTINUITY),
+            ],
+        ),
+        Some(&valid_prior),
+        true,
+        UncertaintyReason::ReplayContinuityMismatch,
+        true,
+    );
+}
+
+#[test]
+fn adapter_preserves_exact_live_and_replay_duplicate_suppression() {
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let provenance = adapter_capture_provenance(
+        "source-a",
+        Some(b"root-a".to_vec()),
+        Some(b"stream-a".to_vec()),
+        1,
+        Some(10),
+        Some(12),
+    );
+    let batch = adapter_batch(
+        provenance.clone(),
+        vec![adapter_observation(RawEventKind::Create, "sample.wav")],
+    );
+    let mut live_supervisor =
+        ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 8));
+    adapter_registered(&mut live_supervisor, &source, &root);
+    let (first_live, second_live) = {
+        let mut adapter = ReconciliationAdapter::new(&mut live_supervisor);
+        (
+            adapter.admit_live(batch.clone()).expect("first live"),
+            adapter.admit_live(batch).expect("duplicate live"),
+        )
+    };
+    assert_eq!(
+        first_live.disposition(),
+        AdapterDisposition::AdmittedUnproven
+    );
+    assert_eq!(
+        second_live.disposition(),
+        AdapterDisposition::DuplicateSuppressed
+    );
+    assert!(matches!(
+        second_live.outcome(),
+        AdmissionOutcome::DuplicateSuppressed(CaptureSequenceRange { .. })
+    ));
+    assert_eq!(live_supervisor.in_flight(), 1);
+    assert_eq!(live_supervisor.uncertainties().len(), 1);
+
+    let prior = replay_prior("source-a", b"root-a", b"stream-a", 1, 9);
+    let mut replay_supervisor =
+        ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 8));
+    adapter_registered(&mut replay_supervisor, &source, &root);
+    let replay_batch = adapter_batch(
+        provenance,
+        vec![adapter_observation(RawEventKind::Modify, "sample.wav")],
+    );
+    let (first_replay, second_replay) = {
+        let mut adapter = ReconciliationAdapter::new(&mut replay_supervisor);
+        (
+            adapter
+                .admit_replay(replay_batch.clone(), Some(&prior), true)
+                .expect("first replay"),
+            adapter
+                .admit_replay(replay_batch, Some(&prior), true)
+                .expect("duplicate replay"),
+        )
+    };
+    assert_eq!(
+        first_replay.disposition(),
+        AdapterDisposition::AdmittedWithContinuity
+    );
+    assert_eq!(
+        second_replay.disposition(),
+        AdapterDisposition::DuplicateSuppressed
+    );
+    assert_eq!(replay_supervisor.in_flight(), 1);
+    assert!(replay_supervisor.uncertainties().is_empty());
+}
+
+#[test]
+fn adapter_marker_only_duplicates_remember_live_and_invalid_replay_evidence() {
+    for kind in [
+        RawEventKind::Overflow,
+        RawEventKind::Error,
+        RawEventKind::Unsupported,
+    ] {
+        let source = SourceId::from_string("source-a");
+        let root = RootIdentity::from_bytes(b"root-a".to_vec());
+        let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 1));
+        let (_lane, generation) = adapter_registered(&mut supervisor, &source, &root);
+        let batch = adapter_batch(
+            adapter_capture_provenance(
+                "source-a",
+                Some(b"root-a".to_vec()),
+                Some(b"stream-a".to_vec()),
+                generation.get(),
+                Some(10),
+                Some(10),
+            ),
+            vec![RawObservation::new(kind, Vec::new())],
+        );
+        let (first, second) = {
+            let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+            (
+                adapter
+                    .admit_live(batch.clone())
+                    .expect("first marker-only live"),
+                adapter
+                    .admit_live(batch)
+                    .expect("duplicate marker-only live"),
+            )
+        };
+        assert_eq!(first.disposition(), AdapterDisposition::SourceAuditRequired);
+        assert!(matches!(first.outcome(), AdmissionOutcome::Rejected(_)));
+        assert_eq!(
+            second.disposition(),
+            AdapterDisposition::DuplicateSuppressed
+        );
+        assert_eq!(
+            second.outcome(),
+            &AdmissionOutcome::DuplicateSuppressed(CaptureSequenceRange::new(10, 10))
+        );
+        assert_eq!(supervisor.in_flight(), 0);
+        assert_eq!(supervisor.uncertainties().len(), 1);
+    }
+
+    for kind in [
+        RawEventKind::Overflow,
+        RawEventKind::Error,
+        RawEventKind::Unsupported,
+    ] {
+        let source = SourceId::from_string("source-a");
+        let root = RootIdentity::from_bytes(b"root-a".to_vec());
+        let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 1));
+        let (_lane, generation) = adapter_registered(&mut supervisor, &source, &root);
+        let prior = replay_prior("source-a", b"root-a", b"stream-a", generation.get(), 9);
+        let batch = adapter_batch(
+            adapter_capture_provenance(
+                "source-a",
+                Some(b"root-a".to_vec()),
+                Some(b"stream-a".to_vec()),
+                generation.get(),
+                Some(10),
+                Some(10),
+            ),
+            vec![RawObservation::new(kind, Vec::new())],
+        );
+        let (first, second) = {
+            let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+            (
+                adapter
+                    .admit_replay(batch.clone(), Some(&prior), true)
+                    .expect("first marker-only replay"),
+                adapter
+                    .admit_replay(batch, Some(&prior), true)
+                    .expect("duplicate marker-only replay"),
+            )
+        };
+        assert_eq!(first.disposition(), AdapterDisposition::SourceAuditRequired);
+        assert!(matches!(first.outcome(), AdmissionOutcome::Rejected(_)));
+        assert_eq!(
+            second.disposition(),
+            AdapterDisposition::DuplicateSuppressed
+        );
+        assert_eq!(
+            second.outcome(),
+            &AdmissionOutcome::DuplicateSuppressed(CaptureSequenceRange::new(10, 10))
+        );
+        assert_eq!(supervisor.in_flight(), 0);
+        assert_eq!(supervisor.uncertainties().len(), 1);
+        assert!(
+            supervisor.uncertainties()[0]
+                .reasons()
+                .contains(&UncertaintyReason::ReplayContinuityMismatch)
+        );
+    }
+}
+
+#[test]
+fn adapter_marker_only_same_sequence_conflict_retains_audit_and_suppresses_exact_repeat() {
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let provenance = adapter_capture_provenance(
+        "source-a",
+        Some(b"root-a".to_vec()),
+        Some(b"stream-a".to_vec()),
+        1,
+        Some(10),
+        Some(10),
+    );
+    let first_batch = adapter_batch(
+        provenance.clone(),
+        vec![RawObservation::new(RawEventKind::Overflow, Vec::new())],
+    );
+    let conflict_batch = adapter_batch(
+        provenance,
+        vec![RawObservation::new(RawEventKind::Error, Vec::new())],
+    );
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 2));
+    adapter_registered(&mut supervisor, &source, &root);
+    let (first, conflict, duplicate) = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        (
+            adapter
+                .admit_live(first_batch.clone())
+                .expect("first marker-only evidence"),
+            adapter
+                .admit_live(conflict_batch)
+                .expect("conflicting marker-only evidence"),
+            adapter
+                .admit_live(first_batch)
+                .expect("exact marker-only repeat"),
+        )
+    };
+    assert!(matches!(first.outcome(), AdmissionOutcome::Rejected(_)));
+    assert!(matches!(conflict.outcome(), AdmissionOutcome::Rejected(_)));
+    assert!(
+        supervisor.uncertainties()[1]
+            .reasons()
+            .contains(&UncertaintyReason::SequenceConflict)
+    );
+    assert_eq!(
+        duplicate.disposition(),
+        AdapterDisposition::DuplicateSuppressed
+    );
+    assert_eq!(supervisor.in_flight(), 0);
+    assert_eq!(supervisor.uncertainties().len(), 2);
+}
+
+#[test]
+fn adjacent_valid_replays_preserve_fifo_and_raw_order() {
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(4, 8));
+    adapter_registered(&mut supervisor, &source, &root);
+    let first_prior = replay_prior("source-a", b"root-a", b"stream-a", 1, 10);
+    let second_prior = replay_prior("source-a", b"root-a", b"stream-a", 1, 12);
+    let first_observations = vec![
+        adapter_observation(RawEventKind::Create, "first-a.wav"),
+        adapter_observation(RawEventKind::Modify, "first-b.wav"),
+    ];
+    let second_observations = vec![
+        adapter_observation(RawEventKind::Delete, "second-a.wav"),
+        adapter_observation(RawEventKind::Rename, "second-b.wav"),
+    ];
+    let first_admission = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_replay(
+                adapter_batch(
+                    adapter_capture_provenance(
+                        "source-a",
+                        Some(b"root-a".to_vec()),
+                        Some(b"stream-a".to_vec()),
+                        1,
+                        Some(11),
+                        Some(12),
+                    ),
+                    first_observations.clone(),
+                ),
+                Some(&first_prior),
+                true,
+            )
+            .expect("first adjacent replay")
+    };
+    let second_admission = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_replay(
+                adapter_batch(
+                    adapter_capture_provenance(
+                        "source-a",
+                        Some(b"root-a".to_vec()),
+                        Some(b"stream-a".to_vec()),
+                        1,
+                        Some(13),
+                        Some(14),
+                    ),
+                    second_observations.clone(),
+                ),
+                Some(&second_prior),
+                true,
+            )
+            .expect("second adjacent replay")
+    };
+    let first_ticket = match first_admission.outcome() {
+        AdmissionOutcome::Accepted(ticket) => *ticket,
+        outcome => panic!("unexpected first adjacent outcome: {outcome:?}"),
+    };
+    let second_ticket = match second_admission.outcome() {
+        AdmissionOutcome::Accepted(ticket) => *ticket,
+        outcome => panic!("unexpected second adjacent outcome: {outcome:?}"),
+    };
+    let first_dispatch = supervisor.dispatch_next().expect("first FIFO dispatch");
+    let second_dispatch = supervisor.dispatch_next().expect("second FIFO dispatch");
+    assert_eq!(first_dispatch.ticket(), first_ticket);
+    assert_eq!(second_dispatch.ticket(), second_ticket);
+    assert_eq!(
+        first_dispatch.normalized().envelope().observations(),
+        first_observations.as_slice()
+    );
+    assert_eq!(
+        second_dispatch.normalized().envelope().observations(),
+        second_observations.as_slice()
+    );
+    assert_eq!(
+        first_dispatch
+            .normalized()
+            .proof()
+            .watcher_continuity()
+            .expect("first proof")
+            .replay_coverage()
+            .through_sequence(),
+        12
+    );
+    assert_eq!(
+        second_dispatch
+            .normalized()
+            .proof()
+            .watcher_continuity()
+            .expect("second proof")
+            .replay_coverage()
+            .through_sequence(),
+        14
+    );
+}
+
+#[test]
+fn adapter_error_preserves_original_batch_and_capacity_is_atomic() {
+    let invalid_batch = adapter_batch(
+        adapter_capture_provenance(
+            "source-a",
+            Some(b"root-a".to_vec()),
+            Some(b"stream-a".to_vec()),
+            1,
+            None,
+            None,
+        ),
+        Vec::new(),
+    );
+    let expected_batch = invalid_batch.clone();
+    let mut empty_supervisor =
+        ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 8));
+    let error = {
+        let mut adapter = ReconciliationAdapter::new(&mut empty_supervisor);
+        adapter
+            .admit_live(invalid_batch)
+            .expect_err("empty batch error")
+    };
+    assert_eq!(error.error(), &RawEnvelopeError::EmptyEnvelope);
+    assert_eq!(error.batch(), &expected_batch);
+    assert_eq!(error.into_batch(), expected_batch);
+
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 1));
+    adapter_registered(&mut supervisor, &source, &root);
+    let first = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live(adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    1,
+                    Some(1),
+                    Some(1),
+                ),
+                vec![adapter_observation(RawEventKind::Create, "first.wav")],
+            ))
+            .expect("first live admission")
+    };
+    assert_eq!(first.disposition(), AdapterDisposition::AdmittedUnproven);
+    let second_batch = adapter_batch(
+        adapter_capture_provenance(
+            "source-a",
+            Some(b"root-a".to_vec()),
+            Some(b"stream-a".to_vec()),
+            1,
+            Some(2),
+            Some(2),
+        ),
+        vec![adapter_observation(RawEventKind::Create, "second.wav")],
+    );
+    let expected_second = second_batch.clone();
+    let second = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter.admit_live(second_batch).expect("capacity result")
+    };
+    assert_eq!(
+        second.disposition(),
+        AdapterDisposition::UncertaintyCapacityExhausted
+    );
+    match second.outcome() {
+        AdmissionOutcome::UncertaintyCapacityExhausted(envelope) => {
+            assert_eq!(envelope.proof(), &Proof::Unproven);
+            assert_eq!(envelope.observations(), expected_second.observations());
+        }
+        outcome => panic!("unexpected capacity outcome: {outcome:?}"),
+    }
+    assert_eq!(supervisor.in_flight(), 1);
+    assert_eq!(supervisor.uncertainties().len(), 1);
+}
+
+#[test]
+fn adapter_remains_fenced_by_cancellation_restart_and_rebind() {
+    let source = SourceId::from_string("source-a");
+    let old_root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let new_root = RootIdentity::from_bytes(b"root-b".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(4, 8));
+    let (lane, generation) = adapter_registered(&mut supervisor, &source, &old_root);
+
+    let first = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live(adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    generation.get(),
+                    Some(1),
+                    Some(1),
+                ),
+                vec![adapter_observation(RawEventKind::Create, "first.wav")],
+            ))
+            .expect("first live admission")
+    };
+    assert_eq!(first.disposition(), AdapterDisposition::AdmittedUnproven);
+    supervisor.stop_lane(&lane, generation).expect("stop lane");
+    let restarted_generation = supervisor.restart_lane(&lane).expect("restart lane");
+    supervisor
+        .begin_capture(&lane, restarted_generation)
+        .expect("begin restarted capture");
+
+    let stale = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live(adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    generation.get(),
+                    Some(2),
+                    Some(2),
+                ),
+                vec![adapter_observation(RawEventKind::Modify, "stale.wav")],
+            ))
+            .expect("stale live admission result")
+    };
+    assert_eq!(stale.disposition(), AdapterDisposition::SourceAuditRequired);
+    assert_eq!(
+        stale.outcome(),
+        &AdmissionOutcome::Rejected(AdmissionRejectReason::StaleGeneration)
+    );
+
+    let (new_lane, new_generation) = supervisor
+        .rebind_lane(&lane, restarted_generation, new_root.clone())
+        .expect("rebind lane");
+    supervisor
+        .begin_capture(&new_lane, new_generation)
+        .expect("begin rebound capture");
+    let rebound = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live(adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-b".to_vec()),
+                    Some(b"stream-b".to_vec()),
+                    new_generation.get(),
+                    Some(3),
+                    Some(3),
+                ),
+                vec![adapter_observation(RawEventKind::Create, "rebound.wav")],
+            ))
+            .expect("rebound live admission")
+    };
+    assert_eq!(rebound.disposition(), AdapterDisposition::AdmittedUnproven);
+    assert!(matches!(rebound.outcome(), AdmissionOutcome::Accepted(_)));
 }


### PR DESCRIPTION
## Goal\n\nAdd the next bounded Wavecrate I/O target-alignment slice: a backend-neutral live and replay adapter over the existing reconciliation admission supervisor.\n\n## Scope\n\n- Keep live observations explicitly unproven and retain typed SourceAudit uncertainty.\n- Validate identity-bound, contiguous replay evidence before attaching watcher continuity proof.\n- Retain invalid replay evidence as unproven audit input.\n- Preserve bounded capacity, lifecycle fences, ordering, duplicate/conflict handling, cancellation, restart, rebind, and acknowledgement boundaries.\n- Preserve original batches on envelope-construction errors.\n- Add focused regression coverage, including marker-only duplicate suppression.\n\n## Non-goals\n\nNo native watcher, filesystem, database, source-writer, GUI, schema, documentation, or external runtime integration changes. This adapter does not establish committed source authority.\n\n## Definition of Done\n\n- Live input remains Proof::Unproven with atomic LiveUnproven audit retention.\n- Only exact identity-bound contiguous replay receives WatcherContinuityProof.\n- Invalid or uncertain replay remains visible as unproven SourceAudit evidence.\n- Exact marker-only duplicates are suppressed without tickets, usage, or redundant markers; conflicting evidence remains audited.\n- The reconciliation library tests and package gates pass.\n\n## Validation\n\n- cargo test -p wavecrate-library --lib reconciliation — 53 passed\n- cargo test -p wavecrate-library --lib — 347 passed\n- cargo check -p wavecrate-library --tests — passed\n- RUSTDOCFLAGS=-D warnings cargo doc -p wavecrate-library --no-deps — passed\n- cargo fmt --check --package wavecrate-library — passed\n- git diff --check — passed\n- cargo clippy -p wavecrate-library --all-targets — only the three pre-existing DB warnings in file_ops_journal/reconcile.rs, db/open/paths.rs, and db/write/manifest_audit.rs\n\n## Known limitations\n\nNative watcher delivery, durable acknowledgement ownership, and external runtime integration remain intentionally out of scope for this slice.\n\nTerra independently reviewed the corrected exact diff and approved it. User approval is required before merge.