### PR TITLE
Add opaque live audit correlation token

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/reconciliation/adapter.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/adapter.rs
@@ -9,7 +9,10 @@ use std::fmt;
 
 use crate::sample_sources::SourceId;
 
-use super::admission::{AdmissionOutcome, ReconciliationAdmissionSupervisor, UncertaintyReason};
+use super::admission::{
+    AdmissionOutcome, DispatchTicket, ReconciliationAcknowledgementIdentity,
+    ReconciliationAdmissionSupervisor, RetainedUncertaintyBoundary, UncertaintyReason,
+};
 use super::model::{
     BackendStreamIdentity, CaptureSequenceEvidence, CaptureSequenceRange,
     DurablePriorAcknowledgement, Proof, RawEnvelopeError, RawEventKind, RawObservation,
@@ -164,6 +167,79 @@ impl AdapterAdmission {
     }
 }
 
+/// An opaque correlation for one accepted live batch and its retained source-audit marker.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LiveAuditCorrelation {
+    ticket: DispatchTicket,
+    identity: ReconciliationAcknowledgementIdentity,
+    boundary: RetainedUncertaintyBoundary,
+}
+
+impl LiveAuditCorrelation {
+    pub(crate) fn new(
+        ticket: DispatchTicket,
+        identity: ReconciliationAcknowledgementIdentity,
+        boundary: RetainedUncertaintyBoundary,
+    ) -> Self {
+        Self {
+            ticket,
+            identity,
+            boundary,
+        }
+    }
+
+    /// Return the ticket assigned to the accepted live batch.
+    pub const fn ticket(&self) -> DispatchTicket {
+        self.ticket
+    }
+
+    /// Borrow the exact identity bound to the retained source-audit marker.
+    pub const fn identity(&self) -> &ReconciliationAcknowledgementIdentity {
+        &self.identity
+    }
+
+    /// Return the retained source-audit watermark boundary.
+    pub const fn boundary(&self) -> RetainedUncertaintyBoundary {
+        self.boundary
+    }
+}
+
+/// A live adapter admission together with its optional retained source-audit correlation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LiveAuditAdmission {
+    admission: AdapterAdmission,
+    correlation: Option<LiveAuditCorrelation>,
+}
+
+impl LiveAuditAdmission {
+    fn new(admission: AdapterAdmission, correlation: Option<LiveAuditCorrelation>) -> Self {
+        Self {
+            admission,
+            correlation,
+        }
+    }
+
+    /// Borrow the existing adapter admission.
+    pub const fn admission(&self) -> &AdapterAdmission {
+        &self.admission
+    }
+
+    /// Borrow the optional opaque live-audit correlation.
+    pub const fn correlation(&self) -> Option<&LiveAuditCorrelation> {
+        self.correlation.as_ref()
+    }
+
+    /// Consume the wrapper and return the existing adapter admission.
+    pub fn into_admission(self) -> AdapterAdmission {
+        self.admission
+    }
+
+    /// Consume the wrapper and return the optional live-audit correlation.
+    pub fn into_correlation(self) -> Option<LiveAuditCorrelation> {
+        self.correlation
+    }
+}
+
 /// An opaque identity-bound prior used by the replay adapter.
 ///
 /// The constructor is crate-restricted because the acknowledgement sequence is
@@ -258,6 +334,48 @@ impl<'a> ReconciliationAdapter<'a> {
             disposition(AdmissionKind::Live, &outcome),
             outcome,
         ))
+    }
+
+    /// Admit a live batch and correlate an accepted result with its new audit marker.
+    ///
+    /// The correlation carries no authority and is absent when admission is not accepted or
+    /// when the required newly retained marker cannot be matched exactly.
+    pub fn admit_live_with_correlation(
+        &mut self,
+        batch: SyntheticObservationBatch,
+    ) -> Result<LiveAuditAdmission, AdapterError> {
+        let provenance = batch.provenance().clone();
+        let uncertainty_start = self.supervisor.uncertainties().len();
+        let admission = self.admit_live(batch)?;
+        let correlation = match admission.outcome() {
+            AdmissionOutcome::Accepted(ticket) => self
+                .supervisor
+                .uncertainties()
+                .get(uncertainty_start..)
+                .and_then(|markers| {
+                    markers.iter().find(|marker| {
+                        marker.source_id() == Some(provenance.source_id())
+                            && marker.root_identity() == provenance.root_identity()
+                            && marker.generation() == Some(provenance.watcher_generation())
+                            && marker.reasons().contains(&UncertaintyReason::LiveUnproven)
+                    })
+                })
+                .and_then(|marker| {
+                    provenance.root_identity().map(|root_identity| {
+                        LiveAuditCorrelation::new(
+                            *ticket,
+                            ReconciliationAcknowledgementIdentity::new(
+                                provenance.source_id().clone(),
+                                root_identity.clone(),
+                                provenance.watcher_generation(),
+                            ),
+                            marker.boundary(),
+                        )
+                    })
+                }),
+            _ => None,
+        };
+        Ok(LiveAuditAdmission::new(admission, correlation))
     }
 
     /// Admit replay after validating its identity and contiguous capture claim.

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
@@ -9,8 +9,8 @@ mod normalize;
 mod tests;
 
 pub use adapter::{
-    AdapterAdmission, AdapterDisposition, AdapterError, ReconciliationAdapter, ReplayPriorToken,
-    SyntheticObservationBatch,
+    AdapterAdmission, AdapterDisposition, AdapterError, LiveAuditAdmission, LiveAuditCorrelation,
+    ReconciliationAdapter, ReplayPriorToken, SyntheticObservationBatch,
 };
 pub use admission::{
     AdmissionError, AdmissionLaneKey, AdmissionOutcome, AdmissionRejectReason,

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
@@ -859,6 +859,178 @@ fn live_adapter_is_unproven_ordered_and_retains_one_audit_marker() {
 }
 
 #[test]
+fn live_adapter_correlation_binds_ticket_identity_and_new_marker_boundary() {
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 8));
+    let (_lane, generation) = adapter_registered(&mut supervisor, &source, &root);
+
+    {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live(adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    generation.get(),
+                    Some(10),
+                    Some(10),
+                ),
+                vec![adapter_observation(RawEventKind::Create, "first.wav")],
+            ))
+            .expect("first live admission");
+    }
+
+    let markers_before = supervisor.uncertainties().len();
+    let provenance = adapter_capture_provenance(
+        "source-a",
+        Some(b"root-a".to_vec()),
+        Some(b"stream-a".to_vec()),
+        generation.get(),
+        Some(11),
+        Some(11),
+    );
+    let admission = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live_with_correlation(adapter_batch(
+                provenance.clone(),
+                vec![adapter_observation(RawEventKind::Modify, "second.wav")],
+            ))
+            .expect("correlated live admission")
+    };
+
+    let ticket = match admission.admission().outcome() {
+        AdmissionOutcome::Accepted(ticket) => *ticket,
+        outcome => panic!("unexpected live outcome: {outcome:?}"),
+    };
+    let correlation = admission.correlation().expect("live correlation");
+    assert_eq!(correlation.ticket(), ticket);
+    assert_eq!(correlation.identity().source_id(), provenance.source_id());
+    assert_eq!(
+        correlation.identity().root_identity(),
+        provenance.root_identity().expect("root identity")
+    );
+    assert_eq!(
+        correlation.identity().generation(),
+        provenance.watcher_generation()
+    );
+    let marker = &supervisor.uncertainties()[markers_before];
+    assert_eq!(marker.scope(), ReconciliationScopeKind::SourceAudit);
+    assert!(marker.reasons().contains(&UncertaintyReason::LiveUnproven));
+    assert_eq!(correlation.boundary(), marker.boundary());
+}
+
+#[test]
+fn live_adapter_correlation_is_none_for_duplicate_admission() {
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 8));
+    let (_lane, generation) = adapter_registered(&mut supervisor, &source, &root);
+    let batch = adapter_batch(
+        adapter_capture_provenance(
+            "source-a",
+            Some(b"root-a".to_vec()),
+            Some(b"stream-a".to_vec()),
+            generation.get(),
+            Some(10),
+            Some(10),
+        ),
+        vec![adapter_observation(RawEventKind::Create, "sample.wav")],
+    );
+
+    let (first, duplicate) = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        (
+            adapter
+                .admit_live_with_correlation(batch.clone())
+                .expect("first live admission"),
+            adapter
+                .admit_live_with_correlation(batch)
+                .expect("duplicate live admission"),
+        )
+    };
+    assert!(first.correlation().is_some());
+    assert!(duplicate.correlation().is_none());
+    assert!(matches!(
+        duplicate.admission().outcome(),
+        AdmissionOutcome::DuplicateSuppressed(_)
+    ));
+}
+
+#[test]
+fn live_adapter_correlation_is_none_for_rejection_and_capacity() {
+    let rejected_batch = adapter_batch(
+        adapter_capture_provenance(
+            "unregistered-source",
+            Some(b"root-a".to_vec()),
+            Some(b"stream-a".to_vec()),
+            1,
+            Some(1),
+            Some(1),
+        ),
+        vec![adapter_observation(RawEventKind::Create, "rejected.wav")],
+    );
+    let mut rejected_supervisor =
+        ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 8));
+    let rejected = {
+        let mut adapter = ReconciliationAdapter::new(&mut rejected_supervisor);
+        adapter
+            .admit_live_with_correlation(rejected_batch)
+            .expect("rejected live admission result")
+    };
+    assert!(rejected.correlation().is_none());
+    assert!(matches!(
+        rejected.admission().outcome(),
+        AdmissionOutcome::Rejected(_)
+    ));
+
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let mut capacity_supervisor =
+        ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 1));
+    let (_lane, generation) = adapter_registered(&mut capacity_supervisor, &source, &root);
+    {
+        let mut adapter = ReconciliationAdapter::new(&mut capacity_supervisor);
+        adapter
+            .admit_live(adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    generation.get(),
+                    Some(1),
+                    Some(1),
+                ),
+                vec![adapter_observation(RawEventKind::Create, "first.wav")],
+            ))
+            .expect("first live admission");
+    }
+    let capacity = {
+        let mut adapter = ReconciliationAdapter::new(&mut capacity_supervisor);
+        adapter
+            .admit_live_with_correlation(adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    generation.get(),
+                    Some(2),
+                    Some(2),
+                ),
+                vec![adapter_observation(RawEventKind::Create, "second.wav")],
+            ))
+            .expect("capacity live admission result")
+    };
+    assert!(capacity.correlation().is_none());
+    assert!(matches!(
+        capacity.admission().outcome(),
+        AdmissionOutcome::UncertaintyCapacityExhausted(_)
+    ));
+}
+
+#[test]
 fn valid_replay_adapter_attaches_exact_continuity_fields_without_adapter_uncertainty() {
     let source = SourceId::from_string("source-a");
     let root = RootIdentity::from_bytes(b"root-a".to_vec());


### PR DESCRIPTION
## Goal\n\nAdvance the Wavecrate I/O target alignment with the first checked handoff between live reconciliation admission and a future authoritative audit owner.\n\n## Scope\n\n- Add an opaque LiveAuditCorrelation bound to an accepted live dispatch ticket.\n- Bind the correlation to the exact source, physical root, watcher generation, and newly retained LiveUnproven SourceAudit watermark.\n- Return no correlation for duplicate, rejected, or uncertainty-capacity outcomes.\n- Add focused coverage for accepted, duplicate, rejection, and bounded-capacity behavior.\n\n## Non-goals\n\nNo native watcher, source-processing scheduler, scanner, filesystem, database, schema, UI, acknowledgement-clearing, or live continuity-proof changes. The token grants no committed authority and does not promote live evidence beyond Proof::Unproven.\n\n## Definition of Done\n\n- Correlation can only be minted from accepted live admission and a newly retained matching audit marker.\n- Ticket, identity, and watermark remain exact and identity-bound.\n- Generic admission behavior is unchanged.\n- The API remains an inert handoff token until a later owner-controlled acknowledgement slice.\n- Reconciliation and full library tests pass.\n\n## Validation\n\n- cargo test -p wavecrate-library live_adapter_correlation -- --nocapture — 3 passed\n- cargo test -p wavecrate-library --lib reconciliation — 56 passed\n- cargo test -p wavecrate-library --lib — 350 passed\n- cargo check -p wavecrate-library --tests — passed\n- RUSTDOCFLAGS=-D warnings cargo doc -p wavecrate-library --no-deps — passed\n- cargo fmt --check --package wavecrate-library — passed\n- rustfmt --edition 2024 on changed reconciliation files — passed\n- git diff --check — passed\n- cargo clippy -p wavecrate-library --all-targets — only the three pre-existing DB warnings in file_ops_journal/reconcile.rs, db/open/paths.rs, and db/write/manifest_audit.rs\n\n## Known limitations\n\nNative live watcher wiring and capability-bound committed acknowledgement remain the next dependent slices. Real macOS Finder acceptance is not claimed here.\n\nTerra independently reviewed the exact diff and approved it. User approval is required before merge.