### PR TITLE
Bound native watcher ingress capture

### DIFF
--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+mod capture;
 mod classification;
 mod debounce;
 mod handle;

--- a/src/native_app/sample_library/source_watcher/capture.rs
+++ b/src/native_app/sample_library/source_watcher/capture.rs
@@ -1,0 +1,160 @@
+use notify::Event;
+
+pub(super) const MAX_CAPTURE_PATHS: usize = 4_096;
+pub(super) const MAX_CAPTURE_PATH_BYTES: usize = 256 * 1_024;
+pub(super) const MAX_CAPTURE_METADATA_BYTES: usize = 256 * 1_024;
+
+pub(super) enum SourceWatcherCapture {
+    Notify(Event),
+    Error,
+    Overflow,
+}
+
+pub(super) fn capture_event(event: notify::Result<Event>) -> SourceWatcherCapture {
+    let Ok(captured_event) = event else {
+        return SourceWatcherCapture::Error;
+    };
+
+    if captured_event.paths.len() > MAX_CAPTURE_PATHS {
+        return SourceWatcherCapture::Overflow;
+    }
+
+    let path_bytes = captured_event.paths.iter().try_fold(0usize, |total, path| {
+        let total = total.checked_add(path.as_os_str().as_encoded_bytes().len())?;
+        (total <= MAX_CAPTURE_PATH_BYTES).then_some(total)
+    });
+    let metadata_bytes = captured_event
+        .attrs
+        .info()
+        .into_iter()
+        .chain(captured_event.attrs.source())
+        .try_fold(0usize, |total, metadata| {
+            total.checked_add(metadata.as_bytes().len())
+        });
+    if path_bytes.is_none()
+        || metadata_bytes.map_or(true, |bytes| bytes > MAX_CAPTURE_METADATA_BYTES)
+    {
+        SourceWatcherCapture::Overflow
+    } else {
+        SourceWatcherCapture::Notify(captured_event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAX_CAPTURE_METADATA_BYTES, MAX_CAPTURE_PATH_BYTES, MAX_CAPTURE_PATHS,
+        SourceWatcherCapture, capture_event,
+    };
+    use notify::event::EventAttributes;
+    use notify::{Event, EventKind};
+    use std::path::PathBuf;
+
+    #[test]
+    fn accepted_event_preserves_kind_paths_and_attributes() {
+        let paths = vec![PathBuf::from("first.wav"), PathBuf::from("second.wav")];
+        let mut attrs = EventAttributes::new();
+        attrs.set_tracker(7);
+        attrs.set_info("capture-test");
+        attrs.set_process_id(42);
+        let event = Event {
+            kind: EventKind::Any,
+            paths: paths.clone(),
+            attrs,
+        };
+
+        let SourceWatcherCapture::Notify(event) = capture_event(Ok(event)) else {
+            panic!("event should be accepted");
+        };
+        assert_eq!(event.kind, EventKind::Any);
+        assert_eq!(event.paths, paths);
+        assert_eq!(event.attrs.tracker(), Some(7));
+        assert_eq!(event.attrs.info(), Some("capture-test"));
+        assert_eq!(event.attrs.process_id(), Some(42));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn accepted_event_preserves_native_non_utf8_path_order() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let first = PathBuf::from(OsString::from_vec(vec![
+            b'f', b'i', b'r', b's', b't', 0xff, b'.', b'w', b'a', b'v',
+        ]));
+        let second = PathBuf::from("second.wav");
+        let paths = vec![first, second];
+        let event = Event {
+            kind: EventKind::Any,
+            paths: paths.clone(),
+            attrs: EventAttributes::default(),
+        };
+
+        let SourceWatcherCapture::Notify(event) = capture_event(Ok(event)) else {
+            panic!("event should be accepted");
+        };
+        assert_eq!(event.paths, paths);
+        assert_eq!(
+            event.paths[0].as_os_str().as_encoded_bytes(),
+            b"first\xff.wav"
+        );
+    }
+
+    #[test]
+    fn path_count_overflow_is_captured_as_overflow() {
+        let paths = (0..=MAX_CAPTURE_PATHS)
+            .map(|index| PathBuf::from(format!("{index}.wav")))
+            .collect();
+        let event = Event {
+            kind: EventKind::Any,
+            paths,
+            attrs: EventAttributes::default(),
+        };
+
+        assert!(matches!(
+            capture_event(Ok(event)),
+            SourceWatcherCapture::Overflow
+        ));
+    }
+
+    #[test]
+    fn path_byte_overflow_is_captured_as_overflow() {
+        let path = PathBuf::from("x".repeat(MAX_CAPTURE_PATH_BYTES + 1));
+        let event = Event {
+            kind: EventKind::Any,
+            paths: vec![path],
+            attrs: EventAttributes::default(),
+        };
+
+        assert!(matches!(
+            capture_event(Ok(event)),
+            SourceWatcherCapture::Overflow
+        ));
+    }
+
+    #[test]
+    fn metadata_byte_overflow_is_captured_as_overflow() {
+        let mut attrs = EventAttributes::default();
+        attrs.set_info(&"é".repeat(MAX_CAPTURE_METADATA_BYTES / 2 + 1));
+        let event = Event {
+            kind: EventKind::Any,
+            paths: Vec::new(),
+            attrs,
+        };
+
+        assert!(matches!(
+            capture_event(Ok(event)),
+            SourceWatcherCapture::Overflow
+        ));
+    }
+
+    #[test]
+    fn notify_error_is_reduced_to_a_bounded_marker() {
+        let error = notify::Error::generic(&"x".repeat(MAX_CAPTURE_METADATA_BYTES + 1))
+            .set_paths(vec![PathBuf::from("error-path")]);
+
+        assert!(matches!(
+            capture_event(Err(error)),
+            SourceWatcherCapture::Error
+        ));
+    }
+}

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -14,6 +14,7 @@ use std::{
 };
 use wavecrate::sample_sources::{SampleSource, SourceId};
 
+use super::capture::{SourceWatcherCapture, capture_event};
 use super::classification::retain_source_refresh_candidates;
 use super::journal::{self, JournalRecovery};
 use super::roots::{
@@ -201,7 +202,7 @@ impl SourceWatcherTeardown {
 }
 
 struct SourceWatcherIngress {
-    event_tx: SyncSender<notify::Result<Event>>,
+    event_tx: SyncSender<SourceWatcherCapture>,
     overflowed: Arc<AtomicBool>,
     enabled: Arc<AtomicBool>,
 }
@@ -211,16 +212,7 @@ impl EventHandler for SourceWatcherIngress {
         if !self.enabled.load(Ordering::Acquire) {
             return;
         }
-        let event = match event {
-            Ok(mut event) => {
-                if !retain_source_refresh_candidates(&mut event) {
-                    return;
-                }
-                Ok(event)
-            }
-            Err(error) => Err(error),
-        };
-        match self.event_tx.try_send(event) {
+        match self.event_tx.try_send(capture_event(event)) {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => {
                 self.overflowed.store(true, Ordering::Release);
@@ -484,7 +476,7 @@ fn run_source_watcher(
                 let event = paths
                     .into_iter()
                     .fold(Event::new(EventKind::Any), Event::add_path);
-                match event_tx.try_send(Ok(event)) {
+                match event_tx.try_send(capture_event(Ok(event))) {
                     Ok(()) => {}
                     Err(TrySendError::Full(_)) => {
                         ingress_overflowed.store(true, Ordering::Release);
@@ -791,14 +783,19 @@ fn run_source_watcher(
         let mut watcher_failed = false;
         let mut root_invalidated = false;
         while let Ok(event) = event_rx.try_recv() {
-            let event: notify::Result<Event> = event;
             match event {
-                Ok(event) => {
+                SourceWatcherCapture::Notify(mut event) => {
+                    if !retain_source_refresh_candidates(&mut event) {
+                        continue;
+                    }
                     root_invalidated |= state.collect_event(&event, Instant::now());
                 }
-                Err(error) => {
-                    tracing::warn!("GUI source watcher error: {error}");
+                SourceWatcherCapture::Error => {
+                    tracing::warn!("GUI source watcher error");
                     watcher_failed = true;
+                }
+                SourceWatcherCapture::Overflow => {
+                    state.mark_all_overflowed(now);
                 }
             }
         }
@@ -1013,7 +1010,7 @@ fn run_source_watcher_without_lifecycle(command_rx: Receiver<GuiSourceWatchComma
 
 fn spawn_source_watcher(
     sources: Vec<SampleSource>,
-    event_tx: SyncSender<notify::Result<Event>>,
+    event_tx: SyncSender<SourceWatcherCapture>,
     ingress_overflowed: Arc<AtomicBool>,
     backend: SourceWatcherBackend,
 ) -> Result<PendingSourceWatcher, String> {
@@ -1093,7 +1090,7 @@ fn start_pending_source_watcher(
     pending: &mut Option<PendingSourceWatcher>,
     retired_initializers: &[PendingSourceWatcher],
     sources: Vec<SampleSource>,
-    event_tx: SyncSender<notify::Result<Event>>,
+    event_tx: SyncSender<SourceWatcherCapture>,
     ingress_overflowed: Arc<AtomicBool>,
     backend: SourceWatcherBackend,
 ) -> bool {

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -57,7 +57,7 @@ fn wavecrate_metadata_files_do_not_trigger_source_refresh() {
 }
 
 #[test]
-fn metadata_event_storm_is_filtered_before_the_bounded_watcher_queue() {
+fn metadata_event_storm_is_filtered_before_state_admission() {
     let root = PathBuf::from(r"C:\samples");
     let mut event = Event {
         kind: EventKind::Modify(notify::event::ModifyKind::Data(


### PR DESCRIPTION
## Goal

Align the native watcher ingress with the Finder reconciliation target by making callback capture bounded, non-blocking, and free of filesystem classification.

## Scope and non-goals

This PR:
- adds a pure bounded native notify capture boundary;
- preserves accepted event kind, attributes, native path spelling, and path order;
- moves source-candidate filtering to the coordinator after queue admission;
- converts path/count/metadata overflow to conservative all-source reconciliation;
- converts notify errors to a bounded failure marker while preserving watcher restart behavior.

It does not change source-writer authority, database schemas, projection/checkpoint authority, replay proof, live proof, or native macOS acceptance. Those remain later alignment slices.

## Definition of Done

- The watcher callback performs only its enabled fence, bounded pure capture, and non-blocking queue send.
- Path count, encoded path bytes, and dynamic notify metadata bytes are bounded with checked short-circuiting.
- Notify errors do not retain unbounded payloads in the ingress queue.
- Existing filtering, lifecycle fencing, queue overflow, restart, and message behavior remain compatible.
- Focused regression coverage proves path/order/attribute preservation, non-UTF-8 paths, and all bounded overflow/error cases.

## Validation

- `cargo test --lib source_watcher` — 86 passed.
- `cargo test -p wavecrate-library --lib reconciliation` — 56 passed.
- `cargo check --all-targets` — passed against Radiant `13ae1f524313a5257fee6691679799a1aca99d32`.
- Changed-file `rustfmt --edition 2024 --check` — passed.
- `git diff --check` — passed.
- Workspace-wide `cargo fmt -- --check` reports unrelated pre-existing formatting differences outside this PR.
- The full library test run was interrupted after broad unrelated baseline failures and is not used as this PR's gate.
- No live macOS/Finder acceptance was claimed for this library/ingress slice.

## Review and limitations

Terra independently reviewed the complete current diff and returned **APPROVE** with no findings. The remaining limitation is intentional: this PR establishes bounded native capture but does not yet connect it to the full live/replay provenance and committed source-revision handoff.

## Next architecture task

Connect the bounded native capture to the validated reconciliation adapter with source/root/backend-stream/generation provenance, then integrate committed authoritative acknowledgements through source writer, projection, checkpoint, crash recovery, and real macOS acceptance.

User approval is required before merge.