### PR TITLE
Retire proofless audit handoff tickets

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
@@ -150,6 +150,8 @@ pub enum AdmissionError {
     UnknownLane,
     /// The requested lifecycle transition is not valid.
     InvalidLifecycleTransition,
+    /// A proof-carrying envelope cannot use the proofless audit handoff.
+    UnprovenAuditHandoffRequiresUnprovenEnvelope,
     /// The supplied generation is not the lane's current generation.
     GenerationMismatch,
     /// The monotonic generation counter cannot advance.
@@ -1096,6 +1098,9 @@ impl ReconciliationAdmissionSupervisor {
             .ok_or(AdmissionError::UnknownTicket)?;
         if pending.phase != DispatchPhase::Applied {
             return Err(AdmissionError::InvalidLifecycleTransition);
+        }
+        if !pending.envelope.proof().is_unproven() {
+            return Err(AdmissionError::UnprovenAuditHandoffRequiresUnprovenEnvelope);
         }
         let pending = self.pending.remove(&ticket).expect("ticket checked above");
         self.release_usage(&pending.lane, pending.usage);

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
@@ -1080,6 +1080,28 @@ impl ReconciliationAdmissionSupervisor {
         Ok(())
     }
 
+    /// Retire an applied live envelope after the proofless audit has been handed off.
+    ///
+    /// This releases bounded admission usage without clearing retained uncertainty, creating
+    /// authority, or advancing a watcher checkpoint. The ticket must have reached `Applied`,
+    /// which is the supervisor's handoff phase for this proofless path. A later committed
+    /// authoritative acknowledgement is still required to clear the retained marker.
+    pub fn mark_unproven_audit_handed_off(
+        &mut self,
+        ticket: DispatchTicket,
+    ) -> Result<(), AdmissionError> {
+        let pending = self
+            .pending
+            .get(&ticket)
+            .ok_or(AdmissionError::UnknownTicket)?;
+        if pending.phase != DispatchPhase::Applied {
+            return Err(AdmissionError::InvalidLifecycleTransition);
+        }
+        let pending = self.pending.remove(&ticket).expect("ticket checked above");
+        self.release_usage(&pending.lane, pending.usage);
+        Ok(())
+    }
+
     /// Borrow all retained uncertainty markers in supervisor insertion order.
     pub fn uncertainties(&self) -> &[RetainedUncertainty] {
         &self.retained_uncertainties
@@ -2477,6 +2499,66 @@ mod tests {
                 restarted_generation,
                 7,
                 RawEventKind::Create,
+            )),
+            AdmissionOutcome::Accepted(_)
+        ));
+    }
+
+    #[test]
+    fn unproven_audit_handoff_releases_usage_and_retains_live_uncertainty() {
+        let source = SourceId::from_string("source-a");
+        let root = RootIdentity::from_bytes(b"root-a".to_vec());
+        let mut supervisor = ReconciliationAdmissionSupervisor::new(limits_with(1, 8, 1, 8, 2));
+        let (_lane, generation) = registered(&mut supervisor, &source, &root);
+        let ticket = match supervisor.admit_with_required_uncertainty(
+            envelope(&source, Some(&root), generation, 1, RawEventKind::Create),
+            UncertaintyReason::LiveUnproven,
+        ) {
+            AdmissionOutcome::Accepted(ticket) => ticket,
+            outcome => panic!("unexpected live outcome: {outcome:?}"),
+        };
+        assert_eq!(
+            last_marker(&supervisor).reasons(),
+            &[UncertaintyReason::LiveUnproven]
+        );
+        let live_marker = last_marker(&supervisor).clone();
+
+        let dispatched = supervisor.dispatch_next().expect("dispatch live envelope");
+        assert_eq!(dispatched.ticket(), ticket);
+        supervisor
+            .mark_dispatched(ticket)
+            .expect("dispatch handoff");
+        supervisor.mark_applied(ticket).expect("audit handoff");
+        assert!(matches!(
+            supervisor.admit(envelope(
+                &source,
+                Some(&root),
+                generation,
+                2,
+                RawEventKind::Modify,
+            )),
+            AdmissionOutcome::Rejected(AdmissionRejectReason::QueueSaturated)
+        ));
+        assert_eq!(supervisor.uncertainties().len(), 2);
+        assert_eq!(supervisor.uncertainties()[0], live_marker);
+        assert!(
+            supervisor.uncertainties()[1]
+                .reasons()
+                .contains(&UncertaintyReason::QueueSaturated)
+        );
+
+        supervisor
+            .mark_unproven_audit_handed_off(ticket)
+            .expect("retire proofless audit handoff");
+        assert_eq!(supervisor.in_flight(), 0);
+        assert_eq!(supervisor.uncertainties()[0], live_marker,);
+        assert!(matches!(
+            supervisor.admit(envelope(
+                &source,
+                Some(&root),
+                generation,
+                3,
+                RawEventKind::Modify,
             )),
             AdmissionOutcome::Accepted(_)
         ));

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
@@ -960,6 +960,113 @@ fn live_adapter_correlation_is_none_for_duplicate_admission() {
 }
 
 #[test]
+fn live_audit_handoff_retires_applied_ticket_without_authority_or_marker_loss() {
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(1, 8));
+    let (_lane, generation) = adapter_registered(&mut supervisor, &source, &root);
+    let batch = adapter_batch(
+        adapter_capture_provenance(
+            "source-a",
+            Some(b"root-a".to_vec()),
+            Some(b"stream-a".to_vec()),
+            generation.get(),
+            Some(10),
+            Some(10),
+        ),
+        vec![adapter_observation(RawEventKind::Create, "sample.wav")],
+    );
+
+    let admission = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live_with_correlation(batch.clone())
+            .expect("live admission")
+    };
+    let ticket = match admission.admission().outcome() {
+        AdmissionOutcome::Accepted(ticket) => *ticket,
+        outcome => panic!("unexpected live outcome: {outcome:?}"),
+    };
+    let correlation = admission.correlation().expect("live audit correlation");
+    let marker_before = supervisor.uncertainties()[0].clone();
+    assert_eq!(marker_before.source_id(), Some(&source));
+    assert_eq!(marker_before.root_identity(), Some(&root));
+    assert_eq!(marker_before.generation(), Some(generation));
+    assert_eq!(marker_before.scope(), ReconciliationScopeKind::SourceAudit);
+    assert_eq!(marker_before.reasons(), &[UncertaintyReason::LiveUnproven]);
+    assert_eq!(correlation.identity().source_id(), &source);
+    assert_eq!(correlation.identity().root_identity(), &root);
+    assert_eq!(correlation.identity().generation(), generation);
+    assert_eq!(correlation.boundary(), marker_before.boundary());
+    assert_eq!(supervisor.in_flight(), 1);
+
+    let duplicate = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live_with_correlation(batch)
+            .expect("duplicate live admission")
+    };
+    assert!(duplicate.correlation().is_none());
+    assert_eq!(
+        duplicate.admission().outcome(),
+        &AdmissionOutcome::DuplicateSuppressed(CaptureSequenceRange::new(10, 10))
+    );
+    assert_eq!(supervisor.in_flight(), 1);
+    assert_eq!(supervisor.uncertainties(), &[marker_before.clone()]);
+
+    assert_eq!(
+        supervisor.mark_unproven_audit_handed_off(ticket),
+        Err(AdmissionError::InvalidLifecycleTransition)
+    );
+    assert_eq!(supervisor.in_flight(), 1);
+    assert_eq!(supervisor.uncertainties(), &[marker_before.clone()]);
+
+    let dispatched = supervisor.dispatch_next().expect("live dispatch");
+    assert_eq!(dispatched.ticket(), ticket);
+    assert_eq!(
+        supervisor.mark_unproven_audit_handed_off(ticket),
+        Err(AdmissionError::InvalidLifecycleTransition)
+    );
+    assert_eq!(supervisor.in_flight(), 1);
+    supervisor
+        .mark_dispatched(ticket)
+        .expect("dispatch handoff");
+    supervisor.mark_applied(ticket).expect("worker completion");
+
+    supervisor
+        .mark_unproven_audit_handed_off(ticket)
+        .expect("source-audit scheduler handoff");
+    assert_eq!(supervisor.in_flight(), 0);
+    assert_eq!(supervisor.uncertainties(), &[marker_before.clone()]);
+
+    assert_eq!(
+        supervisor.mark_unproven_audit_handed_off(ticket),
+        Err(AdmissionError::UnknownTicket)
+    );
+    assert_eq!(supervisor.in_flight(), 0);
+    assert_eq!(supervisor.uncertainties(), &[marker_before]);
+
+    let next = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live(adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    generation.get(),
+                    Some(11),
+                    Some(11),
+                ),
+                vec![adapter_observation(RawEventKind::Modify, "next.wav")],
+            ))
+            .expect("capacity released after audit handoff")
+    };
+    assert!(matches!(next.outcome(), AdmissionOutcome::Accepted(_)));
+    assert_eq!(supervisor.in_flight(), 1);
+}
+
+#[test]
 fn live_adapter_correlation_is_none_for_rejection_and_capacity() {
     let rejected_batch = adapter_batch(
         adapter_capture_provenance(

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
@@ -1202,6 +1202,92 @@ fn valid_replay_adapter_attaches_exact_continuity_fields_without_adapter_uncerta
 }
 
 #[test]
+fn continuity_proven_replay_cannot_use_unproven_audit_handoff() {
+    let source = SourceId::from_string("source-a");
+    let root = RootIdentity::from_bytes(b"root-a".to_vec());
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(1, 8));
+    let (_lane, generation) = adapter_registered(&mut supervisor, &source, &root);
+    let prior = replay_prior("source-a", b"root-a", b"stream-a", generation.get(), 10);
+
+    let admission = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_replay(
+                adapter_batch(
+                    adapter_capture_provenance(
+                        "source-a",
+                        Some(b"root-a".to_vec()),
+                        Some(b"stream-a".to_vec()),
+                        generation.get(),
+                        Some(11),
+                        Some(11),
+                    ),
+                    vec![adapter_observation(RawEventKind::Create, "replayed.wav")],
+                ),
+                Some(&prior),
+                true,
+            )
+            .expect("valid replay admission")
+    };
+    assert_eq!(
+        admission.disposition(),
+        AdapterDisposition::AdmittedWithContinuity
+    );
+    let ticket = match admission.outcome() {
+        AdmissionOutcome::Accepted(ticket) => *ticket,
+        outcome => panic!("unexpected replay outcome: {outcome:?}"),
+    };
+    assert!(supervisor.uncertainties().is_empty());
+
+    let dispatched = supervisor.dispatch_next().expect("replay dispatch");
+    assert_eq!(dispatched.ticket(), ticket);
+    assert!(
+        dispatched
+            .normalized()
+            .proof()
+            .watcher_continuity()
+            .is_some()
+    );
+    supervisor
+        .mark_dispatched(ticket)
+        .expect("replay dispatch handoff");
+    supervisor.mark_applied(ticket).expect("replay applied");
+
+    assert_eq!(
+        supervisor.mark_unproven_audit_handed_off(ticket),
+        Err(AdmissionError::UnprovenAuditHandoffRequiresUnprovenEnvelope)
+    );
+    assert_eq!(supervisor.in_flight(), 1);
+
+    let capacity = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live(adapter_batch(
+                adapter_capture_provenance(
+                    "source-a",
+                    Some(b"root-a".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    generation.get(),
+                    Some(12),
+                    Some(12),
+                ),
+                vec![adapter_observation(RawEventKind::Modify, "next.wav")],
+            ))
+            .expect("capacity admission result")
+    };
+    assert_eq!(
+        capacity.outcome(),
+        &AdmissionOutcome::Rejected(AdmissionRejectReason::QueueSaturated)
+    );
+    assert_eq!(supervisor.in_flight(), 1);
+
+    supervisor
+        .mark_checkpointed(ticket)
+        .expect("normal replay checkpoint");
+    assert_eq!(supervisor.in_flight(), 0);
+}
+
+#[test]
 fn invalid_replay_claims_remain_unproven_and_retain_typed_source_audit_evidence() {
     let valid_prior = replay_prior("source-a", b"root-a", b"stream-a", 1, 10);
     let valid_observations = || vec![adapter_observation(RawEventKind::Create, "sample.wav")];


### PR DESCRIPTION
## Goal

Add an explicit non-authoritative retirement transition for live reconciliation tickets after proofless source-audit handoff.

## Scope

- Retire an applied live envelope through `mark_unproven_audit_handed_off`.
- Require the ticket's envelope to remain proofless; continuity-proven replay tickets cannot use the proofless handoff.
- Release bounded in-flight usage so admission capacity is recoverable.
- Preserve the retained `LiveUnproven` uncertainty marker, identity, and boundary.
- Reject unknown tickets and calls made before the ticket reaches `Applied`.
- Add reconciliation and adapter-level regression coverage for live handoff and replay protection.

## Non-goals

This PR does not wire the native watcher coordinator, change source-writer or projection behavior, advance watcher checkpoints, establish continuity proof, change schemas/migrations, alter replay semantics, or claim macOS Finder acceptance.

## Definition of Done

- Proofless live-audit handoff can release ticket capacity without clearing uncertainty or creating authority.
- Continuity-proven replay work remains in flight and must use its normal checkpoint path.
- Later committed authoritative acknowledgement remains required to clear live uncertainty.
- Invalid lifecycle and unknown-ticket calls remain safe.
- Existing reconciliation behavior remains green.

## Validation

- `cargo test -p wavecrate-library --lib reconciliation` — 59 passed
- `cargo check -p wavecrate-library` — passed
- `cargo check --all-targets` — passed
- Changed-file `rustfmt --edition 2024 --check` — passed
- `git diff --check` — passed

## Known limitations

Native watcher admission wiring and committed authoritative acknowledgement integration remain follow-up slices. Real writable-profile macOS/Finder acceptance is deferred until those boundaries are connected.

## Next architecture task

Wire bounded native watcher captures through the live reconciliation adapter, carry the returned correlation through authoritative source-audit commit and accepted projection handoff, then clear only covered uncertainty and integrate checkpoint/crash recovery.

User approval is required before merge.