### PR TITLE
Expose typed watcher root identities

### DIFF
--- a/src/native_app/sample_library/source_watcher/roots.rs
+++ b/src/native_app/sample_library/source_watcher/roots.rs
@@ -190,12 +190,25 @@ pub(super) fn root_identity_is_current(
     watched_roots: &WatchedRootIdentities,
     root: &Path,
 ) -> Option<bool> {
-    let watched = watched_roots.get(root)?.as_ref()?;
+    let watched = registered_root_identity(watched_roots, root)?;
     match observed_available_root_identity(root) {
-        RootObservation::Available(Some(observed)) => Some(watched == &observed),
+        RootObservation::Available(Some(observed)) => {
+            Some(watched.as_bytes() == observed.as_bytes())
+        }
         RootObservation::Available(None) => None,
         RootObservation::Unavailable => Some(false),
     }
+}
+
+pub(super) fn registered_root_identity(
+    watched_roots: &WatchedRootIdentities,
+    root: &Path,
+) -> Option<wavecrate_library::sample_sources::reconciliation::RootIdentity> {
+    watched_roots.get(root)?.as_ref().map(|identity| {
+        wavecrate_library::sample_sources::reconciliation::RootIdentity::from_bytes(
+            identity.as_bytes().to_vec(),
+        )
+    })
 }
 
 fn observed_available_roots(sources: &[SampleSource]) -> (WatchedRootIdentities, bool) {

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -1,6 +1,8 @@
 use super::classification::{path_is_source_refresh_candidate, retain_source_refresh_candidates};
 use super::handle::{GuiSourceWatcherHandle, doubled_backoff};
-use super::roots::{RootIdentityRecovery, RootWatchUpdate, root_watch_status};
+use super::roots::{
+    RootIdentityRecovery, RootWatchUpdate, registered_root_identity, root_watch_status,
+};
 use super::state::GuiSourceWatchState;
 use notify::{Event, EventKind, event::RemoveKind};
 use std::{
@@ -457,6 +459,35 @@ fn unreadable_root_identity_falls_back_to_bounded_full_reconciliation() {
             .due_roots(&[], started + Duration::from_secs(1))
             .is_empty()
     );
+}
+
+#[test]
+fn registered_root_identity_preserves_registered_identity_bytes() {
+    let root = PathBuf::from("registered-root");
+    let identity = "  registered/root identity :: exact  ".to_string();
+    let watched = HashMap::from([(root.clone(), Some(identity.clone()))]);
+
+    let registered = registered_root_identity(&watched, &root).expect("registered root identity");
+
+    assert_eq!(registered.as_bytes(), identity.as_bytes());
+}
+
+#[test]
+fn registered_root_identity_returns_none_for_none_identity() {
+    let root = PathBuf::from("identity-unavailable");
+    let watched = HashMap::from([(root.clone(), None)]);
+
+    assert!(registered_root_identity(&watched, &root).is_none());
+}
+
+#[test]
+fn registered_root_identity_returns_none_for_missing_root() {
+    let watched = HashMap::from([(
+        PathBuf::from("registered-root"),
+        Some("identity".to_string()),
+    )]);
+
+    assert!(registered_root_identity(&watched, Path::new("missing-root")).is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Goal

Make the watcher’s already-registered physical-root identity available at the coordinator boundary as the typed reconciliation `RootIdentity` required by native admission.

## Scope

- Add a coordinator-private `registered_root_identity` helper.
- Preserve the exact registered identity bytes without normalization or pathname fallback.
- Use the typed identity in `root_identity_is_current` while preserving existing unavailable/unknown semantics.
- Add focused tests for exact bytes, missing roots, and unavailable identities.

## Non-goals

This PR does not admit native events, change callback behavior, alter source-writer/projection/journal/replay behavior, add schema or migrations, or claim Finder acceptance.

## Definition of Done

- Existing watcher root identity is available as typed reconciliation evidence.
- Missing or unavailable identities remain conservative and never become path-derived identities.
- Existing root replacement and watcher recovery behavior is unchanged.

## Validation

- `cargo test --lib source_watcher` — 89 passed
- `cargo check --all-targets` — passed
- Changed-file `rustfmt --edition 2024 --check` — passed
- `git diff --check` — passed

## Known limitations

The next slice will consume this helper to admit bounded native captures through `ReconciliationAdapter::admit_live_with_correlation`. Native admission, authoritative acknowledgement, projection/checkpoint integration, and real macOS Finder acceptance remain pending.

User approval is required before merge.