### PR TITLE
Fence stale native watcher capture streams

### DIFF
--- a/src/native_app/sample_library/source_watcher/capture.rs
+++ b/src/native_app/sample_library/source_watcher/capture.rs
@@ -5,7 +5,7 @@ pub(super) const MAX_CAPTURE_PATH_BYTES: usize = 256 * 1_024;
 pub(super) const MAX_CAPTURE_METADATA_BYTES: usize = 256 * 1_024;
 
 pub(super) enum SourceWatcherCapture {
-    Notify(Event),
+    Notify { stream_id: u64, event: Event },
     Error,
     Overflow,
 }
@@ -36,7 +36,10 @@ pub(super) fn capture_event(event: notify::Result<Event>) -> SourceWatcherCaptur
     {
         SourceWatcherCapture::Overflow
     } else {
-        SourceWatcherCapture::Notify(captured_event)
+        SourceWatcherCapture::Notify {
+            stream_id: 0,
+            event: captured_event,
+        }
     }
 }
 
@@ -63,7 +66,7 @@ mod tests {
             attrs,
         };
 
-        let SourceWatcherCapture::Notify(event) = capture_event(Ok(event)) else {
+        let SourceWatcherCapture::Notify { event, .. } = capture_event(Ok(event)) else {
             panic!("event should be accepted");
         };
         assert_eq!(event.kind, EventKind::Any);
@@ -89,7 +92,7 @@ mod tests {
             attrs: EventAttributes::default(),
         };
 
-        let SourceWatcherCapture::Notify(event) = capture_event(Ok(event)) else {
+        let SourceWatcherCapture::Notify { event, .. } = capture_event(Ok(event)) else {
             panic!("event should be accepted");
         };
         assert_eq!(event.paths, paths);

--- a/src/native_app/sample_library/source_watcher/capture.rs
+++ b/src/native_app/sample_library/source_watcher/capture.rs
@@ -4,19 +4,20 @@ pub(super) const MAX_CAPTURE_PATHS: usize = 4_096;
 pub(super) const MAX_CAPTURE_PATH_BYTES: usize = 256 * 1_024;
 pub(super) const MAX_CAPTURE_METADATA_BYTES: usize = 256 * 1_024;
 
+#[derive(Debug)]
 pub(super) enum SourceWatcherCapture {
     Notify { stream_id: u64, event: Event },
-    Error,
-    Overflow,
+    Error { stream_id: u64 },
+    Overflow { stream_id: u64 },
 }
 
 pub(super) fn capture_event(event: notify::Result<Event>) -> SourceWatcherCapture {
     let Ok(captured_event) = event else {
-        return SourceWatcherCapture::Error;
+        return SourceWatcherCapture::Error { stream_id: 0 };
     };
 
     if captured_event.paths.len() > MAX_CAPTURE_PATHS {
-        return SourceWatcherCapture::Overflow;
+        return SourceWatcherCapture::Overflow { stream_id: 0 };
     }
 
     let path_bytes = captured_event.paths.iter().try_fold(0usize, |total, path| {
@@ -34,7 +35,7 @@ pub(super) fn capture_event(event: notify::Result<Event>) -> SourceWatcherCaptur
     if path_bytes.is_none()
         || metadata_bytes.map_or(true, |bytes| bytes > MAX_CAPTURE_METADATA_BYTES)
     {
-        SourceWatcherCapture::Overflow
+        SourceWatcherCapture::Overflow { stream_id: 0 }
     } else {
         SourceWatcherCapture::Notify {
             stream_id: 0,
@@ -115,7 +116,7 @@ mod tests {
 
         assert!(matches!(
             capture_event(Ok(event)),
-            SourceWatcherCapture::Overflow
+            SourceWatcherCapture::Overflow { .. }
         ));
     }
 
@@ -130,7 +131,7 @@ mod tests {
 
         assert!(matches!(
             capture_event(Ok(event)),
-            SourceWatcherCapture::Overflow
+            SourceWatcherCapture::Overflow { .. }
         ));
     }
 
@@ -146,7 +147,7 @@ mod tests {
 
         assert!(matches!(
             capture_event(Ok(event)),
-            SourceWatcherCapture::Overflow
+            SourceWatcherCapture::Overflow { .. }
         ));
     }
 
@@ -157,7 +158,7 @@ mod tests {
 
         assert!(matches!(
             capture_event(Err(error)),
-            SourceWatcherCapture::Error
+            SourceWatcherCapture::Error { .. }
         ));
     }
 }

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf,
     sync::{
         Arc, Mutex, OnceLock,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         mpsc::{Receiver, Sender, SyncSender, TryRecvError, TrySendError},
     },
     thread,
@@ -35,6 +35,13 @@ use crate::native_app::sample_library::committed_file_mutations::{
 struct ActiveSourceWatcher {
     _watcher: Box<dyn Watcher + Send>,
     ingress_enabled: Arc<AtomicBool>,
+    stream_id: u64,
+}
+
+static NEXT_STREAM_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_stream_id() -> u64 {
+    NEXT_STREAM_ID.fetch_add(1, Ordering::Relaxed)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -205,14 +212,22 @@ struct SourceWatcherIngress {
     event_tx: SyncSender<SourceWatcherCapture>,
     overflowed: Arc<AtomicBool>,
     enabled: Arc<AtomicBool>,
+    stream_id: u64,
 }
 
 impl EventHandler for SourceWatcherIngress {
     fn handle_event(&mut self, event: notify::Result<Event>) {
+        let capture = match capture_event(event) {
+            SourceWatcherCapture::Notify { event, .. } => SourceWatcherCapture::Notify {
+                stream_id: self.stream_id,
+                event,
+            },
+            capture => capture,
+        };
         if !self.enabled.load(Ordering::Acquire) {
             return;
         }
-        match self.event_tx.try_send(capture_event(event)) {
+        match self.event_tx.try_send(capture) {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => {
                 self.overflowed.store(true, Ordering::Release);
@@ -476,7 +491,17 @@ fn run_source_watcher(
                 let event = paths
                     .into_iter()
                     .fold(Event::new(EventKind::Any), Event::add_path);
-                match event_tx.try_send(capture_event(Ok(event))) {
+                let capture = match capture_event(Ok(event)) {
+                    SourceWatcherCapture::Notify { event, .. } => SourceWatcherCapture::Notify {
+                        stream_id: watcher
+                            .as_ref()
+                            .map(|watcher| watcher.stream_id)
+                            .unwrap_or(0),
+                        event,
+                    },
+                    capture => capture,
+                };
+                match event_tx.try_send(capture) {
                     Ok(()) => {}
                     Err(TrySendError::Full(_)) => {
                         ingress_overflowed.store(true, Ordering::Release);
@@ -784,7 +809,14 @@ fn run_source_watcher(
         let mut root_invalidated = false;
         while let Ok(event) = event_rx.try_recv() {
             match event {
-                SourceWatcherCapture::Notify(mut event) => {
+                SourceWatcherCapture::Notify {
+                    stream_id,
+                    mut event,
+                } => {
+                    if watcher.as_ref().map(|watcher| watcher.stream_id) != Some(stream_id) {
+                        state.mark_all_overflowed(now);
+                        continue;
+                    }
                     if !retain_source_refresh_candidates(&mut event) {
                         continue;
                     }
@@ -1014,6 +1046,7 @@ fn spawn_source_watcher(
     ingress_overflowed: Arc<AtomicBool>,
     backend: SourceWatcherBackend,
 ) -> Result<PendingSourceWatcher, String> {
+    let stream_id = next_stream_id();
     let (result_tx, result_rx) = std::sync::mpsc::channel();
     // Native backends can emit callbacks while roots are being registered.
     // Fence those callbacks and open ingress only once the complete watcher is
@@ -1027,6 +1060,7 @@ fn spawn_source_watcher(
                 event_tx,
                 overflowed: ingress_overflowed,
                 enabled: Arc::clone(&watcher_enabled),
+                stream_id,
             };
             let watcher: Result<Box<dyn Watcher + Send>, String> = match backend {
                 SourceWatcherBackend::Native => notify::recommended_watcher(ingress)
@@ -1046,6 +1080,7 @@ fn spawn_source_watcher(
                     ActiveSourceWatcher {
                         _watcher: watcher,
                         ingress_enabled: watcher_enabled,
+                        stream_id,
                     },
                     update,
                     watched_roots,
@@ -1249,7 +1284,7 @@ pub(super) fn doubled_backoff(current: Duration) -> Duration {
 #[cfg(test)]
 mod lifecycle_tests {
     use super::*;
-    use notify::{RecursiveMode, WatcherKind};
+    use notify::{Event, EventKind, RecursiveMode, WatcherKind};
     use std::{
         collections::{HashMap, HashSet},
         path::Path,
@@ -1569,6 +1604,30 @@ mod lifecycle_tests {
         assert!(retired.is_empty());
     }
 
+    #[test]
+    fn ingress_attaches_its_stream_id_to_captured_notifications() {
+        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+        let mut ingress = SourceWatcherIngress {
+            event_tx,
+            overflowed: Arc::new(AtomicBool::new(false)),
+            enabled: Arc::new(AtomicBool::new(true)),
+            stream_id: 41,
+        };
+
+        ingress.handle_event(Ok(Event {
+            kind: EventKind::Any,
+            paths: Vec::new(),
+            attrs: notify::event::EventAttributes::default(),
+        }));
+
+        let SourceWatcherCapture::Notify { stream_id, .. } =
+            event_rx.recv().expect("captured notification")
+        else {
+            panic!("expected captured notification");
+        };
+        assert_eq!(stream_id, 41);
+    }
+
     struct BlockingDropWatcher {
         release_rx: Receiver<()>,
     }
@@ -1609,6 +1668,7 @@ mod lifecycle_tests {
         ActiveSourceWatcher {
             _watcher: Box::new(BlockingDropWatcher { release_rx }),
             ingress_enabled: Arc::new(AtomicBool::new(true)),
+            stream_id: next_stream_id(),
         }
     }
 

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -850,34 +850,8 @@ fn run_source_watcher(
             state.mark_all_overflowed(now);
         }
 
-        let mut watcher_failed = false;
-        let mut root_invalidated = false;
-        while let Ok(event) = event_rx.try_recv() {
-            let stream_id = match &event {
-                SourceWatcherCapture::Notify { stream_id, .. }
-                | SourceWatcherCapture::Error { stream_id }
-                | SourceWatcherCapture::Overflow { stream_id } => *stream_id,
-            };
-            if watcher.as_ref().map(|watcher| watcher.stream_id) != Some(stream_id) {
-                state.mark_all_overflowed(now);
-                continue;
-            }
-            match event {
-                SourceWatcherCapture::Notify { mut event, .. } => {
-                    if !retain_source_refresh_candidates(&mut event) {
-                        continue;
-                    }
-                    root_invalidated |= state.collect_event(&event, Instant::now());
-                }
-                SourceWatcherCapture::Error { .. } => {
-                    tracing::warn!("GUI source watcher error");
-                    watcher_failed = true;
-                }
-                SourceWatcherCapture::Overflow { .. } => {
-                    state.mark_all_overflowed(now);
-                }
-            }
-        }
+        let (watcher_failed, root_invalidated) =
+            drain_watcher_captures(&mut state, watcher.as_ref(), &event_rx, now);
 
         if watcher_failed || root_invalidated {
             retire_source_watcher(&mut watcher, &mut teardown);
@@ -931,6 +905,46 @@ fn run_source_watcher(
             .send(lifecycle)
             .expect("source watcher lifecycle service must outlive its coordinator");
     }
+}
+
+fn drain_watcher_captures(
+    state: &mut GuiSourceWatchState,
+    watcher: Option<&ActiveSourceWatcher>,
+    event_rx: &Receiver<SourceWatcherCapture>,
+    now: Instant,
+) -> (bool, bool) {
+    let mut watcher_failed = false;
+    let mut root_invalidated = false;
+    while let Ok(event) = event_rx.try_recv() {
+        let stream_id = match &event {
+            SourceWatcherCapture::Notify { stream_id, .. }
+            | SourceWatcherCapture::Error { stream_id }
+            | SourceWatcherCapture::Overflow { stream_id } => *stream_id,
+        };
+        let current_stream = watcher.is_some_and(|watcher| {
+            watcher.stream_id == stream_id && watcher.ingress_enabled.load(Ordering::Acquire)
+        });
+        if !current_stream {
+            state.mark_all_overflowed(now);
+            continue;
+        }
+        match event {
+            SourceWatcherCapture::Notify { mut event, .. } => {
+                if !retain_source_refresh_candidates(&mut event) {
+                    continue;
+                }
+                root_invalidated |= state.collect_event(&event, Instant::now());
+            }
+            SourceWatcherCapture::Error { .. } => {
+                tracing::warn!("GUI source watcher error");
+                watcher_failed = true;
+            }
+            SourceWatcherCapture::Overflow { .. } => {
+                state.mark_all_overflowed(now);
+            }
+        }
+    }
+    (watcher_failed, root_invalidated)
 }
 
 fn finish_journal_barrier_audit(
@@ -1732,6 +1746,79 @@ mod lifecycle_tests {
             ingress_enabled: Arc::new(AtomicBool::new(true)),
             stream_id: next_stream_id(),
         }
+    }
+
+    #[test]
+    fn fenced_retained_watcher_capture_widens_without_requesting_teardown() {
+        let _guard = lock_lifecycle_tests();
+        let mut teardown = SourceWatcherTeardown {
+            workers: Vec::new(),
+        };
+        let mut teardown_releases = Vec::new();
+        for _ in 0..MAX_UNRESOLVED_TEARDOWNS {
+            let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+            if teardown.retire(blocking_watcher(release_rx)).is_err() {
+                panic!("teardown slot should be available");
+            }
+            teardown_releases.push(release_tx);
+        }
+
+        let (retained_release_tx, retained_release_rx) = std::sync::mpsc::sync_channel(1);
+        let retained = blocking_watcher(retained_release_rx);
+        let stream_id = retained.stream_id;
+        let mut watcher = Some(retained);
+        retire_source_watcher(&mut watcher, &mut teardown);
+
+        let fenced = watcher
+            .as_ref()
+            .expect("saturated teardown retains watcher");
+        assert!(!fenced.ingress_enabled.load(Ordering::Acquire));
+        assert_eq!(teardown.unresolved_count(), MAX_UNRESOLVED_TEARDOWNS);
+
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("fenced-retained-capture"),
+            PathBuf::from("/tmp/fenced-retained-capture"),
+        );
+        let source_id = source.id.as_str().to_string();
+        let mut state = GuiSourceWatchState {
+            sources: vec![source],
+            ..Default::default()
+        };
+        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+        event_tx
+            .send(SourceWatcherCapture::Error { stream_id })
+            .expect("inject same-stream fenced capture");
+
+        let (watcher_failed, root_invalidated) =
+            drain_watcher_captures(&mut state, watcher.as_ref(), &event_rx, Instant::now());
+
+        assert!(
+            !watcher_failed,
+            "a fenced stream must not request current watcher teardown"
+        );
+        assert!(!root_invalidated);
+        let pending = state
+            .pending
+            .get(&source_id)
+            .expect("fenced capture must widen the source");
+        assert!(pending.paths.is_empty());
+        assert!(pending.overflowed);
+        assert!(watcher.is_some(), "fenced watcher must remain retained");
+        assert_eq!(teardown.unresolved_count(), MAX_UNRESOLVED_TEARDOWNS);
+
+        for release in teardown_releases {
+            release.send(()).expect("release teardown worker");
+        }
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while teardown.unresolved_count() != 0 && Instant::now() < deadline {
+            teardown.reap_finished();
+            thread::yield_now();
+        }
+        assert_eq!(teardown.unresolved_count(), 0);
+        retained_release_tx
+            .send(())
+            .expect("release retained watcher");
+        drop(watcher);
     }
 
     fn completed_initializer(watcher: ActiveSourceWatcher) -> PendingSourceWatcher {

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -222,7 +222,12 @@ impl EventHandler for SourceWatcherIngress {
                 stream_id: self.stream_id,
                 event,
             },
-            capture => capture,
+            SourceWatcherCapture::Error { .. } => SourceWatcherCapture::Error {
+                stream_id: self.stream_id,
+            },
+            SourceWatcherCapture::Overflow { .. } => SourceWatcherCapture::Overflow {
+                stream_id: self.stream_id,
+            },
         };
         if !self.enabled.load(Ordering::Acquire) {
             return;
@@ -340,6 +345,24 @@ impl GuiSourceWatcherHandle {
             .send(GuiSourceWatchCommand::InjectPaths(paths));
     }
 
+    #[cfg(test)]
+    pub(super) fn inject_capture_for_tests(&self, capture: SourceWatcherCapture) {
+        let _ = self
+            .command_tx
+            .send(GuiSourceWatchCommand::InjectCapture(capture));
+    }
+
+    #[cfg(test)]
+    pub(super) fn watcher_is_live_for_tests(&self) -> bool {
+        let (status_tx, status_rx) = std::sync::mpsc::channel();
+        self.command_tx
+            .send(GuiSourceWatchCommand::ReportWatcherLive(status_tx))
+            .expect("source watcher should accept a status query");
+        status_rx
+            .recv_timeout(WATCHER_START_TIMEOUT)
+            .expect("source watcher should report its live status")
+    }
+
     #[cfg(any(test, feature = "legacy-controller"))]
     pub(in crate::native_app) fn wait_until_ready(&self, timeout: Duration) -> Result<(), String> {
         let (ready_tx, ready_rx) = std::sync::mpsc::channel();
@@ -392,6 +415,10 @@ enum GuiSourceWatchCommand {
     AwaitReady(Sender<()>),
     #[cfg(test)]
     InjectPaths(Vec<std::path::PathBuf>),
+    #[cfg(test)]
+    InjectCapture(SourceWatcherCapture),
+    #[cfg(test)]
+    ReportWatcherLive(Sender<bool>),
     Shutdown,
 }
 
@@ -491,15 +518,18 @@ fn run_source_watcher(
                 let event = paths
                     .into_iter()
                     .fold(Event::new(EventKind::Any), Event::add_path);
+                let stream_id = watcher
+                    .as_ref()
+                    .map(|watcher| watcher.stream_id)
+                    .unwrap_or(0);
                 let capture = match capture_event(Ok(event)) {
-                    SourceWatcherCapture::Notify { event, .. } => SourceWatcherCapture::Notify {
-                        stream_id: watcher
-                            .as_ref()
-                            .map(|watcher| watcher.stream_id)
-                            .unwrap_or(0),
-                        event,
-                    },
-                    capture => capture,
+                    SourceWatcherCapture::Notify { event, .. } => {
+                        SourceWatcherCapture::Notify { stream_id, event }
+                    }
+                    SourceWatcherCapture::Error { .. } => SourceWatcherCapture::Error { stream_id },
+                    SourceWatcherCapture::Overflow { .. } => {
+                        SourceWatcherCapture::Overflow { stream_id }
+                    }
                 };
                 match event_tx.try_send(capture) {
                     Ok(()) => {}
@@ -508,6 +538,21 @@ fn run_source_watcher(
                     }
                     Err(TrySendError::Disconnected(_)) => {}
                 }
+            }
+            #[cfg(test)]
+            Ok(GuiSourceWatchCommand::InjectCapture(capture)) => match event_tx.try_send(capture) {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => {
+                    ingress_overflowed.store(true, Ordering::Release);
+                }
+                Err(TrySendError::Disconnected(_)) => {}
+            },
+            #[cfg(test)]
+            Ok(GuiSourceWatchCommand::ReportWatcherLive(status_tx)) => {
+                let is_live = watcher
+                    .as_ref()
+                    .is_some_and(|watcher| watcher.ingress_enabled.load(Ordering::Acquire));
+                let _ = status_tx.send(is_live);
             }
             Ok(GuiSourceWatchCommand::Shutdown) => {
                 cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
@@ -808,25 +853,27 @@ fn run_source_watcher(
         let mut watcher_failed = false;
         let mut root_invalidated = false;
         while let Ok(event) = event_rx.try_recv() {
+            let stream_id = match &event {
+                SourceWatcherCapture::Notify { stream_id, .. }
+                | SourceWatcherCapture::Error { stream_id }
+                | SourceWatcherCapture::Overflow { stream_id } => *stream_id,
+            };
+            if watcher.as_ref().map(|watcher| watcher.stream_id) != Some(stream_id) {
+                state.mark_all_overflowed(now);
+                continue;
+            }
             match event {
-                SourceWatcherCapture::Notify {
-                    stream_id,
-                    mut event,
-                } => {
-                    if watcher.as_ref().map(|watcher| watcher.stream_id) != Some(stream_id) {
-                        state.mark_all_overflowed(now);
-                        continue;
-                    }
+                SourceWatcherCapture::Notify { mut event, .. } => {
                     if !retain_source_refresh_candidates(&mut event) {
                         continue;
                     }
                     root_invalidated |= state.collect_event(&event, Instant::now());
                 }
-                SourceWatcherCapture::Error => {
+                SourceWatcherCapture::Error { .. } => {
                     tracing::warn!("GUI source watcher error");
                     watcher_failed = true;
                 }
-                SourceWatcherCapture::Overflow => {
+                SourceWatcherCapture::Overflow { .. } => {
                     state.mark_all_overflowed(now);
                 }
             }
@@ -1283,6 +1330,7 @@ pub(super) fn doubled_backoff(current: Duration) -> Duration {
 
 #[cfg(test)]
 mod lifecycle_tests {
+    use super::super::capture::MAX_CAPTURE_PATHS;
     use super::*;
     use notify::{Event, EventKind, RecursiveMode, WatcherKind};
     use std::{
@@ -1605,8 +1653,8 @@ mod lifecycle_tests {
     }
 
     #[test]
-    fn ingress_attaches_its_stream_id_to_captured_notifications() {
-        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+    fn ingress_attaches_its_stream_id_to_all_captured_variants() {
+        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(3);
         let mut ingress = SourceWatcherIngress {
             event_tx,
             overflowed: Arc::new(AtomicBool::new(false)),
@@ -1619,13 +1667,27 @@ mod lifecycle_tests {
             paths: Vec::new(),
             attrs: notify::event::EventAttributes::default(),
         }));
+        ingress.handle_event(Err(notify::Error::generic("capture-test")));
+        ingress.handle_event(Ok(Event {
+            kind: EventKind::Any,
+            paths: (0..=MAX_CAPTURE_PATHS)
+                .map(|index| PathBuf::from(format!("{index}.wav")))
+                .collect(),
+            attrs: notify::event::EventAttributes::default(),
+        }));
 
-        let SourceWatcherCapture::Notify { stream_id, .. } =
-            event_rx.recv().expect("captured notification")
-        else {
-            panic!("expected captured notification");
-        };
-        assert_eq!(stream_id, 41);
+        assert!(matches!(
+            event_rx.recv().expect("captured notification"),
+            SourceWatcherCapture::Notify { stream_id: 41, .. }
+        ));
+        assert!(matches!(
+            event_rx.recv().expect("captured error"),
+            SourceWatcherCapture::Error { stream_id: 41 }
+        ));
+        assert!(matches!(
+            event_rx.recv().expect("captured overflow"),
+            SourceWatcherCapture::Overflow { stream_id: 41 }
+        ));
     }
 
     struct BlockingDropWatcher {

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -1,3 +1,4 @@
+use super::capture::SourceWatcherCapture;
 use super::classification::{path_is_source_refresh_candidate, retain_source_refresh_candidates};
 use super::handle::{GuiSourceWatcherHandle, doubled_backoff};
 use super::roots::{
@@ -760,6 +761,75 @@ fn filesystem_event_after_initial_watcher_ready_is_not_suppressed() {
     assert_eq!(refresh.1, vec![PathBuf::from("recording.wav")]);
     assert!(!refresh.2);
     assert!(refresh.3);
+}
+
+#[test]
+fn stale_error_and_overflow_widen_without_retiring_current_watcher() {
+    let root = tempfile::tempdir().expect("watched source root");
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("source_id::stale-capture"),
+        root.path().to_path_buf(),
+    );
+    let source_id = source.id.as_str().to_string();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let watcher = GuiSourceWatcherHandle::spawn(vec![source], sender);
+    watcher.wait_until_ready_for_tests();
+    while !matches!(
+        receiver
+            .recv_timeout(super::WATCHER_START_TIMEOUT)
+            .expect("initial watcher-ready message"),
+        GuiMessage::SourceWatcherReady { .. }
+    ) {}
+    assert!(
+        watcher.watcher_is_live_for_tests(),
+        "initial watcher should be live before stale capture injection"
+    );
+
+    watcher.force_restart_for_tests();
+    watcher.wait_until_ready_for_tests();
+    while receiver.try_recv().is_ok() {}
+    assert!(
+        watcher.watcher_is_live_for_tests(),
+        "replacement watcher should be live before stale capture injection"
+    );
+
+    for (capture, label) in [
+        (SourceWatcherCapture::Error { stream_id: 0 }, "stale error"),
+        (
+            SourceWatcherCapture::Overflow { stream_id: 0 },
+            "stale overflow",
+        ),
+    ] {
+        watcher.inject_capture_for_tests(capture);
+
+        let deadline = Instant::now()
+            + super::SOURCE_CHANGE_DEBOUNCE
+            + super::WATCHER_POLL_INTERVAL.saturating_mul(4);
+        loop {
+            let message = receiver
+                .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                .unwrap_or_else(|error| panic!("{label} source refresh: {error}"));
+            if let GuiMessage::SourceFilesystemChanged {
+                source_id: observed_source_id,
+                paths,
+                overflowed,
+                ..
+            } = message
+                && observed_source_id == source_id
+            {
+                assert!(
+                    paths.is_empty(),
+                    "{label} must widen rather than target paths"
+                );
+                assert!(overflowed, "{label} must conservatively widen sources");
+                break;
+            }
+        }
+        assert!(
+            watcher.watcher_is_live_for_tests(),
+            "{label} must not retire the replacement watcher"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Goal

Fence delayed callbacks from retired native watcher instances so they cannot be admitted as current live filesystem observations.

## Scope and non-goals

- Assign each watcher instance a process-local monotonic stream identity.
- Attach that identity to every bounded callback capture variant.
- Gate every capture at the coordinator by both stream identity and live ingress state.
- Treat stale or fenced captures as conservative full-source reconciliation evidence.
- Keep the test injection seam aligned with the active stream.
- No journal, source-writer, projection, schema, or reconciliation API changes.

## Definition of Done

- A notification from the current enabled watcher stream continues through normal candidate filtering and debounce.
- A current-stream error or overflow retains its existing failure/reconciliation behavior.
- A notification, error, or overflow from a retired, fenced, or absent watcher stream cannot be treated as current live authority and instead marks all sources for bounded reconciliation without tearing down the replacement watcher.
- Stream identity is attached without adding unbounded callback work or payload growth beyond the existing bounded envelope.
- Regression coverage proves stale error/overflow behavior after watcher replacement and matching captures from a retained fenced watcher during teardown saturation.
- Regression coverage and proportional validation pass.

## Validation

- `cargo test --lib source_watcher` — 92 passed
- `cargo check --all-targets` — passed
- `rustfmt --edition 2024 --check src/native_app/sample_library/source_watcher/capture.rs src/native_app/sample_library/source_watcher/handle.rs src/native_app/sample_library/source_watcher/tests.rs` — passed
- `git diff --check` — passed

## Known limitations

Native host acceptance and the later supervisor/source-writer/projection wiring remain separate alignment slices.

User approval is required before merge.