### PR TITLE
Make same-root admission begins idempotent

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
@@ -140,7 +140,7 @@ impl ReconciliationAdmissionOwner {
                 .supervisor
                 .restart_lane(&existing_lane)
                 .map_err(AdmissionOwnerError::Supervisor)?,
-            ReconciliationLifecycle::Capturing => generation,
+            ReconciliationLifecycle::Capturing => return self.snapshot(&existing_lane),
         };
 
         self.supervisor
@@ -345,6 +345,23 @@ mod tests {
                 AdmissionError::LaneLimitReached
             ))
         );
+    }
+
+    #[test]
+    fn begin_source_is_idempotent_for_capturing_same_root() {
+        let source = SourceId::from_string("source-a");
+        let root_identity = root(b"root-a");
+        let mut owner = owner(1, 2, 8);
+
+        let first = owner
+            .begin_source(source.clone(), root_identity.clone())
+            .expect("begin source");
+        let second = owner
+            .begin_source(source.clone(), root_identity)
+            .expect("repeat begin source");
+
+        assert_eq!(second, first);
+        assert_eq!(owner.supervisor().in_flight(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Goal

Make repeated same-root admission-owner begin calls idempotent so lifecycle synchronization can safely repeat unchanged source/root setup.

## Scope and non-goals

- When a source/root lane is already Capturing, return its current authoritative snapshot unchanged.
- Preserve Starting -> begin_capture and Stopped -> restart with a newer generation -> begin_capture.
- Preserve root mismatch, supervisor errors, uncertainty, and stale-generation semantics.
- Add regression coverage for repeated same-root begin preserving lane and generation.
- No native watcher, capture, adapter, dispatch, projection, acknowledgement, filesystem, database, GUI, or checkpoint changes.

## Definition of Done

- Repeated same-root begin returns success while preserving the existing lane key and generation.
- A currently Capturing lane is not silently restarted or assigned a new generation.
- Existing Starting and Stopped transitions remain unchanged.
- Focused owner and reconciliation tests pass.

## Validation

- cargo test -p wavecrate-library --lib sample_sources::reconciliation::owner — 10 passed
- cargo test -p wavecrate-library --lib sample_sources::reconciliation — 69 passed
- cargo check -p wavecrate-library --tests — passed
- Changed-file rustfmt check — passed
- git diff --check — passed

## Known limitations

Native lifecycle wiring and raw capture admission remain the next separate slices.

User approval is required before merge.