### PR TITLE
Wire native admission lifecycle ownership

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
@@ -49,6 +49,14 @@ pub enum ReconciliationLifecycle {
     Stopped,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InFlightCapacityMode {
+    /// Reserve one in-flight envelope slot for every possible registered lane.
+    ReservedPerLane,
+    /// Bound each registered lane independently without reserving capacity for the registry.
+    ExplicitPerLane { max_in_flight_per_lane: usize },
+}
+
 /// A bounded admission configuration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ReconciliationAdmissionLimits {
@@ -56,6 +64,7 @@ pub struct ReconciliationAdmissionLimits {
     per_lane: RawObservationLimits,
     global: RawObservationLimits,
     max_in_flight: usize,
+    capacity_mode: InFlightCapacityMode,
     max_recent_sequences_per_lane: usize,
     max_retained_uncertainties: usize,
 }
@@ -74,10 +83,70 @@ impl ReconciliationAdmissionLimits {
         max_recent_sequences_per_lane: usize,
         max_retained_uncertainties: usize,
     ) -> Result<Self, AdmissionError> {
+        Self::new_with_capacity_mode(
+            max_lanes,
+            per_lane,
+            global,
+            max_in_flight,
+            InFlightCapacityMode::ReservedPerLane,
+            max_recent_sequences_per_lane,
+            max_retained_uncertainties,
+        )
+    }
+
+    /// Construct limits with an explicit per-lane in-flight envelope capacity.
+    ///
+    /// Unlike [`Self::new`], this mode does not reserve one global envelope slot for every
+    /// possible registered lane. The global `max_in_flight` bound and the explicit
+    /// `max_in_flight_per_lane` bound are enforced independently, so a large lifecycle lane
+    /// registry can share a fixed raw-work budget.
+    pub fn new_with_per_lane_capacity(
+        max_lanes: usize,
+        per_lane: RawObservationLimits,
+        global: RawObservationLimits,
+        max_in_flight: usize,
+        max_in_flight_per_lane: usize,
+        max_recent_sequences_per_lane: usize,
+        max_retained_uncertainties: usize,
+    ) -> Result<Self, AdmissionError> {
+        Self::new_with_capacity_mode(
+            max_lanes,
+            per_lane,
+            global,
+            max_in_flight,
+            InFlightCapacityMode::ExplicitPerLane {
+                max_in_flight_per_lane,
+            },
+            max_recent_sequences_per_lane,
+            max_retained_uncertainties,
+        )
+    }
+
+    fn new_with_capacity_mode(
+        max_lanes: usize,
+        per_lane: RawObservationLimits,
+        global: RawObservationLimits,
+        max_in_flight: usize,
+        capacity_mode: InFlightCapacityMode,
+        max_recent_sequences_per_lane: usize,
+        max_retained_uncertainties: usize,
+    ) -> Result<Self, AdmissionError> {
         if max_lanes == 0 {
             return Err(AdmissionError::ZeroLaneLimit);
         }
-        if max_in_flight == 0 || max_in_flight < max_lanes {
+        if max_in_flight == 0
+            || matches!(
+                capacity_mode,
+                InFlightCapacityMode::ExplicitPerLane {
+                    max_in_flight_per_lane: 0
+                }
+            )
+            || matches!(capacity_mode, InFlightCapacityMode::ExplicitPerLane {
+                max_in_flight_per_lane
+            } if max_in_flight_per_lane > max_in_flight)
+            || (matches!(capacity_mode, InFlightCapacityMode::ReservedPerLane)
+                && max_in_flight < max_lanes)
+        {
             return Err(AdmissionError::InsufficientEnvelopeCapacity);
         }
         if max_recent_sequences_per_lane == 0 {
@@ -91,6 +160,7 @@ impl ReconciliationAdmissionLimits {
             per_lane,
             global,
             max_in_flight,
+            capacity_mode,
             max_recent_sequences_per_lane,
             max_retained_uncertainties,
         })
@@ -986,9 +1056,7 @@ impl ReconciliationAdmissionSupervisor {
             );
         };
         let lane_live_tickets = self.lanes[&lane].live_tickets;
-        let shared_capacity = self.limits.max_in_flight - self.limits.max_lanes;
-        let lane_capacity_available =
-            lane_live_tickets == 0 || self.shared_used() < shared_capacity;
+        let lane_capacity_available = self.lane_capacity_available(lane_live_tickets);
         if self.pending.len() >= self.limits.max_in_flight
             || !lane_capacity_available
             || !next_lane_usage.within(self.limits.per_lane)
@@ -1284,6 +1352,18 @@ impl ReconciliationAdmissionSupervisor {
         self.lanes.values().fold(0, |used, state| {
             used.saturating_add(state.live_tickets.saturating_sub(1))
         })
+    }
+
+    fn lane_capacity_available(&self, lane_live_tickets: usize) -> bool {
+        match self.limits.capacity_mode {
+            InFlightCapacityMode::ReservedPerLane => {
+                let shared_capacity = self.limits.max_in_flight - self.limits.max_lanes;
+                lane_live_tickets == 0 || self.shared_used() < shared_capacity
+            }
+            InFlightCapacityMode::ExplicitPerLane {
+                max_in_flight_per_lane,
+            } => lane_live_tickets < max_in_flight_per_lane,
+        }
     }
 
     fn retain_marker(&mut self, mut marker: RetainedUncertainty) {
@@ -2376,6 +2456,94 @@ mod tests {
             ReconciliationAdmissionLimits::new(1, per_lane, global, 1, 8, 0),
             Err(AdmissionError::ZeroRetainedUncertaintyLimit)
         );
+        assert_eq!(
+            ReconciliationAdmissionLimits::new_with_per_lane_capacity(
+                usize::MAX,
+                per_lane,
+                global,
+                8,
+                9,
+                8,
+                64,
+            ),
+            Err(AdmissionError::InsufficientEnvelopeCapacity)
+        );
+    }
+
+    #[test]
+    fn explicit_per_lane_capacity_allows_large_registry_with_bounded_in_flight_work() {
+        let per_lane = RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("limits");
+        let global = RawObservationLimits::new(256, usize::MAX, usize::MAX).expect("limits");
+        let limits = ReconciliationAdmissionLimits::new_with_per_lane_capacity(
+            usize::MAX,
+            per_lane,
+            global,
+            256,
+            1,
+            8,
+            512,
+        )
+        .expect("explicit per-lane limits");
+        let mut supervisor = ReconciliationAdmissionSupervisor::new(limits);
+        let mut identities = Vec::with_capacity(257);
+        for index in 0..257 {
+            let source = SourceId::from_string(format!("source-{index}"));
+            let root = RootIdentity::from_bytes(format!("root-{index}").into_bytes());
+            let (_, generation) = registered(&mut supervisor, &source, &root);
+            identities.push((source, root, generation));
+        }
+        assert_eq!(supervisor.source_ids().count(), 257);
+
+        let (source, root, generation) = &identities[0];
+        assert!(matches!(
+            supervisor.admit(envelope(
+                source,
+                Some(root),
+                *generation,
+                0,
+                RawEventKind::Create
+            )),
+            AdmissionOutcome::Accepted(_)
+        ));
+        assert_eq!(
+            supervisor.admit(envelope(
+                source,
+                Some(root),
+                *generation,
+                1,
+                RawEventKind::Modify,
+            )),
+            AdmissionOutcome::Rejected(AdmissionRejectReason::QueueSaturated)
+        );
+
+        for (captured_at, (source, root, generation)) in
+            identities.iter().skip(1).take(255).enumerate()
+        {
+            assert!(matches!(
+                supervisor.admit(envelope(
+                    source,
+                    Some(root),
+                    *generation,
+                    captured_at as u64 + 2,
+                    RawEventKind::Create,
+                )),
+                AdmissionOutcome::Accepted(_)
+            ));
+        }
+        assert_eq!(supervisor.in_flight(), 256);
+
+        let (source, root, generation) = &identities[256];
+        assert_eq!(
+            supervisor.admit(envelope(
+                source,
+                Some(root),
+                *generation,
+                257,
+                RawEventKind::Create,
+            )),
+            AdmissionOutcome::Rejected(AdmissionRejectReason::QueueSaturated)
+        );
+        assert_eq!(supervisor.in_flight(), 256);
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
@@ -674,6 +674,11 @@ impl ReconciliationAdmissionSupervisor {
         self.sources.get(source_id)
     }
 
+    /// Iterate over the source identifiers in the authoritative lane index.
+    pub fn source_ids(&self) -> impl Iterator<Item = &SourceId> {
+        self.sources.keys()
+    }
+
     /// Register a source/root lane in `Starting` state.
     pub fn register_lane(
         &mut self,

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
@@ -102,6 +102,11 @@ impl ReconciliationAdmissionOwner {
         self.snapshot(lane).ok()
     }
 
+    /// Iterate over source identifiers registered in the owned supervisor.
+    pub fn source_ids(&self) -> impl Iterator<Item = &SourceId> {
+        self.supervisor.source_ids()
+    }
+
     /// Register and begin a source, or begin/restart its existing same-root lane.
     ///
     /// A newly registered lane is left in `Starting` if the final `begin_capture` call fails;

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+mod admission_lifecycle;
 mod capture;
 mod classification;
 mod debounce;

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -1,0 +1,491 @@
+//! Watcher-local lifecycle ownership for source/root admission lanes.
+
+use std::collections::HashSet;
+
+use wavecrate::sample_sources::{SampleSource, SourceId};
+use wavecrate_library::sample_sources::reconciliation::{
+    AdmissionOwnerError, RawObservationLimits, ReconciliationAdmissionLimits,
+    ReconciliationAdmissionOwner, ReconciliationAdmissionSupervisor, ReconciliationLifecycle,
+    RootIdentity,
+};
+
+#[cfg(test)]
+use wavecrate_library::sample_sources::reconciliation::OwnedAdmissionLane;
+
+use super::roots::{WatchedRootIdentities, registered_root_identity};
+
+/// Bounded owner capacity for the native watcher lifecycle.
+///
+/// This is a resource bound, not a source-count policy. If the owner reaches it, lifecycle
+/// reconciliation fails closed and the owner is retained for a later retry.
+const NATIVE_ADMISSION_MAX_LANES: usize = 256;
+const NATIVE_ADMISSION_MAX_IN_FLIGHT: usize = NATIVE_ADMISSION_MAX_LANES;
+const NATIVE_ADMISSION_MAX_RECENT_SEQUENCES_PER_LANE: usize = 64;
+const NATIVE_ADMISSION_MAX_RETAINED_UNCERTAINTIES: usize = 4096;
+const NATIVE_ADMISSION_MAX_EVENTS_PER_LANE: usize = 512;
+
+/// Owns the one admission owner used by a native source-watcher coordinator.
+pub(super) struct AdmissionLifecycle {
+    owner: ReconciliationAdmissionOwner,
+}
+
+impl AdmissionLifecycle {
+    /// Create an empty lifecycle owner with the native bounded capacity.
+    pub(super) fn new() -> Self {
+        Self::from_limits(native_admission_limits())
+    }
+
+    fn from_limits(limits: ReconciliationAdmissionLimits) -> Self {
+        Self {
+            owner: ReconciliationAdmissionOwner::new(ReconciliationAdmissionSupervisor::new(
+                limits,
+            )),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_limits(limits: ReconciliationAdmissionLimits) -> Self {
+        Self::from_limits(limits)
+    }
+
+    /// Stop every registered lane while retaining the owner's uncertainty markers.
+    pub(super) fn fence_all(&mut self) -> Result<(), AdmissionOwnerError> {
+        let mut source_ids = self.owner.source_ids().cloned().collect::<Vec<_>>();
+        source_ids.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        for source_id in source_ids {
+            self.stop_if_capturing(&source_id)?;
+        }
+        Ok(())
+    }
+
+    /// Reconcile configured sources with the roots that the current watcher installed.
+    ///
+    /// Only a root identity recorded by successful watcher installation is eligible for a lane.
+    /// Missing or unreadable identities leave a configured source stopped or unregistered. The
+    /// owner remains authoritative for all existing lane and generation state.
+    pub(super) fn reconcile(
+        &mut self,
+        sources: &[SampleSource],
+        watched_roots: &WatchedRootIdentities,
+    ) -> Result<(), AdmissionOwnerError> {
+        let desired_source_ids = sources
+            .iter()
+            .map(|source| source.id.clone())
+            .collect::<HashSet<_>>();
+
+        let mut registered_source_ids = self.owner.source_ids().cloned().collect::<Vec<_>>();
+        registered_source_ids.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        for source_id in registered_source_ids {
+            if !desired_source_ids.contains(&source_id) {
+                self.stop_if_capturing(&source_id)?;
+                self.owner.remove_source(&source_id)?;
+            }
+        }
+
+        for source in sources {
+            let Some(root_identity) = registered_root_identity(watched_roots, &source.root) else {
+                self.stop_if_capturing(&source.id)?;
+                continue;
+            };
+            self.reconcile_source(source, root_identity)?;
+        }
+        Ok(())
+    }
+
+    fn reconcile_source(
+        &mut self,
+        source: &SampleSource,
+        root_identity: RootIdentity,
+    ) -> Result<(), AdmissionOwnerError> {
+        let Some(existing) = self.owner.lane(&source.id) else {
+            return self
+                .owner
+                .begin_source(source.id.clone(), root_identity)
+                .map(|_| ())
+                .map_err(Into::into);
+        };
+
+        if existing.root_identity() != &root_identity {
+            self.owner
+                .rebind_source(&source.id, root_identity.clone())?;
+            return self
+                .owner
+                .begin_source(source.id.clone(), root_identity)
+                .map(|_| ())
+                .map_err(Into::into);
+        }
+
+        if existing.lifecycle() == ReconciliationLifecycle::Capturing {
+            return Ok(());
+        }
+
+        self.owner
+            .begin_source(source.id.clone(), root_identity)
+            .map(|_| ())
+            .map_err(Into::into)
+    }
+
+    fn stop_if_capturing(&mut self, source_id: &SourceId) -> Result<(), AdmissionOwnerError> {
+        let Some(lane) = self.owner.lane(source_id) else {
+            return Ok(());
+        };
+        if lane.lifecycle() != ReconciliationLifecycle::Stopped {
+            self.owner.stop_source(source_id)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn lane(&self, source_id: &SourceId) -> Option<OwnedAdmissionLane> {
+        self.owner.lane(source_id)
+    }
+}
+
+fn native_admission_limits() -> ReconciliationAdmissionLimits {
+    let per_lane =
+        RawObservationLimits::new(NATIVE_ADMISSION_MAX_EVENTS_PER_LANE, usize::MAX, usize::MAX)
+            .expect("native per-lane admission limits");
+    let global_events = NATIVE_ADMISSION_MAX_EVENTS_PER_LANE
+        .checked_mul(NATIVE_ADMISSION_MAX_LANES)
+        .expect("native global event limit");
+    let global = RawObservationLimits::new(global_events, usize::MAX, usize::MAX)
+        .expect("native global admission limits");
+    ReconciliationAdmissionLimits::new(
+        NATIVE_ADMISSION_MAX_LANES,
+        per_lane,
+        global,
+        NATIVE_ADMISSION_MAX_IN_FLIGHT,
+        NATIVE_ADMISSION_MAX_RECENT_SEQUENCES_PER_LANE,
+        NATIVE_ADMISSION_MAX_RETAINED_UNCERTAINTIES,
+    )
+    .expect("native admission limits")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{collections::HashMap, path::PathBuf};
+
+    fn source(id: &str, root: &str) -> SampleSource {
+        SampleSource::new_with_id(SourceId::from_string(id), PathBuf::from(root))
+    }
+
+    fn root(identity: &[u8]) -> RootIdentity {
+        RootIdentity::from_bytes(identity.to_vec())
+    }
+
+    fn watched(entries: &[(&str, Option<&[u8]>)]) -> WatchedRootIdentities {
+        entries
+            .iter()
+            .map(|(path, identity)| {
+                (
+                    PathBuf::from(path),
+                    identity.map(|identity| String::from_utf8_lossy(identity).into_owned()),
+                )
+            })
+            .collect()
+    }
+
+    fn limits(
+        max_lanes: usize,
+        max_in_flight: usize,
+        max_retained_uncertainties: usize,
+    ) -> ReconciliationAdmissionLimits {
+        let per_lane = RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("lane limits");
+        let global = RawObservationLimits::new(32, usize::MAX, usize::MAX).expect("global limits");
+        ReconciliationAdmissionLimits::new(
+            max_lanes,
+            per_lane,
+            global,
+            max_in_flight,
+            8,
+            max_retained_uncertainties,
+        )
+        .expect("admission limits")
+    }
+
+    #[test]
+    fn startup_binds_only_identity_qualified_watched_roots() {
+        let source = source("startup", "root-a");
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(2, 2, 8));
+
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&source),
+                &watched(&[("root-a", Some(b"identity-a"))]),
+            )
+            .expect("startup binding");
+
+        let lane = lifecycle.lane(&source.id).expect("startup lane");
+        assert_eq!(lane.root_identity(), &root(b"identity-a"));
+        assert_eq!(lane.generation().get(), 1);
+        assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn repeated_same_sources_are_a_no_op_for_lane_and_generation() {
+        let source = source("repeat", "root-a");
+        let sources = [source.clone()];
+        let watched = watched(&[("root-a", Some(b"identity-a"))]);
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(2, 2, 8));
+
+        lifecycle
+            .reconcile(&sources, &watched)
+            .expect("first binding");
+        let first = lifecycle.lane(&source.id).expect("first lane");
+        lifecycle
+            .reconcile(&sources, &watched)
+            .expect("repeat binding");
+
+        assert_eq!(lifecycle.lane(&source.id).expect("repeated lane"), first);
+        assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn source_add_and_remove_are_independent_and_removal_retains_uncertainty() {
+        let first = source("first", "root-a");
+        let second = source("second", "root-b");
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(2, 2, 8));
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&first),
+                &watched(&[("root-a", Some(b"identity-a"))]),
+            )
+            .expect("first binding");
+
+        lifecycle
+            .reconcile(
+                &[first.clone(), second.clone()],
+                &watched(&[
+                    ("root-a", Some(b"identity-a")),
+                    ("root-b", Some(b"identity-b")),
+                ]),
+            )
+            .expect("independent addition");
+
+        assert_eq!(
+            lifecycle.lane(&first.id).expect("first lane").lifecycle(),
+            ReconciliationLifecycle::Capturing
+        );
+        assert_eq!(
+            lifecycle.lane(&second.id).expect("second lane").lifecycle(),
+            ReconciliationLifecycle::Capturing
+        );
+
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&second),
+                &watched(&[("root-b", Some(b"identity-b"))]),
+            )
+            .expect("independent removal");
+
+        assert!(lifecycle.lane(&first.id).is_none());
+        assert_eq!(
+            lifecycle.lane(&second.id).expect("second lane").lifecycle(),
+            ReconciliationLifecycle::Capturing
+        );
+        assert!(
+            !lifecycle
+                .owner
+                .supervisor()
+                .retained_uncertainties()
+                .is_empty()
+        );
+        assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn same_id_root_rebind_stops_old_generation_then_begins_new_root() {
+        let initial_source = source("rebind", "root-a");
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(1, 1, 16));
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&initial_source),
+                &watched(&[("root-a", Some(b"identity-a"))]),
+            )
+            .expect("old binding");
+        let old = lifecycle.lane(&initial_source.id).expect("old lane");
+
+        let replacement = source("rebind", "root-b");
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&replacement),
+                &watched(&[("root-b", Some(b"identity-b"))]),
+            )
+            .expect("rebound binding");
+        let new = lifecycle.lane(&replacement.id).expect("new lane");
+
+        assert_eq!(new.root_identity(), &root(b"identity-b"));
+        assert!(new.generation() > old.generation());
+        assert_eq!(new.lifecycle(), ReconciliationLifecycle::Capturing);
+        assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn same_root_source_id_replacement_removes_old_lane_and_begins_new_one() {
+        let old_source = source("old-id", "root-a");
+        let new_source = source("new-id", "root-a");
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(2, 2, 8));
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&old_source),
+                &watched(&[("root-a", Some(b"identity-a"))]),
+            )
+            .expect("old binding");
+
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&new_source),
+                &watched(&[("root-a", Some(b"identity-a"))]),
+            )
+            .expect("source-id replacement");
+
+        assert!(lifecycle.lane(&old_source.id).is_none());
+        assert_eq!(
+            lifecycle
+                .lane(&new_source.id)
+                .expect("new source lane")
+                .lifecycle(),
+            ReconciliationLifecycle::Capturing
+        );
+        assert_eq!(
+            lifecycle.owner.source_ids().collect::<Vec<_>>(),
+            vec![&new_source.id]
+        );
+    }
+
+    #[test]
+    fn restart_same_source_and_root_allocates_a_new_generation() {
+        let source = source("restart", "root-a");
+        let watched = watched(&[("root-a", Some(b"identity-a"))]);
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(1, 1, 8));
+        lifecycle
+            .reconcile(std::slice::from_ref(&source), &watched)
+            .expect("initial binding");
+        let first = lifecycle.lane(&source.id).expect("initial lane");
+
+        lifecycle.fence_all().expect("fence restart");
+        lifecycle
+            .reconcile(std::slice::from_ref(&source), &watched)
+            .expect("restart binding");
+        let restarted = lifecycle.lane(&source.id).expect("restarted lane");
+
+        assert_eq!(restarted.root_identity(), first.root_identity());
+        assert!(restarted.generation() > first.generation());
+        assert_eq!(restarted.lifecycle(), ReconciliationLifecycle::Capturing);
+    }
+
+    #[test]
+    fn unavailable_identity_never_registers_a_lane_and_stops_existing_capture() {
+        let source = source("unavailable", "root-a");
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(1, 1, 8));
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&source),
+                &watched(&[("root-a", Some(b"identity-a"))]),
+            )
+            .expect("initial binding");
+
+        lifecycle
+            .reconcile(std::slice::from_ref(&source), &watched(&[("root-a", None)]))
+            .expect("unavailable identity");
+
+        assert_eq!(
+            lifecycle
+                .lane(&source.id)
+                .expect("retained lane")
+                .lifecycle(),
+            ReconciliationLifecycle::Stopped
+        );
+        assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn partial_watch_cleanup_fences_successfully_bound_roots_without_synthesizing_missing_ones() {
+        let first = source("partial-first", "root-a");
+        let second = source("partial-second", "root-b");
+        let sources = [first.clone(), second.clone()];
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(2, 2, 8));
+
+        lifecycle
+            .reconcile(
+                &sources,
+                &watched(&[("root-a", Some(b"identity-a")), ("root-b", None)]),
+            )
+            .expect("partial binding");
+        assert_eq!(
+            lifecycle.lane(&first.id).expect("watched lane").lifecycle(),
+            ReconciliationLifecycle::Capturing
+        );
+        assert!(lifecycle.lane(&second.id).is_none());
+
+        lifecycle.fence_all().expect("partial cleanup");
+        assert_eq!(
+            lifecycle.lane(&first.id).expect("fenced lane").lifecycle(),
+            ReconciliationLifecycle::Stopped
+        );
+        assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn capacity_failure_keeps_owner_state_and_fails_closed() {
+        let first = source("capacity-first", "root-a");
+        let second = source("capacity-second", "root-b");
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(1, 1, 8));
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&first),
+                &watched(&[("root-a", Some(b"identity-a"))]),
+            )
+            .expect("initial capacity binding");
+
+        let error = lifecycle
+            .reconcile(
+                &[first.clone(), second.clone()],
+                &watched(&[
+                    ("root-a", Some(b"identity-a")),
+                    ("root-b", Some(b"identity-b")),
+                ]),
+            )
+            .expect_err("second lane must fail closed at capacity");
+
+        assert_eq!(
+            error,
+            AdmissionOwnerError::Supervisor(
+                wavecrate_library::sample_sources::reconciliation::AdmissionError::LaneLimitReached
+            )
+        );
+        assert_eq!(
+            lifecycle
+                .lane(&first.id)
+                .expect("owner state retained")
+                .lifecycle(),
+            ReconciliationLifecycle::Capturing
+        );
+        assert!(lifecycle.lane(&second.id).is_none());
+        lifecycle.fence_all().expect("failed lifecycle cleanup");
+        assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn helper_does_not_construct_or_dispatch_observation_work() {
+        let source = source("no-adapter", "root-a");
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(1, 1, 8));
+
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&source),
+                &HashMap::from([(PathBuf::from("root-a"), Some("identity-a".to_string()))]),
+            )
+            .expect("lifecycle binding");
+
+        assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+        assert!(
+            lifecycle
+                .owner
+                .supervisor()
+                .retained_uncertainties()
+                .is_empty()
+        );
+    }
+}

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -17,9 +17,10 @@ use super::roots::{WatchedRootIdentities, registered_root_identity};
 /// Bounded owner capacity for the native watcher lifecycle.
 ///
 /// This is a resource bound, not a source-count policy. If the owner reaches it, lifecycle
-/// reconciliation fails closed and the owner is retained for a later retry.
-const NATIVE_ADMISSION_MAX_LANES: usize = 256;
-const NATIVE_ADMISSION_MAX_IN_FLIGHT: usize = NATIVE_ADMISSION_MAX_LANES;
+/// reconciliation fails closed and the owner is retained for a later retry. Admission stays
+/// closed until a later fence proves every registered lane stopped.
+const NATIVE_ADMISSION_MAX_IN_FLIGHT: usize = 256;
+const NATIVE_ADMISSION_MAX_IN_FLIGHT_PER_LANE: usize = 1;
 const NATIVE_ADMISSION_MAX_RECENT_SEQUENCES_PER_LANE: usize = 64;
 const NATIVE_ADMISSION_MAX_RETAINED_UNCERTAINTIES: usize = 4096;
 const NATIVE_ADMISSION_MAX_EVENTS_PER_LANE: usize = 512;
@@ -27,6 +28,7 @@ const NATIVE_ADMISSION_MAX_EVENTS_PER_LANE: usize = 512;
 /// Owns the one admission owner used by a native source-watcher coordinator.
 pub(super) struct AdmissionLifecycle {
     owner: ReconciliationAdmissionOwner,
+    admission_closed: bool,
 }
 
 impl AdmissionLifecycle {
@@ -40,6 +42,7 @@ impl AdmissionLifecycle {
             owner: ReconciliationAdmissionOwner::new(ReconciliationAdmissionSupervisor::new(
                 limits,
             )),
+            admission_closed: false,
         }
     }
 
@@ -49,12 +52,23 @@ impl AdmissionLifecycle {
     }
 
     /// Stop every registered lane while retaining the owner's uncertainty markers.
+    ///
+    /// A failed stop latches admission closed. Later lifecycle boundaries retry the fence, and
+    /// admission only reopens after every registered lane is proven stopped.
     pub(super) fn fence_all(&mut self) -> Result<(), AdmissionOwnerError> {
+        self.admission_closed = true;
         let mut source_ids = self.owner.source_ids().cloned().collect::<Vec<_>>();
         source_ids.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        let mut first_error = None;
         for source_id in source_ids {
-            self.stop_if_capturing(&source_id)?;
+            if let Err(error) = self.stop_if_capturing(&source_id) {
+                first_error.get_or_insert(error);
+            }
         }
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        self.admission_closed = false;
         Ok(())
     }
 
@@ -68,6 +82,10 @@ impl AdmissionLifecycle {
         sources: &[SampleSource],
         watched_roots: &WatchedRootIdentities,
     ) -> Result<(), AdmissionOwnerError> {
+        if self.admission_closed {
+            self.fence_all()?;
+        }
+
         let desired_source_ids = sources
             .iter()
             .map(|source| source.id.clone())
@@ -146,15 +164,16 @@ fn native_admission_limits() -> ReconciliationAdmissionLimits {
         RawObservationLimits::new(NATIVE_ADMISSION_MAX_EVENTS_PER_LANE, usize::MAX, usize::MAX)
             .expect("native per-lane admission limits");
     let global_events = NATIVE_ADMISSION_MAX_EVENTS_PER_LANE
-        .checked_mul(NATIVE_ADMISSION_MAX_LANES)
+        .checked_mul(NATIVE_ADMISSION_MAX_IN_FLIGHT)
         .expect("native global event limit");
     let global = RawObservationLimits::new(global_events, usize::MAX, usize::MAX)
         .expect("native global admission limits");
-    ReconciliationAdmissionLimits::new(
-        NATIVE_ADMISSION_MAX_LANES,
+    ReconciliationAdmissionLimits::new_with_per_lane_capacity(
+        usize::MAX,
         per_lane,
         global,
         NATIVE_ADMISSION_MAX_IN_FLIGHT,
+        NATIVE_ADMISSION_MAX_IN_FLIGHT_PER_LANE,
         NATIVE_ADMISSION_MAX_RECENT_SEQUENCES_PER_LANE,
         NATIVE_ADMISSION_MAX_RETAINED_UNCERTAINTIES,
     )
@@ -219,6 +238,34 @@ mod tests {
         let lane = lifecycle.lane(&source.id).expect("startup lane");
         assert_eq!(lane.root_identity(), &root(b"identity-a"));
         assert_eq!(lane.generation().get(), 1);
+        assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn native_limits_allow_more_than_256_identity_qualified_sources() {
+        let limits = native_admission_limits();
+        assert_eq!(limits.max_lanes(), usize::MAX);
+        assert_eq!(limits.max_in_flight(), NATIVE_ADMISSION_MAX_IN_FLIGHT);
+
+        let mut sources = Vec::with_capacity(257);
+        let mut watched_roots = HashMap::with_capacity(257);
+        for index in 0..257 {
+            let source = source(&format!("native-{index}"), &format!("root-{index}"));
+            watched_roots.insert(source.root.clone(), Some(format!("identity-{index}")));
+            sources.push(source);
+        }
+
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits);
+        lifecycle
+            .reconcile(&sources, &watched_roots)
+            .expect("native lifecycle lane registry");
+
+        assert_eq!(lifecycle.owner.source_ids().count(), 257);
+        assert!(sources.iter().all(|source| {
+            lifecycle
+                .lane(&source.id)
+                .is_some_and(|lane| lane.lifecycle() == ReconciliationLifecycle::Capturing)
+        }));
         assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
     }
 
@@ -465,6 +512,58 @@ mod tests {
         assert!(lifecycle.lane(&second.id).is_none());
         lifecycle.fence_all().expect("failed lifecycle cleanup");
         assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn retained_uncertainty_fence_failure_blocks_later_reconcile() {
+        let initial = source("fence-capacity", "root-a");
+        let replacement = source("fence-capacity", "root-b");
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(1, 1, 2));
+
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&initial),
+                &watched(&[("root-a", Some(b"identity-a"))]),
+            )
+            .expect("initial binding");
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&replacement),
+                &watched(&[("root-b", Some(b"identity-b"))]),
+            )
+            .expect("root retirement and replacement binding");
+
+        let retained_uncertainties = lifecycle
+            .owner
+            .supervisor()
+            .retained_uncertainties()
+            .to_vec();
+        assert_eq!(retained_uncertainties.len(), 2);
+        let generation = lifecycle
+            .lane(&replacement.id)
+            .expect("replacement lane")
+            .generation();
+        let expected_error = AdmissionOwnerError::Supervisor(
+            wavecrate_library::sample_sources::reconciliation::AdmissionError::UncertaintyCapacityExhausted,
+        );
+        assert_eq!(lifecycle.fence_all(), Err(expected_error));
+
+        assert_eq!(
+            lifecycle.reconcile(
+                std::slice::from_ref(&replacement),
+                &watched(&[("root-b", Some(b"identity-b"))]),
+            ),
+            Err(expected_error)
+        );
+        let lane = lifecycle
+            .lane(&replacement.id)
+            .expect("capturing lane remains authoritative");
+        assert_eq!(lane.generation(), generation);
+        assert_eq!(lane.lifecycle(), ReconciliationLifecycle::Capturing);
+        assert_eq!(
+            lifecycle.owner.supervisor().retained_uncertainties(),
+            retained_uncertainties.as_slice()
+        );
     }
 
     #[test]

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -14,6 +14,7 @@ use std::{
 };
 use wavecrate::sample_sources::{SampleSource, SourceId};
 
+use super::admission_lifecycle::AdmissionLifecycle;
 use super::capture::{SourceWatcherCapture, capture_event};
 use super::classification::retain_source_refresh_candidates;
 use super::journal::{self, JournalRecovery};
@@ -438,6 +439,7 @@ fn run_source_watcher(
     };
     let mut state = GuiSourceWatchState::default();
     state.set_sources(initial_sources);
+    let mut admission_lifecycle = AdmissionLifecycle::new();
     let mut next_restart = Instant::now();
     let mut restart_delay = WATCHER_RESTART_MIN;
     let mut next_root_refresh = Instant::now();
@@ -452,17 +454,34 @@ fn run_source_watcher(
     loop {
         match command_rx.recv_timeout(WATCHER_POLL_INTERVAL) {
             Ok(GuiSourceWatchCommand::ReplaceSources(sources)) => {
+                let now = Instant::now();
                 let roots_changed =
                     desired_watched_roots(&sources) != desired_watched_roots(&state.sources);
                 state.set_sources(sources);
-                if roots_changed {
+                if !reconcile_watcher_admission(
+                    &mut admission_lifecycle,
+                    &state.sources,
+                    &state.watched_roots,
+                    "source-list replacement",
+                ) {
                     retire_source_watcher(&mut watcher, &mut teardown);
                     cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
-                    state.reset_watches(Instant::now());
-                    next_restart = Instant::now();
+                    if watcher_has_been_ready {
+                        state.reset_watches(now);
+                    } else {
+                        state.clear_watches();
+                    }
+                    next_restart = now + restart_delay;
+                    restart_delay = doubled_backoff(restart_delay);
+                } else if roots_changed {
+                    fence_watcher_admission(&mut admission_lifecycle, "source-list watcher reset");
+                    retire_source_watcher(&mut watcher, &mut teardown);
+                    cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
+                    state.reset_watches(now);
+                    next_restart = now;
                     restart_delay = WATCHER_RESTART_MIN;
                 }
-                next_root_refresh = Instant::now();
+                next_root_refresh = now;
             }
             Ok(GuiSourceWatchCommand::AcknowledgeCommittedPaths {
                 source_id,
@@ -499,6 +518,7 @@ fn run_source_watcher(
             }
             #[cfg(test)]
             Ok(GuiSourceWatchCommand::ForceRestart) => {
+                fence_watcher_admission(&mut admission_lifecycle, "forced watcher restart");
                 retire_source_watcher(&mut watcher, &mut teardown);
                 cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
                 state.reset_watches(Instant::now());
@@ -555,12 +575,14 @@ fn run_source_watcher(
                 let _ = status_tx.send(is_live);
             }
             Ok(GuiSourceWatchCommand::Shutdown) => {
+                fence_watcher_admission(&mut admission_lifecycle, "watcher shutdown");
                 cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
                 retire_source_watcher_on_shutdown(&mut watcher, &mut teardown);
                 break;
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                fence_watcher_admission(&mut admission_lifecycle, "watcher command disconnect");
                 cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
                 retire_source_watcher_on_shutdown(&mut watcher, &mut teardown);
                 break;
@@ -624,6 +646,10 @@ fn run_source_watcher(
                     let (unavailable, watch_failed) =
                         state.apply_root_watch_update(update, now, false);
                     if watch_failed {
+                        fence_watcher_admission(
+                            &mut admission_lifecycle,
+                            "partial watcher installation",
+                        );
                         if let Err(restarted) =
                             retire_source_watcher_value(restarted, &mut teardown)
                         {
@@ -653,6 +679,34 @@ fn run_source_watcher(
                             restart_delay = doubled_backoff(restart_delay);
                         }
                     } else {
+                        let lifecycle_ready = reconcile_watcher_admission(
+                            &mut admission_lifecycle,
+                            &state.sources,
+                            &state.watched_roots,
+                            "successful watcher installation",
+                        );
+                        if !lifecycle_ready {
+                            if let Err(restarted) =
+                                retire_source_watcher_value(restarted, &mut teardown)
+                            {
+                                watcher = Some(restarted);
+                            }
+                            if watcher_has_been_ready {
+                                state.reset_watches(now);
+                            } else {
+                                state.clear_watches();
+                            }
+                            if !watcher_has_been_ready {
+                                publish_watcher_unavailable_fallback(
+                                    &message_tx,
+                                    &state.sources,
+                                    &mut watcher_unavailable_reported,
+                                );
+                            }
+                            next_restart = now + restart_delay;
+                            restart_delay = doubled_backoff(restart_delay);
+                            continue;
+                        }
                         restarted.ingress_enabled.store(true, Ordering::Release);
                         let first_ready = !watcher_has_been_ready;
                         let recovered_after_unavailability = watcher_unavailable_reported;
@@ -690,6 +744,10 @@ fn run_source_watcher(
                 }
                 Ok(Err(error)) => {
                     let _ = pending.join_handle.join();
+                    fence_watcher_admission(
+                        &mut admission_lifecycle,
+                        "watcher initialization failure",
+                    );
                     tracing::warn!(
                         ?backend,
                         retry_ms = restart_delay.as_millis(),
@@ -729,6 +787,10 @@ fn run_source_watcher(
                     pending_watcher = Some(pending);
                 }
                 Err(TryRecvError::Empty) => {
+                    fence_watcher_admission(
+                        &mut admission_lifecycle,
+                        "watcher initialization timeout",
+                    );
                     pending.ingress_enabled.store(false, Ordering::Release);
                     debug_assert!(
                         retired_initializers
@@ -777,6 +839,10 @@ fn run_source_watcher(
                 }
                 Err(TryRecvError::Disconnected) => {
                     let _ = pending.join_handle.join();
+                    fence_watcher_admission(
+                        &mut admission_lifecycle,
+                        "watcher initializer disconnect",
+                    );
                     tracing::warn!(
                         ?backend,
                         retry_ms = restart_delay.as_millis(),
@@ -831,6 +897,7 @@ fn run_source_watcher(
                     "Source root availability or filesystem identity changed; restarting watcher"
                 );
                 state.mark_roots_overflowed(&invalidated_roots, now);
+                fence_watcher_admission(&mut admission_lifecycle, "root identity refresh");
                 retire_source_watcher(&mut watcher, &mut teardown);
                 cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
                 state.clear_watches();
@@ -854,6 +921,7 @@ fn run_source_watcher(
             drain_watcher_captures(&mut state, watcher.as_ref(), &event_rx, now);
 
         if watcher_failed || root_invalidated {
+            fence_watcher_admission(&mut admission_lifecycle, "watcher capture retirement");
             retire_source_watcher(&mut watcher, &mut teardown);
             cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
             if watcher_failed {
@@ -904,6 +972,36 @@ fn run_source_watcher(
         lifecycle_tx
             .send(lifecycle)
             .expect("source watcher lifecycle service must outlive its coordinator");
+    }
+}
+
+fn fence_watcher_admission(admission: &mut AdmissionLifecycle, boundary: &'static str) {
+    if let Err(error) = admission.fence_all() {
+        tracing::error!(
+            boundary,
+            ?error,
+            "Could not fully fence native watcher admission; keeping backend ingress closed"
+        );
+    }
+}
+
+fn reconcile_watcher_admission(
+    admission: &mut AdmissionLifecycle,
+    sources: &[SampleSource],
+    watched_roots: &WatchedRootIdentities,
+    boundary: &'static str,
+) -> bool {
+    match admission.reconcile(sources, watched_roots) {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::error!(
+                boundary,
+                ?error,
+                "Native watcher admission lifecycle failed closed"
+            );
+            fence_watcher_admission(admission, boundary);
+            false
+        }
     }
 }
 


### PR DESCRIPTION
## Goal
Align the native source-watcher coordinator with the I/O target's admission and lifecycle ownership boundary: only successfully watched, identity-qualified roots may enter a capturing lane, and every watcher retirement boundary must fence admission before ingress can resume.

## Scope
- Add a watcher-local `AdmissionLifecycle` that owns one `ReconciliationAdmissionOwner`.
- Reconcile configured source IDs against typed `WatchedRootIdentities` after successful watcher installation.
- Fence lanes on watcher failure, timeout, disconnect, forced restart, root identity refresh, source-list replacement, and shutdown.
- Preserve source/root/generation distinctions, idempotent same-root capture, explicit rebind/restart generations, and retained uncertainty on removal.
- Add an explicit per-lane raw-work capacity mode so lifecycle lane registration is not coupled to the bounded raw-work pool.
- Keep failed fences latched closed until every lane is proven stopped; preserve the owner and uncertainty for later retry.
- Add focused lifecycle and admission-limit regressions.

## Non-goals
- No raw capture envelope construction or adapter/normalizer/dispatch work.
- No source-database writer, committed-delta, projection, checkpoint, readiness, artifact, or journal implementation.
- No product-level configured-source-count policy or owner recreation.
- No source-wide uncertainty acknowledgement redesign; capacity exhaustion remains fail-closed for the later dependent slice.
- No changes to Radiant.

## Definition of Done
- Admission is owned by the watcher coordinator and is identity-qualified before ingress opens.
- Retirement and failure paths fail closed without clearing owner uncertainty or recreating the owner.
- Same-root repeats are idempotent; root replacement and watcher restart receive newer generations; removed lanes stop before removal.
- Missing identities never synthesize a lane from a path or stream ID.
- Native lifecycle lanes can represent more than 256 configured sources while raw admission remains bounded to 256 global live envelopes and one live envelope per source.
- Focused lifecycle coverage exercises startup, repeat, add/remove, rebind, restart, unavailable identity, partial watch cleanup, capacity failure, and no-observation-work behavior.

## Validation
- `cargo test -p wavecrate-library reconciliation::admission` — PASS (31 tests, including 257-lane registration with bounded explicit per-lane capacity).
- `cargo test -p wavecrate-library reconciliation::owner` — PASS (10 tests).
- `cargo check --lib` — PASS.
- `git diff --check` — PASS.
- `cargo test --lib source_watcher` — BLOCKED by the unchanged Radiant API mismatch in `src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/tests.rs:320,329` (`WidgetInput.timestamp` missing).
- `cargo check --all-targets` — BLOCKED by the same unchanged Radiant errors.
- `bash scripts/ci.sh smoke` — BLOCKED at the Wavecrate test/bin check by the same unchanged Radiant errors; preliminary Radiant checks pass.
- `cargo fmt --all -- --check` — reports only five pre-existing unrelated diffs; changed files are formatted.

## Known limitations
The native watcher test target cannot execute until the existing Radiant `WidgetInput.timestamp` mismatch is resolved in the dependency validation environment. No real-app or DAW acceptance is claimed by this slice.

User approval is required before merge; Terra independent review must approve the corrected current PR head first.