### PR TITLE
Admit native watcher captures through the reconciliation owner

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -140,6 +140,7 @@ pub struct SourceWriteBatch<'conn> {
     identities_revision_dirty: bool,
     index_revision_dirty: bool,
     manifest_touched_paths: BTreeSet<PathBuf>,
+    manifest_audit_completed: bool,
     telemetry_label: &'static str,
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/write/database.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/database.rs
@@ -178,6 +178,7 @@ impl SourceDatabase {
             identities_revision_dirty: false,
             index_revision_dirty: false,
             manifest_touched_paths: std::collections::BTreeSet::new(),
+            manifest_audit_completed: false,
             telemetry_label: self.telemetry_label,
         })
     }

--- a/crates/wavecrate-library/src/sample_sources/db/write/manifest_audit.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/manifest_audit.rs
@@ -168,6 +168,7 @@ impl SourceWriteBatch<'_> {
                 params![1],
             )
             .map_err(map_sql_error)?;
+        self.manifest_audit_completed = true;
         Ok(())
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -7,6 +7,7 @@ use super::super::{
     META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError, SourceManifestEntry,
     SourceTraversalPolicy, SourceWriteBatch,
 };
+use crate::sample_sources::reconciliation::{RootIdentity, SourceAuditCommit, SourceAuditRequest};
 
 /// Manifest state published by a committed source-database write batch.
 pub struct ManifestCommitResult {
@@ -121,6 +122,34 @@ impl SourceWriteBatch<'_> {
             self.telemetry_label,
         );
         Ok(snapshot)
+    }
+
+    /// Commit complete manifest-audit coverage and return its opaque source-audit authority.
+    ///
+    /// The authority exists only when [`SourceWriteBatch::complete_manifest_audit`] was applied
+    /// to this same transaction. Callers must revalidate their held source-root capability before
+    /// invoking this method; the returned token is the only input accepted by the receipt boundary
+    /// for a clearing source-audit acknowledgement.
+    pub fn commit_with_manifest_snapshot_and_audit(
+        self,
+        committed_root_identity: RootIdentity,
+        audit_request: Option<&SourceAuditRequest>,
+    ) -> Result<(SourceAuditCommit, Vec<SourceManifestEntry>), SourceDbError> {
+        if !self.manifest_audit_completed {
+            return Err(SourceDbError::Unexpected);
+        }
+        self.prepare_commit()?;
+        let (revision, snapshot) = manifest_snapshot(&self.tx)?;
+        self.tx.commit().map_err(map_sql_error)?;
+        crate::sqlite_wal::maybe_checkpoint_database_file(
+            &self.db_path,
+            "source_db",
+            self.telemetry_label,
+        );
+        Ok((
+            SourceAuditCommit::new(revision, committed_root_identity, audit_request.cloned()),
+            snapshot,
+        ))
     }
 
     /// Commit the batch and return its exact revision plus manifest state owned by that revision.

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/adapter.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/adapter.rs
@@ -215,13 +215,19 @@ impl LiveAuditCorrelation {
 pub struct LiveAuditAdmission {
     admission: AdapterAdmission,
     correlation: Option<LiveAuditCorrelation>,
+    audit_request: Option<SourceAuditRequest>,
 }
 
 impl LiveAuditAdmission {
-    fn new(admission: AdapterAdmission, correlation: Option<LiveAuditCorrelation>) -> Self {
+    fn new(
+        admission: AdapterAdmission,
+        correlation: Option<LiveAuditCorrelation>,
+        audit_request: Option<SourceAuditRequest>,
+    ) -> Self {
         Self {
             admission,
             correlation,
+            audit_request,
         }
     }
 
@@ -235,6 +241,11 @@ impl LiveAuditAdmission {
         self.correlation.as_ref()
     }
 
+    /// Borrow the retained source-audit request, including marker-only emergency retention.
+    pub const fn audit_request(&self) -> Option<&SourceAuditRequest> {
+        self.audit_request.as_ref()
+    }
+
     /// Consume the wrapper and return the existing adapter admission.
     pub fn into_admission(self) -> AdapterAdmission {
         self.admission
@@ -243,6 +254,11 @@ impl LiveAuditAdmission {
     /// Consume the wrapper and return the optional live-audit correlation.
     pub fn into_correlation(self) -> Option<LiveAuditCorrelation> {
         self.correlation
+    }
+
+    /// Consume the wrapper and return the optional retained source-audit request.
+    pub fn into_audit_request(self) -> Option<SourceAuditRequest> {
+        self.audit_request
     }
 }
 
@@ -351,37 +367,38 @@ impl<'a> ReconciliationAdapter<'a> {
         batch: SyntheticObservationBatch,
     ) -> Result<LiveAuditAdmission, AdapterError> {
         let provenance = batch.provenance().clone();
-        let uncertainty_start = self.supervisor.uncertainties().len();
         let admission = self.admit_live(batch)?;
-        let correlation = match admission.outcome() {
-            AdmissionOutcome::Accepted(ticket) => self
+        let audit_request = match admission.outcome() {
+            AdmissionOutcome::Accepted(_) | AdmissionOutcome::Rejected(_) => {
+                self.supervisor.source_audit_request_for_source(
+                    provenance.source_id(),
+                    UncertaintyReason::LiveUnproven,
+                )
+            }
+            AdmissionOutcome::DuplicateSuppressed(_) => None,
+            AdmissionOutcome::UncertaintyCapacityExhausted(_) => self
                 .supervisor
-                .uncertainties()
-                .get(uncertainty_start..)
-                .and_then(|markers| {
-                    markers.iter().find(|marker| {
-                        marker.source_id() == Some(provenance.source_id())
-                            && marker.root_identity() == provenance.root_identity()
-                            && marker.generation() == Some(provenance.watcher_generation())
-                            && marker.reasons().contains(&UncertaintyReason::LiveUnproven)
-                    })
-                })
-                .and_then(|marker| {
-                    provenance.root_identity().map(|root_identity| {
-                        LiveAuditCorrelation::new(
-                            *ticket,
-                            ReconciliationAcknowledgementIdentity::new(
-                                provenance.source_id().clone(),
-                                root_identity.clone(),
-                                provenance.watcher_generation(),
-                            ),
-                            marker.boundary(),
-                        )
-                    })
-                }),
+                .source_audit_request_for_current_lane(provenance.source_id()),
+        };
+        let correlation = match admission.outcome() {
+            AdmissionOutcome::Accepted(ticket) => audit_request.as_ref().map(|request| {
+                LiveAuditCorrelation::new(
+                    *ticket,
+                    ReconciliationAcknowledgementIdentity::new(
+                        request.source_id().clone(),
+                        request.root_identity().clone(),
+                        request.generation(),
+                    ),
+                    request.boundary(),
+                )
+            }),
             _ => None,
         };
-        Ok(LiveAuditAdmission::new(admission, correlation))
+        Ok(LiveAuditAdmission::new(
+            admission,
+            correlation,
+            audit_request,
+        ))
     }
 
     /// Admit replay after validating its identity and contiguous capture claim.

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/adapter.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/adapter.rs
@@ -11,7 +11,8 @@ use crate::sample_sources::SourceId;
 
 use super::admission::{
     AdmissionOutcome, DispatchTicket, ReconciliationAcknowledgementIdentity,
-    ReconciliationAdmissionSupervisor, RetainedUncertaintyBoundary, UncertaintyReason,
+    ReconciliationAdmissionSupervisor, RetainedUncertaintyBoundary, SourceAuditRequest,
+    UncertaintyReason,
 };
 use super::model::{
     BackendStreamIdentity, CaptureSequenceEvidence, CaptureSequenceRange,
@@ -201,6 +202,11 @@ impl LiveAuditCorrelation {
     /// Return the retained source-audit watermark boundary.
     pub const fn boundary(&self) -> RetainedUncertaintyBoundary {
         self.boundary
+    }
+
+    /// Build the source-scoped authoritative manifest-audit request for this live handoff.
+    pub fn audit_request(&self) -> SourceAuditRequest {
+        SourceAuditRequest::new(self.identity.clone(), self.boundary)
     }
 }
 

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
@@ -67,7 +67,15 @@ pub struct ReconciliationAdmissionLimits {
     capacity_mode: InFlightCapacityMode,
     max_recent_sequences_per_lane: usize,
     max_retained_uncertainties: usize,
+    max_emergency_uncertainties: usize,
 }
+
+/// Fixed upper bound for emergency uncertainty slots derived from the configured lane bound.
+///
+/// Ordinary retained markers remain the primary bounded store. Emergency slots exist only to
+/// preserve source-bound audit evidence when that store is full; same-lane evidence is coalesced
+/// before a new emergency slot is consumed.
+const MAX_EMERGENCY_UNCERTAINTIES: usize = 64;
 
 impl ReconciliationAdmissionLimits {
     /// Construct limits for a supervisor.
@@ -163,6 +171,7 @@ impl ReconciliationAdmissionLimits {
             capacity_mode,
             max_recent_sequences_per_lane,
             max_retained_uncertainties,
+            max_emergency_uncertainties: max_lanes.min(MAX_EMERGENCY_UNCERTAINTIES),
         })
     }
 
@@ -194,6 +203,11 @@ impl ReconciliationAdmissionLimits {
     /// Return the global retained-uncertainty capacity.
     pub const fn max_retained_uncertainties(self) -> usize {
         self.max_retained_uncertainties
+    }
+
+    /// Return the bounded emergency uncertainty capacity.
+    pub const fn max_emergency_uncertainties(self) -> usize {
+        self.max_emergency_uncertainties
     }
 }
 
@@ -409,32 +423,79 @@ impl SourceAuditRequest {
         self.identity.generation()
     }
 
-    /// Build a complete receipt from a committed source audit.
-    pub fn complete(
+    /// Build a complete receipt from an opaque committed source-audit authority.
+    ///
+    /// The authority is produced by the source-processing scanner only after it has held and
+    /// revalidated its source-root capability and committed complete manifest coverage. A
+    /// delivered request by itself cannot mint a clearing receipt.
+    pub fn complete_from_committed_audit(
         &self,
-        committed_source_revision: u64,
-        committed_root_identity: RootIdentity,
-    ) -> SourceAuditReceipt {
-        SourceAuditReceipt::new(
-            self.clone(),
-            self.boundary,
-            self.identity.clone(),
-            Some(committed_source_revision),
-            Some(committed_root_identity),
-            true,
-        )
+        committed_audit: SourceAuditCommit,
+    ) -> Option<SourceAuditReceipt> {
+        if committed_audit.request.as_ref() != Some(self)
+            || committed_audit.committed_source_revision == 0
+            || committed_audit.committed_root_identity != *self.root_identity()
+        {
+            return None;
+        }
+        Some(SourceAuditReceipt {
+            request: self.clone(),
+            covered_boundary: self.boundary,
+            committed_identity: self.identity.clone(),
+            committed_source_revision: Some(committed_audit.committed_source_revision),
+            committed_root_identity: Some(committed_audit.committed_root_identity),
+            complete: true,
+        })
     }
 
     /// Build a non-clearing receipt for an audit that did not complete authoritatively.
     pub fn incomplete(&self) -> SourceAuditReceipt {
-        SourceAuditReceipt::new(
-            self.clone(),
-            self.boundary,
-            self.identity.clone(),
-            None,
-            None,
-            false,
-        )
+        SourceAuditReceipt {
+            request: self.clone(),
+            covered_boundary: self.boundary,
+            committed_identity: self.identity.clone(),
+            committed_source_revision: None,
+            committed_root_identity: None,
+            complete: false,
+        }
+    }
+}
+
+/// Opaque authority returned by a committed, complete source-manifest audit.
+///
+/// There is deliberately no public constructor. The source database creates this value only
+/// from the transaction that records manifest-audit completion and commits the authoritative
+/// manifest revision. The scanner binds the held `SourceRootCapability` identity immediately
+/// before that commit. Public scanner calls without a live request may carry an unbound value,
+/// which cannot mint a clearing receipt.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceAuditCommit {
+    request: Option<SourceAuditRequest>,
+    committed_source_revision: u64,
+    committed_root_identity: RootIdentity,
+}
+
+impl SourceAuditCommit {
+    pub(crate) const fn new(
+        committed_source_revision: u64,
+        committed_root_identity: RootIdentity,
+        request: Option<SourceAuditRequest>,
+    ) -> Self {
+        Self {
+            request,
+            committed_source_revision,
+            committed_root_identity,
+        }
+    }
+
+    /// Return the source-manifest revision committed by the audit.
+    pub const fn committed_source_revision(&self) -> u64 {
+        self.committed_source_revision
+    }
+
+    /// Borrow the physical root identity held by the committed audit.
+    pub fn committed_root_identity(&self) -> &RootIdentity {
+        &self.committed_root_identity
     }
 }
 
@@ -454,25 +515,6 @@ pub struct SourceAuditReceipt {
 }
 
 impl SourceAuditReceipt {
-    /// Construct a typed receipt received from the source-processing owner.
-    pub fn new(
-        request: SourceAuditRequest,
-        covered_boundary: RetainedUncertaintyBoundary,
-        committed_identity: ReconciliationAcknowledgementIdentity,
-        committed_source_revision: Option<u64>,
-        committed_root_identity: Option<RootIdentity>,
-        complete: bool,
-    ) -> Self {
-        Self {
-            request,
-            covered_boundary,
-            committed_identity,
-            committed_source_revision,
-            committed_root_identity,
-            complete,
-        }
-    }
-
     /// Borrow the request whose retained uncertainty this receipt claims to cover.
     pub const fn request(&self) -> &SourceAuditRequest {
         &self.request
@@ -509,7 +551,9 @@ impl SourceAuditReceipt {
         if !self.complete
             || self.covered_boundary != self.request.boundary
             || self.committed_identity != self.request.identity
-            || self.committed_source_revision.is_none()
+            || self
+                .committed_source_revision
+                .is_none_or(|revision| revision == 0)
             || self.committed_root_identity.as_ref()
                 != Some(self.committed_identity.root_identity())
         {
@@ -594,10 +638,12 @@ pub struct RetainedUncertainty {
     source_id: Option<SourceId>,
     root_identity: Option<RootIdentity>,
     generation: Option<WatcherGeneration>,
+    backend_stream_identity: Option<BackendStreamIdentity>,
     capture_boundary: Option<CaptureBoundary>,
     retained_boundary: RetainedUncertaintyBoundary,
     scope: ReconciliationScopeKind,
     reasons: Vec<UncertaintyReason>,
+    emergency: bool,
 }
 
 impl RetainedUncertainty {
@@ -614,6 +660,11 @@ impl RetainedUncertainty {
     /// Return the generation when all retained evidence belongs to one generation.
     pub const fn generation(&self) -> Option<WatcherGeneration> {
         self.generation
+    }
+
+    /// Borrow the backend stream identity when it remains unambiguous.
+    pub fn backend_stream_identity(&self) -> Option<&BackendStreamIdentity> {
+        self.backend_stream_identity.as_ref()
     }
 
     /// Return the original capture boundary, if it is known.
@@ -639,6 +690,11 @@ impl RetainedUncertainty {
     /// Borrow the bounded, ordered reasons retained by this marker.
     pub fn reasons(&self) -> &[UncertaintyReason] {
         &self.reasons
+    }
+
+    /// Return whether this marker occupies the bounded emergency retention path.
+    pub const fn is_emergency(&self) -> bool {
+        self.emergency
     }
 }
 
@@ -880,6 +936,7 @@ pub struct ReconciliationAdmissionSupervisor {
     next_ticket: u64,
     retained_uncertainties: Vec<RetainedUncertainty>,
     next_retained_uncertainty_boundary: u64,
+    emergency_uncertainty_count: usize,
 }
 
 impl ReconciliationAdmissionSupervisor {
@@ -897,6 +954,7 @@ impl ReconciliationAdmissionSupervisor {
             next_ticket: 0,
             retained_uncertainties: Vec::new(),
             next_retained_uncertainty_boundary: 0,
+            emergency_uncertainty_count: 0,
         }
     }
 
@@ -1248,14 +1306,24 @@ impl ReconciliationAdmissionSupervisor {
             }
         };
         let has_uncertainty = !evidence_reasons.is_empty();
-        if has_uncertainty && let Err(error) = self.ensure_uncertainty_capacity(1) {
-            debug_assert!(matches!(
-                error,
-                AdmissionError::UncertaintyCapacityExhausted
-                    | AdmissionError::UncertaintyBoundaryExhausted
-            ));
-            return AdmissionOutcome::UncertaintyCapacityExhausted(Box::new(envelope));
-        }
+        let retained_marker = has_uncertainty.then(|| {
+            RetainedUncertainty::from_envelope_with_generation_and_reasons(
+                &envelope,
+                Some(current_generation),
+                evidence_reasons,
+            )
+        });
+        let use_emergency = if let Some(marker) = retained_marker.as_ref() {
+            if self.ensure_uncertainty_capacity(1).is_ok() {
+                false
+            } else if self.can_retain_marker_with_emergency(marker) {
+                true
+            } else {
+                return AdmissionOutcome::UncertaintyCapacityExhausted(Box::new(envelope));
+            }
+        } else {
+            false
+        };
         let recent_record = recent_exact_sequence_record(&envelope);
         let pending_envelope = envelope.clone();
         self.next_ticket = ticket.id();
@@ -1281,14 +1349,13 @@ impl ReconciliationAdmissionSupervisor {
         if was_empty && self.runnable_set.insert(lane.clone()) {
             self.runnable.push_back(lane);
         }
-        if has_uncertainty {
-            self.retain_marker(
-                RetainedUncertainty::from_envelope_with_generation_and_reasons(
-                    &envelope,
-                    Some(current_generation),
-                    evidence_reasons,
-                ),
-            );
+        if let Some(marker) = retained_marker {
+            if use_emergency {
+                self.retain_marker_with_emergency(marker)
+                    .expect("emergency uncertainty capacity was preflighted");
+            } else {
+                self.retain_marker(marker);
+            }
         }
         AdmissionOutcome::Accepted(ticket)
     }
@@ -1378,6 +1445,71 @@ impl ReconciliationAdmissionSupervisor {
         self.uncertainties()
     }
 
+    pub(crate) fn source_audit_request_for_source(
+        &self,
+        source_id: &SourceId,
+        reason: UncertaintyReason,
+    ) -> Option<SourceAuditRequest> {
+        let lane = self.sources.get(source_id)?;
+        let generation = self.lanes.get(lane)?.generation;
+        let root_identity = lane.root_identity();
+        self.retained_uncertainties
+            .iter()
+            .filter(|marker| {
+                marker.source_id() == Some(source_id)
+                    && marker.root_identity() == Some(root_identity)
+                    && marker.generation() == Some(generation)
+                    && marker.reasons().contains(&reason)
+            })
+            .max_by_key(|marker| marker.boundary().through())
+            .map(|marker| {
+                SourceAuditRequest::new(
+                    ReconciliationAcknowledgementIdentity::new(
+                        source_id.clone(),
+                        root_identity.clone(),
+                        generation,
+                    ),
+                    marker.boundary(),
+                )
+            })
+    }
+
+    /// Build a bounded source-audit request for the current registered lane when retained-marker
+    /// capacity could not preserve the incoming raw evidence.
+    ///
+    /// The request uses the supervisor's already-issued watermark rather than allocating another
+    /// marker. It therefore remains bounded and monotonic even when both ordinary and emergency
+    /// retention are full. Any existing marker for the lane is included from its first boundary;
+    /// a lane without a marker starts at the current watermark and still receives a full source
+    /// audit request before the raw envelope is dropped.
+    pub(crate) fn source_audit_request_for_current_lane(
+        &self,
+        source_id: &SourceId,
+    ) -> Option<SourceAuditRequest> {
+        let lane = self.sources.get(source_id)?;
+        let generation = self.lanes.get(lane)?.generation;
+        let watermark = self.next_retained_uncertainty_boundary;
+        let first = self
+            .retained_uncertainties
+            .iter()
+            .filter(|marker| {
+                marker.source_id() == Some(source_id)
+                    && marker.root_identity() == Some(lane.root_identity())
+                    && marker.generation() == Some(generation)
+            })
+            .map(|marker| marker.boundary().first())
+            .min()
+            .unwrap_or(watermark);
+        Some(SourceAuditRequest::new(
+            ReconciliationAcknowledgementIdentity::new(
+                source_id.clone(),
+                lane.root_identity().clone(),
+                generation,
+            ),
+            RetainedUncertaintyBoundary::new(first, watermark),
+        ))
+    }
+
     /// Borrow retained markers that belong to a registered lane's exact identity.
     pub fn uncertainties_for_lane(
         &self,
@@ -1401,8 +1533,17 @@ impl ReconciliationAdmissionSupervisor {
         acknowledgement: &CommittedAuthoritativeReconciliationAcknowledgement,
     ) -> ReconciliationAcknowledgementOutcome {
         let before = self.retained_uncertainties.len();
-        self.retained_uncertainties
-            .retain(|marker| !marker.is_covered_by(acknowledgement));
+        let mut cleared_emergency = 0;
+        self.retained_uncertainties.retain(|marker| {
+            let covered = marker.is_covered_by(acknowledgement);
+            if covered && marker.emergency {
+                cleared_emergency += 1;
+            }
+            !covered
+        });
+        self.emergency_uncertainty_count = self
+            .emergency_uncertainty_count
+            .saturating_sub(cleared_emergency);
         ReconciliationAcknowledgementOutcome {
             cleared_markers: before - self.retained_uncertainties.len(),
             remaining_markers: self.retained_uncertainties.len(),
@@ -1483,12 +1624,86 @@ impl ReconciliationAdmissionSupervisor {
         if next_len > self.limits.max_retained_uncertainties {
             return Err(AdmissionError::UncertaintyCapacityExhausted);
         }
+        self.ensure_uncertainty_boundary_capacity(additional)
+    }
+
+    fn ensure_uncertainty_boundary_capacity(
+        &self,
+        additional: usize,
+    ) -> Result<(), AdmissionError> {
         let additional =
             u64::try_from(additional).map_err(|_| AdmissionError::UncertaintyBoundaryExhausted)?;
         self.next_retained_uncertainty_boundary
             .checked_add(additional)
             .ok_or(AdmissionError::UncertaintyBoundaryExhausted)
             .map(|_| ())
+    }
+
+    fn same_lane_marker_index(&self, marker: &RetainedUncertainty) -> Option<usize> {
+        if marker.source_id.is_none()
+            || marker.root_identity.is_none()
+            || marker.generation.is_none()
+        {
+            return None;
+        }
+        self.retained_uncertainties.iter().position(|existing| {
+            existing.source_id == marker.source_id
+                && existing.root_identity == marker.root_identity
+                && existing.generation == marker.generation
+        })
+    }
+
+    fn can_retain_marker_with_emergency(&self, marker: &RetainedUncertainty) -> bool {
+        self.ensure_uncertainty_boundary_capacity(1).is_ok()
+            && (self.same_lane_marker_index(marker).is_some()
+                || (marker.source_id.is_some()
+                    && marker.root_identity.is_some()
+                    && marker.generation.is_some()
+                    && self.emergency_uncertainty_count < self.limits.max_emergency_uncertainties))
+    }
+
+    fn retain_marker_with_emergency(
+        &mut self,
+        mut marker: RetainedUncertainty,
+    ) -> Result<(), AdmissionError> {
+        self.ensure_uncertainty_boundary_capacity(1)?;
+        if let Some(index) = self.same_lane_marker_index(&marker) {
+            let next = self
+                .next_retained_uncertainty_boundary
+                .checked_add(1)
+                .ok_or(AdmissionError::UncertaintyBoundaryExhausted)?;
+            self.next_retained_uncertainty_boundary = next;
+            let existing = &mut self.retained_uncertainties[index];
+            existing.retained_boundary =
+                RetainedUncertaintyBoundary::new(existing.retained_boundary.first(), next);
+            if existing.capture_boundary != marker.capture_boundary {
+                existing.capture_boundary = None;
+            }
+            if existing.backend_stream_identity != marker.backend_stream_identity {
+                existing.backend_stream_identity = None;
+            }
+            existing.reasons.append(&mut marker.reasons);
+            existing.reasons.sort_unstable();
+            existing.reasons.dedup();
+            return Ok(());
+        }
+        if marker.source_id.is_none()
+            || marker.root_identity.is_none()
+            || marker.generation.is_none()
+            || self.emergency_uncertainty_count >= self.limits.max_emergency_uncertainties
+        {
+            return Err(AdmissionError::UncertaintyCapacityExhausted);
+        }
+        let next = self
+            .next_retained_uncertainty_boundary
+            .checked_add(1)
+            .ok_or(AdmissionError::UncertaintyBoundaryExhausted)?;
+        self.next_retained_uncertainty_boundary = next;
+        marker.retained_boundary = RetainedUncertaintyBoundary::new(next, next);
+        marker.emergency = true;
+        self.retained_uncertainties.push(marker);
+        self.emergency_uncertainty_count += 1;
+        Ok(())
     }
 
     fn release_usage(&mut self, lane: &AdmissionLaneKey, usage: Usage) {
@@ -1539,7 +1754,20 @@ impl ReconciliationAdmissionSupervisor {
             .expect("retained uncertainty capacity was preflighted");
         self.next_retained_uncertainty_boundary = next;
         marker.retained_boundary = RetainedUncertaintyBoundary::new(next, next);
+        marker.emergency = false;
         self.retained_uncertainties.push(marker);
+    }
+
+    fn retain_marker_with_fallback(
+        &mut self,
+        marker: RetainedUncertainty,
+    ) -> Result<(), AdmissionError> {
+        if self.ensure_uncertainty_capacity(1).is_ok() {
+            self.retain_marker(marker);
+            Ok(())
+        } else {
+            self.retain_marker_with_emergency(marker)
+        }
     }
 
     fn reject_with_marker(
@@ -1605,7 +1833,7 @@ impl ReconciliationAdmissionSupervisor {
             root_identity,
             reasons,
         );
-        if let Err(error) = self.ensure_uncertainty_capacity(1) {
+        if let Err(error) = self.retain_marker_with_fallback(marker) {
             debug_assert!(matches!(
                 error,
                 AdmissionError::UncertaintyCapacityExhausted
@@ -1613,7 +1841,6 @@ impl ReconciliationAdmissionSupervisor {
             ));
             return AdmissionOutcome::UncertaintyCapacityExhausted(Box::new(envelope));
         }
-        self.retain_marker(marker);
         AdmissionOutcome::Rejected(reject_reason)
     }
 
@@ -1642,13 +1869,21 @@ impl RetainedUncertainty {
         boundary: Option<CaptureBoundary>,
         reason: UncertaintyReason,
     ) -> Self {
-        Self::with_reasons(source_id, root_identity, generation, boundary, vec![reason])
+        Self::with_reasons(
+            source_id,
+            root_identity,
+            generation,
+            None,
+            boundary,
+            vec![reason],
+        )
     }
 
     fn with_reasons(
         source_id: Option<SourceId>,
         root_identity: Option<RootIdentity>,
         generation: Option<WatcherGeneration>,
+        backend_stream_identity: Option<BackendStreamIdentity>,
         boundary: Option<CaptureBoundary>,
         mut reasons: Vec<UncertaintyReason>,
     ) -> Self {
@@ -1659,10 +1894,12 @@ impl RetainedUncertainty {
             source_id,
             root_identity,
             generation,
+            backend_stream_identity,
             capture_boundary: boundary,
             retained_boundary: RetainedUncertaintyBoundary::new(0, 0),
             scope: ReconciliationScopeKind::SourceAudit,
             reasons,
+            emergency: false,
         }
     }
 
@@ -1671,12 +1908,13 @@ impl RetainedUncertainty {
         generation: Option<WatcherGeneration>,
         reason: UncertaintyReason,
     ) -> Self {
-        Self::new(
+        Self::with_reasons(
             Some(envelope.provenance().source_id().clone()),
             envelope.provenance().root_identity().cloned(),
             generation,
+            envelope.provenance().backend_stream_identity().cloned(),
             Some(envelope.provenance().capture_boundary()),
-            reason,
+            vec![reason],
         )
     }
 
@@ -1705,6 +1943,7 @@ impl RetainedUncertainty {
             source_id,
             root_identity,
             generation,
+            envelope.provenance().backend_stream_identity().cloned(),
             Some(envelope.provenance().capture_boundary()),
             reasons,
         )
@@ -3225,10 +3464,10 @@ mod tests {
     }
 
     #[test]
-    fn uncertainty_capacity_returns_envelope_and_control_error_without_mutation() {
+    fn full_retention_coalesces_same_lane_without_dropping_new_uncertainty() {
         let source = SourceId::from_string("source-a");
         let root = RootIdentity::from_bytes(b"root-a".to_vec());
-        let mut supervisor = ReconciliationAdmissionSupervisor::new(limits_with(1, 8, 2, 8, 1));
+        let mut supervisor = ReconciliationAdmissionSupervisor::new(limits_with(1, 8, 1, 8, 1));
         let (lane, generation) = registered(&mut supervisor, &source, &root);
         let first_marker =
             envelope_with_kinds(&source, &root, generation, 1, &[RawEventKind::Overflow]);
@@ -3241,12 +3480,15 @@ mod tests {
             AdmissionOutcome::Accepted(ticket) => ticket,
             outcome => panic!("unexpected outcome: {outcome:?}"),
         };
-        let markers_before = supervisor.uncertainties().to_vec();
         assert_eq!(
             supervisor.admit(first_marker.clone()),
-            AdmissionOutcome::UncertaintyCapacityExhausted(Box::new(first_marker))
+            AdmissionOutcome::Rejected(AdmissionRejectReason::UncertaintyMarkerRetained)
         );
-        assert_eq!(supervisor.uncertainties(), markers_before.as_slice());
+        assert_eq!(supervisor.uncertainties().len(), 1);
+        assert_eq!(
+            supervisor.uncertainties()[0].boundary(),
+            RetainedUncertaintyBoundary::new(1, 2)
+        );
         assert_eq!(supervisor.in_flight(), 1);
         let mixed = envelope_with_kinds(
             &source,
@@ -3256,10 +3498,14 @@ mod tests {
             &[RawEventKind::Create, RawEventKind::Overflow],
         );
         assert_eq!(
-            supervisor.admit(mixed.clone()),
-            AdmissionOutcome::UncertaintyCapacityExhausted(Box::new(mixed))
+            supervisor.admit(mixed),
+            AdmissionOutcome::Rejected(AdmissionRejectReason::QueueSaturated)
         );
-        assert_eq!(supervisor.uncertainties(), markers_before.as_slice());
+        assert_eq!(supervisor.uncertainties().len(), 1);
+        assert_eq!(
+            supervisor.uncertainties()[0].boundary(),
+            RetainedUncertaintyBoundary::new(1, 3)
+        );
         assert_eq!(supervisor.in_flight(), 1);
         assert_eq!(
             supervisor.lifecycle(&lane).expect("lifecycle"),
@@ -3269,7 +3515,7 @@ mod tests {
             supervisor.stop_lane(&lane, generation),
             Err(AdmissionError::UncertaintyCapacityExhausted)
         );
-        assert_eq!(supervisor.uncertainties(), markers_before.as_slice());
+        assert_eq!(supervisor.uncertainties().len(), 1);
         assert_eq!(supervisor.in_flight(), 1);
         assert_eq!(
             supervisor.lifecycle(&lane).expect("lifecycle"),
@@ -3300,7 +3546,7 @@ mod tests {
         supervisor
             .mark_checkpointed(ticket)
             .expect("checkpointed phase");
-        let boundary = markers_before[0].boundary();
+        let boundary = supervisor.uncertainties()[0].boundary();
         let acknowledgement = acknowledgement(
             &source,
             &root,

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
@@ -364,6 +364,165 @@ impl ReconciliationAcknowledgementIdentity {
     }
 }
 
+/// An opaque, source-scoped request boundary for one authoritative manifest audit.
+///
+/// The boundary is assigned by the admission supervisor when it retains the live uncertainty
+/// marker. It therefore orders requests without exposing a second mutable request counter.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceAuditRequest {
+    identity: ReconciliationAcknowledgementIdentity,
+    boundary: RetainedUncertaintyBoundary,
+}
+
+impl SourceAuditRequest {
+    /// Construct a request for crate-owned admission and transport tests.
+    #[allow(dead_code)]
+    pub(crate) fn new(
+        identity: ReconciliationAcknowledgementIdentity,
+        boundary: RetainedUncertaintyBoundary,
+    ) -> Self {
+        Self { identity, boundary }
+    }
+
+    /// Borrow the exact source/root/generation identity requested for audit.
+    pub const fn identity(&self) -> &ReconciliationAcknowledgementIdentity {
+        &self.identity
+    }
+
+    /// Return the monotonic retained-marker boundary covered by this request.
+    pub const fn boundary(&self) -> RetainedUncertaintyBoundary {
+        self.boundary
+    }
+
+    /// Borrow the requested source identifier.
+    pub fn source_id(&self) -> &SourceId {
+        self.identity.source_id()
+    }
+
+    /// Borrow the requested physical root identity.
+    pub fn root_identity(&self) -> &RootIdentity {
+        self.identity.root_identity()
+    }
+
+    /// Return the requested watcher generation.
+    pub const fn generation(&self) -> WatcherGeneration {
+        self.identity.generation()
+    }
+
+    /// Build a complete receipt from a committed source audit.
+    pub fn complete(
+        &self,
+        committed_source_revision: u64,
+        committed_root_identity: RootIdentity,
+    ) -> SourceAuditReceipt {
+        SourceAuditReceipt::new(
+            self.clone(),
+            self.boundary,
+            self.identity.clone(),
+            Some(committed_source_revision),
+            Some(committed_root_identity),
+            true,
+        )
+    }
+
+    /// Build a non-clearing receipt for an audit that did not complete authoritatively.
+    pub fn incomplete(&self) -> SourceAuditReceipt {
+        SourceAuditReceipt::new(
+            self.clone(),
+            self.boundary,
+            self.identity.clone(),
+            None,
+            None,
+            false,
+        )
+    }
+}
+
+/// Typed result of a source manifest audit associated with one audit request.
+///
+/// The watcher admission owner converts a receipt into the existing committed-authoritative
+/// acknowledgement only when every request, boundary, identity, completion, revision, and root
+/// field matches. A receipt is transport evidence, not authority by itself.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceAuditReceipt {
+    request: SourceAuditRequest,
+    covered_boundary: RetainedUncertaintyBoundary,
+    committed_identity: ReconciliationAcknowledgementIdentity,
+    committed_source_revision: Option<u64>,
+    committed_root_identity: Option<RootIdentity>,
+    complete: bool,
+}
+
+impl SourceAuditReceipt {
+    /// Construct a typed receipt received from the source-processing owner.
+    pub fn new(
+        request: SourceAuditRequest,
+        covered_boundary: RetainedUncertaintyBoundary,
+        committed_identity: ReconciliationAcknowledgementIdentity,
+        committed_source_revision: Option<u64>,
+        committed_root_identity: Option<RootIdentity>,
+        complete: bool,
+    ) -> Self {
+        Self {
+            request,
+            covered_boundary,
+            committed_identity,
+            committed_source_revision,
+            committed_root_identity,
+            complete,
+        }
+    }
+
+    /// Borrow the request whose retained uncertainty this receipt claims to cover.
+    pub const fn request(&self) -> &SourceAuditRequest {
+        &self.request
+    }
+
+    /// Return the request boundary claimed by the committed audit.
+    pub const fn covered_boundary(&self) -> RetainedUncertaintyBoundary {
+        self.covered_boundary
+    }
+
+    /// Borrow the identity observed by the committed audit.
+    pub const fn committed_identity(&self) -> &ReconciliationAcknowledgementIdentity {
+        &self.committed_identity
+    }
+
+    /// Return the committed source revision, when the audit supplied one.
+    pub const fn committed_source_revision(&self) -> Option<u64> {
+        self.committed_source_revision
+    }
+
+    /// Borrow the physical root identity held by the audit, when available.
+    pub fn committed_root_identity(&self) -> Option<&RootIdentity> {
+        self.committed_root_identity.as_ref()
+    }
+
+    /// Return whether the source audit completed authoritatively.
+    pub const fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    pub(crate) fn authoritative_acknowledgement(
+        &self,
+    ) -> Option<CommittedAuthoritativeReconciliationAcknowledgement> {
+        if !self.complete
+            || self.covered_boundary != self.request.boundary
+            || self.committed_identity != self.request.identity
+            || self.committed_source_revision.is_none()
+            || self.committed_root_identity.as_ref()
+                != Some(self.committed_identity.root_identity())
+        {
+            return None;
+        }
+        Some(CommittedAuthoritativeReconciliationAcknowledgement::new(
+            self.committed_identity.clone(),
+            ReconciliationScopeKind::SourceAudit,
+            self.covered_boundary,
+        ))
+    }
+}
+
 /// A committed authoritative reconciliation acknowledgement.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CommittedAuthoritativeReconciliationAcknowledgement {
@@ -411,6 +570,13 @@ pub struct ReconciliationAcknowledgementOutcome {
 }
 
 impl ReconciliationAcknowledgementOutcome {
+    pub(crate) const fn unchanged(remaining_markers: usize) -> Self {
+        Self {
+            cleared_markers: 0,
+            remaining_markers,
+        }
+    }
+
     /// Return the number of markers cleared by the acknowledgement.
     pub const fn cleared_markers(self) -> usize {
         self.cleared_markers

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/admission.rs
@@ -408,6 +408,23 @@ impl SourceAuditRequest {
         self.boundary
     }
 
+    /// Cover two requests for the same source/root/generation identity.
+    ///
+    /// Requests with different identities must remain separate so a later committed audit cannot
+    /// accidentally clear uncertainty from another root or lifecycle generation.
+    pub fn covering(&self, other: &Self) -> Option<Self> {
+        if self.identity() != other.identity() {
+            return None;
+        }
+        Some(Self::new(
+            self.identity.clone(),
+            RetainedUncertaintyBoundary::new(
+                self.boundary.first().min(other.boundary.first()),
+                self.boundary.through().max(other.boundary.through()),
+            ),
+        ))
+    }
+
     /// Borrow the requested source identifier.
     pub fn source_id(&self) -> &SourceId {
         self.identity.source_id()
@@ -2123,6 +2140,30 @@ mod tests {
             scope,
             RetainedUncertaintyBoundary::new(first, through),
         )
+    }
+
+    #[test]
+    fn source_audit_requests_cover_same_identity_only() {
+        let identity = ReconciliationAcknowledgementIdentity::new(
+            SourceId::from_string("source-a"),
+            RootIdentity::from_bytes(b"root-a".to_vec()),
+            WatcherGeneration::new(7),
+        );
+        let first =
+            SourceAuditRequest::new(identity.clone(), RetainedUncertaintyBoundary::new(10, 20));
+        let second = SourceAuditRequest::new(identity, RetainedUncertaintyBoundary::new(5, 30));
+
+        let covered = first.covering(&second).expect("matching request identity");
+        assert_eq!(covered.boundary(), RetainedUncertaintyBoundary::new(5, 30));
+
+        let different_identity = ReconciliationAcknowledgementIdentity::new(
+            SourceId::from_string("source-b"),
+            RootIdentity::from_bytes(b"root-b".to_vec()),
+            WatcherGeneration::new(8),
+        );
+        let different =
+            SourceAuditRequest::new(different_identity, RetainedUncertaintyBoundary::new(5, 30));
+        assert_eq!(first.covering(&different), None);
     }
 
     fn marker_bearing_envelope(

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
@@ -19,7 +19,8 @@ pub use admission::{
     DispatchedObservation, ReconciliationAcknowledgementIdentity,
     ReconciliationAcknowledgementOutcome, ReconciliationAdmissionLimits,
     ReconciliationAdmissionSupervisor, ReconciliationLifecycle, RetainedUncertainty,
-    RetainedUncertaintyBoundary, SourceAuditReceipt, SourceAuditRequest, UncertaintyReason,
+    RetainedUncertaintyBoundary, SourceAuditCommit, SourceAuditReceipt, SourceAuditRequest,
+    UncertaintyReason,
 };
 pub use model::{
     BackendStreamIdentity, CaptureBoundary, CaptureSequenceEvidence, CaptureSequenceRange,

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
@@ -19,7 +19,7 @@ pub use admission::{
     DispatchedObservation, ReconciliationAcknowledgementIdentity,
     ReconciliationAcknowledgementOutcome, ReconciliationAdmissionLimits,
     ReconciliationAdmissionSupervisor, ReconciliationLifecycle, RetainedUncertainty,
-    RetainedUncertaintyBoundary, UncertaintyReason,
+    RetainedUncertaintyBoundary, SourceAuditReceipt, SourceAuditRequest, UncertaintyReason,
 };
 pub use model::{
     BackendStreamIdentity, CaptureBoundary, CaptureSequenceEvidence, CaptureSequenceRange,

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/model.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/model.rs
@@ -541,6 +541,8 @@ pub struct RawObservationMetadata {
     event_id: Option<u64>,
     cursor: Option<Vec<u8>>,
     detail: Option<OsString>,
+    source: Option<OsString>,
+    process_id: Option<u32>,
 }
 
 impl RawObservationMetadata {
@@ -579,6 +581,18 @@ impl RawObservationMetadata {
         self
     }
 
+    /// Retain the backend source identifier.
+    pub fn with_source(mut self, source: OsString) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    /// Retain the origin process identifier.
+    pub fn with_process_id(mut self, process_id: u32) -> Self {
+        self.process_id = Some(process_id);
+        self
+    }
+
     /// Return backend flags, with zero meaning no flags were retained.
     pub const fn flags(&self) -> u64 {
         self.flags
@@ -604,6 +618,16 @@ impl RawObservationMetadata {
         self.detail.as_deref()
     }
 
+    /// Borrow the backend source identifier.
+    pub fn source(&self) -> Option<&OsStr> {
+        self.source.as_deref()
+    }
+
+    /// Return the origin process identifier.
+    pub const fn process_id(&self) -> Option<u32> {
+        self.process_id
+    }
+
     fn encoded_metadata_bytes(&self) -> Result<usize, RawEnvelopeError> {
         let flags_bytes = if self.flags == 0 {
             0
@@ -625,12 +649,23 @@ impl RawObservationMetadata {
             .detail
             .as_ref()
             .map_or(0, |detail| detail.as_os_str().as_encoded_bytes().len());
+        let source_bytes = self
+            .source
+            .as_ref()
+            .map_or(0, |source| source.as_os_str().as_encoded_bytes().len());
+        let process_id_bytes = if self.process_id.is_some() {
+            std::mem::size_of::<u32>()
+        } else {
+            0
+        };
 
         flags_bytes
             .checked_add(rename_cookie_bytes)
             .and_then(|value| value.checked_add(event_id_bytes))
             .and_then(|value| value.checked_add(cursor_bytes))
             .and_then(|value| value.checked_add(detail_bytes))
+            .and_then(|value| value.checked_add(source_bytes))
+            .and_then(|value| value.checked_add(process_id_bytes))
             .ok_or(RawEnvelopeError::ArithmeticOverflow {
                 counter: RawEnvelopeCounter::MetadataBytes,
             })

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
@@ -5,7 +5,8 @@ use super::adapter::{
 };
 use super::admission::{
     AdmissionError, AdmissionLaneKey, DispatchTicket, DispatchedObservation,
-    ReconciliationAdmissionSupervisor, ReconciliationLifecycle,
+    ReconciliationAcknowledgementOutcome, ReconciliationAdmissionSupervisor,
+    ReconciliationLifecycle, SourceAuditReceipt,
 };
 use super::model::{RootIdentity, WatcherGeneration};
 use crate::sample_sources::SourceId;
@@ -142,6 +143,42 @@ impl ReconciliationAdmissionOwner {
         self.supervisor.mark_unproven_audit_handed_off(ticket)
     }
 
+    /// Apply a complete source-audit receipt only while its lane identity is still active.
+    ///
+    /// This is the only native-owner entry point for the existing typed acknowledgement model.
+    /// Stopped lanes and replaced roots/generations reject old receipts without clearing anything.
+    pub fn acknowledge_source_audit_receipt(
+        &mut self,
+        receipt: &SourceAuditReceipt,
+    ) -> ReconciliationAcknowledgementOutcome {
+        let Some(acknowledgement) = receipt.authoritative_acknowledgement() else {
+            return ReconciliationAcknowledgementOutcome::unchanged(
+                self.supervisor.retained_uncertainties().len(),
+            );
+        };
+        let Some(lane) = self
+            .supervisor
+            .lane_for_source(acknowledgement.identity().source_id())
+            .cloned()
+        else {
+            return ReconciliationAcknowledgementOutcome::unchanged(
+                self.supervisor.retained_uncertainties().len(),
+            );
+        };
+        let lane_generation = self.supervisor.generation(&lane).ok();
+        let lane_lifecycle = self.supervisor.lifecycle(&lane).ok();
+        if lane.root_identity() != acknowledgement.identity().root_identity()
+            || lane_generation != Some(acknowledgement.identity().generation())
+            || lane_lifecycle != Some(ReconciliationLifecycle::Capturing)
+        {
+            return ReconciliationAcknowledgementOutcome::unchanged(
+                self.supervisor.retained_uncertainties().len(),
+            );
+        }
+        self.supervisor
+            .acknowledge_committed_authoritative_reconciliation(&acknowledgement)
+    }
+
     /// Return the bounded number of live envelopes the owner can retain.
     pub fn max_in_flight(&self) -> usize {
         self.supervisor.limits().max_in_flight()
@@ -264,7 +301,9 @@ mod tests {
     use crate::sample_sources::reconciliation::{
         AdmissionOutcome, BackendStreamIdentity, CaptureBoundary, RawEventKind, RawObservation,
         RawObservationEnvelope, RawObservationLimits, RawObservationProvenance, RawObservedPath,
-        RawPathRole, ReconciliationAdmissionLimits, SyntheticObservationBatch, UncertaintyReason,
+        RawPathRole, ReconciliationAcknowledgementIdentity, ReconciliationAdmissionLimits,
+        RetainedUncertaintyBoundary, SourceAuditRequest, SyntheticObservationBatch,
+        UncertaintyReason,
     };
 
     fn root(value: &[u8]) -> RootIdentity {
@@ -324,6 +363,31 @@ mod tests {
             RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("envelope limits"),
         )
         .expect("envelope")
+    }
+
+    fn live_batch(
+        source: &SourceId,
+        root_identity: &RootIdentity,
+        generation: WatcherGeneration,
+        captured_at: u64,
+    ) -> SyntheticObservationBatch {
+        SyntheticObservationBatch::new(
+            RawObservationProvenance::new(
+                source.clone(),
+                Some(root_identity.clone()),
+                Some(BackendStreamIdentity::from_bytes(b"stream".to_vec())),
+                generation,
+                CaptureBoundary::try_new(captured_at, None, None).expect("capture boundary"),
+            ),
+            vec![RawObservation::new(
+                RawEventKind::Create,
+                vec![RawObservedPath::new(
+                    "sample.wav".into(),
+                    RawPathRole::Subject,
+                )],
+            )],
+            RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("batch limits"),
+        )
     }
 
     #[test]
@@ -409,6 +473,140 @@ mod tests {
         assert_eq!(marker.generation(), Some(lane.generation()));
         assert_eq!(marker.capture_boundary(), Some(boundary));
         assert!(marker.reasons().contains(&UncertaintyReason::LiveUnproven));
+    }
+
+    #[test]
+    fn source_audit_receipts_require_complete_matching_identity_and_boundary() {
+        let source = SourceId::from_string("receipt-source");
+        let root_identity = root(b"receipt-root");
+        let mut owner = owner(1, 1, 8);
+        let lane = owner
+            .begin_source(source.clone(), root_identity.clone())
+            .expect("capturing lane");
+        let live = owner
+            .admit_live_with_correlation(live_batch(&source, &root_identity, lane.generation(), 11))
+            .expect("live admission");
+        let ticket = match live.admission().outcome() {
+            AdmissionOutcome::Accepted(ticket) => *ticket,
+            outcome => panic!("expected accepted live admission, got {outcome:?}"),
+        };
+        let request = live
+            .correlation()
+            .expect("live audit request correlation")
+            .audit_request();
+        owner.dispatch_next().expect("dispatch live admission");
+        owner.mark_dispatched(ticket).expect("mark dispatched");
+        owner.mark_applied(ticket).expect("mark applied");
+        owner
+            .mark_unproven_audit_handed_off(ticket)
+            .expect("handoff proofless live admission");
+
+        let incomplete = request.incomplete();
+        assert_eq!(
+            owner.acknowledge_source_audit_receipt(&incomplete),
+            ReconciliationAcknowledgementOutcome::unchanged(1)
+        );
+        let insufficient_boundary = SourceAuditReceipt::new(
+            request.clone(),
+            RetainedUncertaintyBoundary::new(0, 0),
+            ReconciliationAcknowledgementIdentity::new(
+                source.clone(),
+                root_identity.clone(),
+                lane.generation(),
+            ),
+            Some(12),
+            Some(root_identity.clone()),
+            true,
+        );
+        assert_eq!(
+            owner.acknowledge_source_audit_receipt(&insufficient_boundary),
+            ReconciliationAcknowledgementOutcome::unchanged(1)
+        );
+        let wrong_identity = SourceAuditReceipt::new(
+            request.clone(),
+            request.boundary(),
+            ReconciliationAcknowledgementIdentity::new(
+                SourceId::from_string("wrong-source"),
+                root_identity.clone(),
+                lane.generation(),
+            ),
+            Some(12),
+            Some(root_identity.clone()),
+            true,
+        );
+        assert_eq!(
+            owner.acknowledge_source_audit_receipt(&wrong_identity),
+            ReconciliationAcknowledgementOutcome::unchanged(1)
+        );
+
+        let complete = request.complete(12, root_identity);
+        let acknowledgement = owner.acknowledge_source_audit_receipt(&complete);
+        assert_eq!(acknowledgement.cleared_markers(), 1);
+        assert_eq!(acknowledgement.remaining_markers(), 0);
+        assert_eq!(
+            owner.acknowledge_source_audit_receipt(&complete),
+            ReconciliationAcknowledgementOutcome::unchanged(0),
+            "duplicate receipt must be idempotent"
+        );
+    }
+
+    #[test]
+    fn audit_receipt_before_capture_and_after_root_rebind_clears_nothing() {
+        let source = SourceId::from_string("receipt-fence");
+        let old_root = root(b"old-root");
+        let new_root = root(b"new-root");
+        let mut owner = owner(1, 1, 8);
+        let pre_capture_request = SourceAuditRequest::new(
+            ReconciliationAcknowledgementIdentity::new(
+                source.clone(),
+                old_root.clone(),
+                WatcherGeneration::new(1),
+            ),
+            RetainedUncertaintyBoundary::new(1, 1),
+        );
+        let pre_capture_receipt = pre_capture_request.complete(1, old_root.clone());
+        assert_eq!(
+            owner.acknowledge_source_audit_receipt(&pre_capture_receipt),
+            ReconciliationAcknowledgementOutcome::unchanged(0)
+        );
+
+        let lane = owner
+            .begin_source(source.clone(), old_root.clone())
+            .expect("old capturing lane");
+        let live = owner
+            .admit_live_with_correlation(live_batch(&source, &old_root, lane.generation(), 21))
+            .expect("live admission");
+        let ticket = match live.admission().outcome() {
+            AdmissionOutcome::Accepted(ticket) => *ticket,
+            outcome => panic!("expected accepted live admission, got {outcome:?}"),
+        };
+        let receipt = live
+            .correlation()
+            .expect("live audit correlation")
+            .audit_request()
+            .complete(2, old_root.clone());
+        owner.dispatch_next().expect("dispatch live admission");
+        owner.mark_dispatched(ticket).expect("mark dispatched");
+        owner.mark_applied(ticket).expect("mark applied");
+        owner
+            .mark_unproven_audit_handed_off(ticket)
+            .expect("handoff live admission");
+
+        owner
+            .rebind_source(&source, new_root.clone())
+            .expect("rebind source root");
+        let fenced_before_restart = owner.acknowledge_source_audit_receipt(&receipt);
+        assert_eq!(fenced_before_restart.cleared_markers(), 0);
+        assert!(fenced_before_restart.remaining_markers() >= 1);
+        owner
+            .begin_source(source, new_root)
+            .expect("restart replacement lane");
+        let fenced_after_restart = owner.acknowledge_source_audit_receipt(&receipt);
+        assert_eq!(fenced_after_restart.cleared_markers(), 0);
+        assert!(
+            fenced_after_restart.remaining_markers() >= 1,
+            "old root/generation receipt must remain fenced after rebind"
+        );
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
@@ -196,6 +196,17 @@ impl ReconciliationAdmissionOwner {
         self.supervisor.limits().max_in_flight()
     }
 
+    /// Return the bounded number of exact source-audit request entries the watcher may retain.
+    ///
+    /// The request transport mirrors both ordinary and emergency retained-uncertainty capacity;
+    /// it is not an independent source-count or context limit.
+    pub fn max_source_audit_request_entries(&self) -> usize {
+        let limits = self.supervisor.limits();
+        limits
+            .max_retained_uncertainties()
+            .saturating_add(limits.max_emergency_uncertainties())
+    }
+
     /// Register and begin a source, or begin/restart its existing same-root lane.
     ///
     /// A newly registered lane is left in `Starting` if the final `begin_capture` call fails;

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
@@ -6,7 +6,7 @@ use super::adapter::{
 use super::admission::{
     AdmissionError, AdmissionLaneKey, DispatchTicket, DispatchedObservation,
     ReconciliationAcknowledgementOutcome, ReconciliationAdmissionSupervisor,
-    ReconciliationLifecycle, SourceAuditReceipt,
+    ReconciliationLifecycle, SourceAuditReceipt, SourceAuditRequest,
 };
 use super::model::{RootIdentity, WatcherGeneration};
 use crate::sample_sources::SourceId;
@@ -94,6 +94,18 @@ impl ReconciliationAdmissionOwner {
     /// Borrow the owned supervisor without exposing mutable supervisor state.
     pub fn supervisor(&self) -> &ReconciliationAdmissionSupervisor {
         &self.supervisor
+    }
+
+    /// Build the bounded source-audit request for the currently registered lane.
+    ///
+    /// The supervisor derives the request from the lane's current source/root/generation and
+    /// issued uncertainty watermark without allocating another marker or admission ticket.
+    pub fn source_audit_request_for_current_lane(
+        &self,
+        source_id: &SourceId,
+    ) -> Option<SourceAuditRequest> {
+        self.supervisor
+            .source_audit_request_for_current_lane(source_id)
     }
 
     /// Consume the owner and return its admission supervisor.

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
@@ -1,7 +1,11 @@
 //! Source-scoped ownership over the pure reconciliation admission supervisor.
 
+use super::adapter::{
+    AdapterError, LiveAuditAdmission, ReconciliationAdapter, SyntheticObservationBatch,
+};
 use super::admission::{
-    AdmissionError, AdmissionLaneKey, ReconciliationAdmissionSupervisor, ReconciliationLifecycle,
+    AdmissionError, AdmissionLaneKey, DispatchTicket, DispatchedObservation,
+    ReconciliationAdmissionSupervisor, ReconciliationLifecycle,
 };
 use super::model::{RootIdentity, WatcherGeneration};
 use crate::sample_sources::SourceId;
@@ -105,6 +109,42 @@ impl ReconciliationAdmissionOwner {
     /// Iterate over source identifiers registered in the owned supervisor.
     pub fn source_ids(&self) -> impl Iterator<Item = &SourceId> {
         self.supervisor.source_ids()
+    }
+
+    /// Admit one live batch through the owner-held adapter without replacing the supervisor.
+    pub fn admit_live_with_correlation(
+        &mut self,
+        batch: SyntheticObservationBatch,
+    ) -> Result<LiveAuditAdmission, AdapterError> {
+        ReconciliationAdapter::new(&mut self.supervisor).admit_live_with_correlation(batch)
+    }
+
+    /// Select the next admitted envelope using the supervisor's fair lane scheduler.
+    pub fn dispatch_next(&mut self) -> Option<DispatchedObservation> {
+        self.supervisor.dispatch_next()
+    }
+
+    /// Advance one dispatched envelope to the downstream handoff phase.
+    pub fn mark_dispatched(&mut self, ticket: DispatchTicket) -> Result<(), AdmissionError> {
+        self.supervisor.mark_dispatched(ticket)
+    }
+
+    /// Advance one handed-off envelope to the applied phase.
+    pub fn mark_applied(&mut self, ticket: DispatchTicket) -> Result<(), AdmissionError> {
+        self.supervisor.mark_applied(ticket)
+    }
+
+    /// Retire one proofless live envelope after its conservative audit handoff.
+    pub fn mark_unproven_audit_handed_off(
+        &mut self,
+        ticket: DispatchTicket,
+    ) -> Result<(), AdmissionError> {
+        self.supervisor.mark_unproven_audit_handed_off(ticket)
+    }
+
+    /// Return the bounded number of live envelopes the owner can retain.
+    pub fn max_in_flight(&self) -> usize {
+        self.supervisor.limits().max_in_flight()
     }
 
     /// Register and begin a source, or begin/restart its existing same-root lane.
@@ -224,7 +264,7 @@ mod tests {
     use crate::sample_sources::reconciliation::{
         AdmissionOutcome, BackendStreamIdentity, CaptureBoundary, RawEventKind, RawObservation,
         RawObservationEnvelope, RawObservationLimits, RawObservationProvenance, RawObservedPath,
-        RawPathRole, ReconciliationAdmissionLimits,
+        RawPathRole, ReconciliationAdmissionLimits, SyntheticObservationBatch, UncertaintyReason,
     };
 
     fn root(value: &[u8]) -> RootIdentity {
@@ -309,6 +349,66 @@ mod tests {
 
         let supervisor = owner.into_supervisor();
         assert_eq!(supervisor.lane_for_source(&source), Some(&lane));
+    }
+
+    #[test]
+    fn live_dispatch_seam_preserves_correlation_and_releases_only_proofless_work() {
+        let source = SourceId::from_string("live-seam");
+        let root_identity = root(b"live-root");
+        let mut owner = owner(1, 1, 8);
+        let lane = owner
+            .begin_source(source.clone(), root_identity.clone())
+            .expect("capturing lane");
+        let boundary = CaptureBoundary::try_new(4, None, None).expect("capture boundary");
+        let batch = SyntheticObservationBatch::new(
+            RawObservationProvenance::new(
+                source.clone(),
+                Some(root_identity.clone()),
+                Some(BackendStreamIdentity::from_bytes(b"live-stream".to_vec())),
+                lane.generation(),
+                boundary,
+            ),
+            vec![RawObservation::new(
+                RawEventKind::Create,
+                vec![RawObservedPath::new(
+                    "sample.wav".into(),
+                    RawPathRole::Subject,
+                )],
+            )],
+            RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("batch limits"),
+        );
+
+        let live = owner
+            .admit_live_with_correlation(batch)
+            .expect("live admission");
+        let ticket = match live.admission().outcome() {
+            AdmissionOutcome::Accepted(ticket) => *ticket,
+            outcome => panic!("expected accepted live admission, got {outcome:?}"),
+        };
+        assert_eq!(
+            live.correlation().map(|correlation| correlation.ticket()),
+            Some(ticket)
+        );
+        let dispatched = owner.dispatch_next().expect("fair dispatch");
+        assert_eq!(dispatched.ticket(), ticket);
+        assert!(dispatched.normalized().proof().is_unproven());
+        owner.mark_dispatched(ticket).expect("mark dispatched");
+        owner.mark_applied(ticket).expect("mark applied");
+        owner
+            .mark_unproven_audit_handed_off(ticket)
+            .expect("retire proofless handoff");
+
+        assert_eq!(owner.supervisor().in_flight(), 0);
+        let marker = owner
+            .supervisor()
+            .retained_uncertainties()
+            .iter()
+            .find(|marker| marker.source_id() == Some(&source))
+            .expect("retained live uncertainty");
+        assert_eq!(marker.root_identity(), Some(&root_identity));
+        assert_eq!(marker.generation(), Some(lane.generation()));
+        assert_eq!(marker.capture_boundary(), Some(boundary));
+        assert!(marker.reasons().contains(&UncertaintyReason::LiveUnproven));
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/owner.rs
@@ -299,11 +299,12 @@ impl ReconciliationAdmissionOwner {
 mod tests {
     use super::*;
     use crate::sample_sources::reconciliation::{
-        AdmissionOutcome, BackendStreamIdentity, CaptureBoundary, RawEventKind, RawObservation,
-        RawObservationEnvelope, RawObservationLimits, RawObservationProvenance, RawObservedPath,
-        RawPathRole, ReconciliationAcknowledgementIdentity, ReconciliationAdmissionLimits,
-        RetainedUncertaintyBoundary, SourceAuditRequest, SyntheticObservationBatch,
-        UncertaintyReason,
+        AdmissionOutcome, AdmissionRejectReason, BackendStreamIdentity, CaptureBoundary,
+        RawEventKind, RawObservation, RawObservationEnvelope, RawObservationLimits,
+        RawObservationProvenance, RawObservedPath, RawPathRole,
+        ReconciliationAcknowledgementIdentity, ReconciliationAdmissionLimits,
+        RetainedUncertaintyBoundary, SourceAuditCommit, SourceAuditRequest,
+        SyntheticObservationBatch, UncertaintyReason,
     };
 
     fn root(value: &[u8]) -> RootIdentity {
@@ -371,6 +372,30 @@ mod tests {
         generation: WatcherGeneration,
         captured_at: u64,
     ) -> SyntheticObservationBatch {
+        live_batch_with_kind(
+            source,
+            root_identity,
+            generation,
+            captured_at,
+            RawEventKind::Create,
+        )
+    }
+
+    fn committed_audit(
+        request: &SourceAuditRequest,
+        revision: u64,
+        root_identity: RootIdentity,
+    ) -> SourceAuditCommit {
+        SourceAuditCommit::new(revision, root_identity, Some(request.clone()))
+    }
+
+    fn live_batch_with_kind(
+        source: &SourceId,
+        root_identity: &RootIdentity,
+        generation: WatcherGeneration,
+        captured_at: u64,
+        kind: RawEventKind,
+    ) -> SyntheticObservationBatch {
         SyntheticObservationBatch::new(
             RawObservationProvenance::new(
                 source.clone(),
@@ -380,7 +405,7 @@ mod tests {
                 CaptureBoundary::try_new(captured_at, None, None).expect("capture boundary"),
             ),
             vec![RawObservation::new(
-                RawEventKind::Create,
+                kind,
                 vec![RawObservedPath::new(
                     "sample.wav".into(),
                     RawPathRole::Subject,
@@ -476,6 +501,141 @@ mod tests {
     }
 
     #[test]
+    fn full_retention_uses_bounded_emergency_marker_and_monotonic_audit_correlation() {
+        let first_source = SourceId::from_string("emergency-first");
+        let first_root = root(b"emergency-first-root");
+        let second_source = SourceId::from_string("emergency-second");
+        let second_root = root(b"emergency-second-root");
+        let mut owner = owner(2, 2, 1);
+        let first_lane = owner
+            .begin_source(first_source.clone(), first_root.clone())
+            .expect("first capturing lane");
+        let second_lane = owner
+            .begin_source(second_source.clone(), second_root.clone())
+            .expect("second capturing lane");
+
+        let first = owner
+            .admit_live_with_correlation(live_batch(
+                &first_source,
+                &first_root,
+                first_lane.generation(),
+                1,
+            ))
+            .expect("ordinary live admission");
+        let first_ticket = match first.admission().outcome() {
+            AdmissionOutcome::Accepted(ticket) => *ticket,
+            outcome => panic!("expected first accepted admission, got {outcome:?}"),
+        };
+        owner.dispatch_next().expect("dispatch first admission");
+        owner
+            .mark_dispatched(first_ticket)
+            .expect("mark first dispatched");
+        owner
+            .mark_applied(first_ticket)
+            .expect("mark first applied");
+        owner
+            .mark_unproven_audit_handed_off(first_ticket)
+            .expect("handoff first admission");
+
+        let emergency = owner
+            .admit_live_with_correlation(live_batch_with_kind(
+                &second_source,
+                &second_root,
+                second_lane.generation(),
+                2,
+                RawEventKind::Overflow,
+            ))
+            .expect("overflow admission");
+        assert!(matches!(
+            emergency.admission().outcome(),
+            AdmissionOutcome::Rejected(AdmissionRejectReason::UncertaintyMarkerRetained)
+        ));
+        assert!(emergency.correlation().is_none());
+        let emergency_request = emergency
+            .audit_request()
+            .cloned()
+            .expect("emergency source audit request");
+        let emergency_marker = owner
+            .supervisor()
+            .retained_uncertainties()
+            .iter()
+            .find(|marker| marker.source_id() == Some(&second_source))
+            .expect("emergency marker");
+        assert!(emergency_marker.is_emergency());
+        assert_eq!(emergency_marker.root_identity(), Some(&second_root));
+        assert_eq!(
+            emergency_marker.generation(),
+            Some(second_lane.generation())
+        );
+        assert_eq!(
+            emergency_marker.backend_stream_identity(),
+            Some(&BackendStreamIdentity::from_bytes(b"stream".to_vec()))
+        );
+        assert_eq!(emergency_request.identity().source_id(), &second_source);
+        assert_eq!(emergency_request.root_identity(), &second_root);
+        assert_eq!(emergency_request.generation(), second_lane.generation());
+        assert_eq!(emergency_request.boundary(), emergency_marker.boundary());
+        assert_eq!(emergency_request.boundary().first(), 2);
+        assert_eq!(emergency_request.boundary().through(), 2);
+
+        let later = owner
+            .admit_live_with_correlation(live_batch(
+                &second_source,
+                &second_root,
+                second_lane.generation(),
+                3,
+            ))
+            .expect("later capture admission");
+        let later_ticket = match later.admission().outcome() {
+            AdmissionOutcome::Accepted(ticket) => *ticket,
+            outcome => panic!("later capture must remain deferred, got {outcome:?}"),
+        };
+        let later_request = later
+            .audit_request()
+            .cloned()
+            .expect("later capture audit request");
+        assert!(later.correlation().is_some());
+        assert_eq!(later_request.boundary().first(), 2);
+        assert_eq!(later_request.boundary().through(), 3);
+        owner.dispatch_next().expect("dispatch later capture");
+        owner
+            .mark_dispatched(later_ticket)
+            .expect("mark later dispatched");
+        owner
+            .mark_applied(later_ticket)
+            .expect("mark later applied");
+        owner
+            .mark_unproven_audit_handed_off(later_ticket)
+            .expect("handoff later capture");
+
+        let premature = emergency_request
+            .complete_from_committed_audit(committed_audit(
+                &emergency_request,
+                7,
+                second_root.clone(),
+            ))
+            .expect("matching root commit token");
+        assert_eq!(
+            owner.acknowledge_source_audit_receipt(&premature),
+            ReconciliationAcknowledgementOutcome::unchanged(2),
+            "the earlier boundary cannot clear later retained evidence"
+        );
+        let committed = later_request
+            .complete_from_committed_audit(committed_audit(&later_request, 8, second_root))
+            .expect("matching later root commit token");
+        let acknowledgement = owner.acknowledge_source_audit_receipt(&committed);
+        assert_eq!(acknowledgement.cleared_markers(), 1);
+        assert_eq!(acknowledgement.remaining_markers(), 1);
+        assert!(
+            owner
+                .supervisor()
+                .retained_uncertainties()
+                .iter()
+                .any(|marker| marker.source_id() == Some(&first_source))
+        );
+    }
+
+    #[test]
     fn source_audit_receipts_require_complete_matching_identity_and_boundary() {
         let source = SourceId::from_string("receipt-source");
         let root_identity = root(b"receipt-root");
@@ -506,40 +666,93 @@ mod tests {
             owner.acknowledge_source_audit_receipt(&incomplete),
             ReconciliationAcknowledgementOutcome::unchanged(1)
         );
-        let insufficient_boundary = SourceAuditReceipt::new(
-            request.clone(),
-            RetainedUncertaintyBoundary::new(0, 0),
+        assert!(
+            request
+                .complete_from_committed_audit(SourceAuditCommit::new(
+                    0,
+                    root_identity.clone(),
+                    Some(request.clone()),
+                ))
+                .is_none(),
+            "a zero revision cannot mint a clearing receipt"
+        );
+        assert!(
+            request
+                .complete_from_committed_audit(SourceAuditCommit::new(
+                    12,
+                    RootIdentity::from_bytes(b"other-root".to_vec()),
+                    Some(request.clone()),
+                ))
+                .is_none(),
+            "a commit for another physical root cannot mint a clearing receipt"
+        );
+        assert!(
+            request
+                .complete_from_committed_audit(SourceAuditCommit::new(
+                    12,
+                    root_identity.clone(),
+                    None,
+                ))
+                .is_none(),
+            "an unbound scanner completion cannot mint a clearing receipt"
+        );
+        let insufficient_boundary_request = SourceAuditRequest::new(
             ReconciliationAcknowledgementIdentity::new(
                 source.clone(),
                 root_identity.clone(),
                 lane.generation(),
             ),
-            Some(12),
-            Some(root_identity.clone()),
-            true,
+            RetainedUncertaintyBoundary::new(0, 0),
         );
+        let insufficient_boundary = insufficient_boundary_request
+            .complete_from_committed_audit(committed_audit(
+                &insufficient_boundary_request,
+                12,
+                root_identity.clone(),
+            ))
+            .expect("matching committed audit authority");
         assert_eq!(
             owner.acknowledge_source_audit_receipt(&insufficient_boundary),
             ReconciliationAcknowledgementOutcome::unchanged(1)
         );
-        let wrong_identity = SourceAuditReceipt::new(
-            request.clone(),
-            request.boundary(),
+        let wrong_identity_request = SourceAuditRequest::new(
             ReconciliationAcknowledgementIdentity::new(
                 SourceId::from_string("wrong-source"),
                 root_identity.clone(),
                 lane.generation(),
             ),
-            Some(12),
-            Some(root_identity.clone()),
-            true,
+            request.boundary(),
         );
+        let wrong_identity = wrong_identity_request
+            .complete_from_committed_audit(committed_audit(
+                &wrong_identity_request,
+                12,
+                root_identity.clone(),
+            ))
+            .expect("matching committed audit authority");
         assert_eq!(
             owner.acknowledge_source_audit_receipt(&wrong_identity),
             ReconciliationAcknowledgementOutcome::unchanged(1)
         );
 
-        let complete = request.complete(12, root_identity);
+        let newer_request = SourceAuditRequest::new(
+            request.identity().clone(),
+            RetainedUncertaintyBoundary::new(
+                request.boundary().first(),
+                request.boundary().through() + 1,
+            ),
+        );
+        assert!(
+            newer_request
+                .complete_from_committed_audit(
+                    committed_audit(&request, 12, root_identity.clone(),)
+                )
+                .is_none(),
+            "an old valid commit cannot mint a receipt for a newer request"
+        );
+        let complete = request
+            .complete_from_committed_audit(committed_audit(&request, 12, root_identity.clone()))
+            .expect("matching committed audit authority");
         let acknowledgement = owner.acknowledge_source_audit_receipt(&complete);
         assert_eq!(acknowledgement.cleared_markers(), 1);
         assert_eq!(acknowledgement.remaining_markers(), 0);
@@ -564,7 +777,13 @@ mod tests {
             ),
             RetainedUncertaintyBoundary::new(1, 1),
         );
-        let pre_capture_receipt = pre_capture_request.complete(1, old_root.clone());
+        let pre_capture_receipt = pre_capture_request
+            .complete_from_committed_audit(committed_audit(
+                &pre_capture_request,
+                1,
+                old_root.clone(),
+            ))
+            .expect("matching committed audit authority");
         assert_eq!(
             owner.acknowledge_source_audit_receipt(&pre_capture_receipt),
             ReconciliationAcknowledgementOutcome::unchanged(0)
@@ -580,11 +799,13 @@ mod tests {
             AdmissionOutcome::Accepted(ticket) => *ticket,
             outcome => panic!("expected accepted live admission, got {outcome:?}"),
         };
-        let receipt = live
+        let audit_request = live
             .correlation()
             .expect("live audit correlation")
-            .audit_request()
-            .complete(2, old_root.clone());
+            .audit_request();
+        let receipt = audit_request
+            .complete_from_committed_audit(committed_audit(&audit_request, 2, old_root.clone()))
+            .expect("matching committed audit authority");
         owner.dispatch_next().expect("dispatch live admission");
         owner.mark_dispatched(ticket).expect("mark dispatched");
         owner.mark_applied(ticket).expect("mark applied");

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
@@ -173,7 +173,9 @@ fn limits_are_checked_and_accounting_is_exact_without_truncation() {
         .with_flags(1)
         .with_event_id(9)
         .with_cursor(vec![8, 7])
-        .with_detail(OsString::from("err"));
+        .with_detail(OsString::from("err"))
+        .with_source(OsString::from("source"))
+        .with_process_id(42);
     let observations = vec![
         RawObservation::new(
             RawEventKind::Create,
@@ -194,9 +196,17 @@ fn limits_are_checked_and_accounting_is_exact_without_truncation() {
 
     assert_eq!(raw.accounting().event_count(), 2);
     assert_eq!(raw.accounting().path_bytes(), 3);
-    assert_eq!(raw.accounting().metadata_bytes(), 26);
-    assert_eq!(raw.accounting().total_bytes(), Ok(29));
+    assert_eq!(raw.accounting().metadata_bytes(), 36);
+    assert_eq!(raw.accounting().total_bytes(), Ok(39));
     assert_eq!(raw.observations(), observations.as_slice());
+    assert_eq!(
+        raw.observations()[0]
+            .metadata()
+            .source()
+            .and_then(|source| source.to_str()),
+        Some("source")
+    );
+    assert_eq!(raw.observations()[0].metadata().process_id(), Some(42));
     assert_eq!(
         raw.observations()[0]
             .paths()
@@ -245,7 +255,7 @@ fn limits_are_checked_and_accounting_is_exact_without_truncation() {
         ),
         Err(RawEnvelopeError::LimitExceeded {
             limit: RawEnvelopeLimit::MetadataBytes,
-            actual: 26,
+            actual: 36,
             maximum: 25,
         })
     ));

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
@@ -1077,7 +1077,7 @@ fn live_audit_handoff_retires_applied_ticket_without_authority_or_marker_loss() 
 }
 
 #[test]
-fn live_adapter_correlation_is_none_for_rejection_and_capacity() {
+fn live_adapter_correlation_is_none_for_rejection_and_retained_coalescing() {
     let rejected_batch = adapter_batch(
         adapter_capture_provenance(
             "unregistered-source",
@@ -1106,7 +1106,7 @@ fn live_adapter_correlation_is_none_for_rejection_and_capacity() {
     let source = SourceId::from_string("source-a");
     let root = RootIdentity::from_bytes(b"root-a".to_vec());
     let mut capacity_supervisor =
-        ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 1));
+        ReconciliationAdmissionSupervisor::new(adapter_admission_limits(1, 1));
     let (_lane, generation) = adapter_registered(&mut capacity_supervisor, &source, &root);
     {
         let mut adapter = ReconciliationAdapter::new(&mut capacity_supervisor);
@@ -1141,10 +1141,103 @@ fn live_adapter_correlation_is_none_for_rejection_and_capacity() {
             .expect("capacity live admission result")
     };
     assert!(capacity.correlation().is_none());
+    assert!(capacity.audit_request().is_some());
+    assert!(matches!(
+        capacity.admission().outcome(),
+        AdmissionOutcome::Rejected(_)
+    ));
+}
+
+#[test]
+fn live_capacity_exhaustion_still_returns_current_lane_audit_request() {
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(
+        ReconciliationAdmissionLimits::new(2, limits(), limits(), 2, 64, 1)
+            .expect("capacity limits"),
+    );
+
+    for (source, root) in [
+        ("ordinary-overflow", b"ordinary-root".as_slice()),
+        ("emergency-overflow-a", b"emergency-root-a".as_slice()),
+        ("emergency-overflow-b", b"emergency-root-b".as_slice()),
+        ("emergency-overflow-c", b"emergency-root-c".as_slice()),
+    ] {
+        let outcome = supervisor.admit(
+            RawObservationEnvelope::try_new(
+                adapter_capture_provenance(
+                    source,
+                    Some(root.to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    1,
+                    None,
+                    None,
+                ),
+                vec![adapter_observation(RawEventKind::Overflow, "overflow")],
+                limits(),
+            )
+            .expect("overflow envelope"),
+        );
+        if source == "emergency-overflow-c" {
+            assert!(matches!(
+                outcome,
+                AdmissionOutcome::UncertaintyCapacityExhausted(_)
+            ));
+        } else {
+            assert!(matches!(
+                outcome,
+                AdmissionOutcome::Rejected(AdmissionRejectReason::UnknownLane)
+            ));
+        }
+    }
+    assert_eq!(supervisor.uncertainties().len(), 3);
+    assert!(!supervisor.uncertainties()[0].is_emergency());
+    assert!(
+        supervisor.uncertainties()[1..]
+            .iter()
+            .all(|marker| marker.is_emergency())
+    );
+
+    let source = SourceId::from_string("current-source");
+    let root = RootIdentity::from_bytes(b"current-root".to_vec());
+    let (_lane, generation) = adapter_registered(&mut supervisor, &source, &root);
+    let capacity = {
+        let mut adapter = ReconciliationAdapter::new(&mut supervisor);
+        adapter
+            .admit_live_with_correlation(adapter_batch(
+                adapter_capture_provenance(
+                    source.as_str(),
+                    Some(b"current-root".to_vec()),
+                    Some(b"stream-a".to_vec()),
+                    generation.get(),
+                    Some(4),
+                    Some(4),
+                ),
+                vec![adapter_observation(RawEventKind::Create, "dropped.wav")],
+            ))
+            .expect("capacity exhaustion admission result")
+    };
     assert!(matches!(
         capacity.admission().outcome(),
         AdmissionOutcome::UncertaintyCapacityExhausted(_)
     ));
+    assert!(capacity.correlation().is_none());
+    let request = capacity
+        .audit_request()
+        .expect("capacity exhaustion must retain a typed audit request");
+    assert_eq!(request.source_id(), &source);
+    assert_eq!(request.root_identity(), &root);
+    assert_eq!(request.generation(), generation);
+    assert_eq!(request.boundary().first(), 3);
+    assert_eq!(request.boundary().through(), 3);
+    assert_eq!(
+        request.boundary().through(),
+        supervisor
+            .uncertainties()
+            .iter()
+            .map(RetainedUncertainty::boundary)
+            .map(RetainedUncertaintyBoundary::through)
+            .max()
+            .expect("retained watermark")
+    );
 }
 
 #[test]
@@ -1863,7 +1956,7 @@ fn adapter_error_preserves_original_batch_and_capacity_is_atomic() {
 
     let source = SourceId::from_string("source-a");
     let root = RootIdentity::from_bytes(b"root-a".to_vec());
-    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(2, 1));
+    let mut supervisor = ReconciliationAdmissionSupervisor::new(adapter_admission_limits(1, 1));
     adapter_registered(&mut supervisor, &source, &root);
     let first = {
         let mut adapter = ReconciliationAdapter::new(&mut supervisor);
@@ -1893,20 +1986,16 @@ fn adapter_error_preserves_original_batch_and_capacity_is_atomic() {
         ),
         vec![adapter_observation(RawEventKind::Create, "second.wav")],
     );
-    let expected_second = second_batch.clone();
     let second = {
         let mut adapter = ReconciliationAdapter::new(&mut supervisor);
         adapter.admit_live(second_batch).expect("capacity result")
     };
     assert_eq!(
         second.disposition(),
-        AdapterDisposition::UncertaintyCapacityExhausted
+        AdapterDisposition::SourceAuditRequired
     );
     match second.outcome() {
-        AdmissionOutcome::UncertaintyCapacityExhausted(envelope) => {
-            assert_eq!(envelope.proof(), &Proof::Unproven);
-            assert_eq!(envelope.observations(), expected_second.observations());
-        }
+        AdmissionOutcome::Rejected(_) => {}
         outcome => panic!("unexpected capacity outcome: {outcome:?}"),
     }
     assert_eq!(supervisor.in_flight(), 1);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -19,6 +19,7 @@ pub use scan::{
     audit_source_and_record, audit_source_and_record_with_budget_and_progress,
     audit_source_and_record_with_budget_and_progress_and_writer,
     audit_source_and_record_with_budget_and_progress_and_writer_outcome,
+    audit_source_and_record_with_budget_and_progress_and_writer_with_request,
     audit_source_and_record_with_progress, audit_source_with_budget, complete_deferred_hashes,
     complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
     complete_deferred_rename_candidates_with_cancel,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -11,6 +11,7 @@ pub use runner::{
     audit_source_and_record_with_budget_and_progress,
     audit_source_and_record_with_budget_and_progress_and_writer,
     audit_source_and_record_with_budget_and_progress_and_writer_outcome,
+    audit_source_and_record_with_budget_and_progress_and_writer_with_request,
     audit_source_and_record_with_progress, audit_source_with_budget, complete_deferred_hashes,
     complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
     complete_deferred_rename_candidates_with_cancel,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -7,6 +7,9 @@ use std::thread;
 
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::SourceManifestEntry;
+use wavecrate_library::sample_sources::reconciliation::{
+    RootIdentity, SourceAuditCommit, SourceAuditRequest,
+};
 
 use super::super::scan_capability::SourceRootCapability;
 use super::super::scan_db_sync::{complete_scan_generation, db_sync_phase};
@@ -182,15 +185,14 @@ pub fn audit_source_and_record_with_budget_and_progress_and_writer(
     on_progress: &mut impl FnMut(usize, &Path),
     writer: &impl ScanWriter,
 ) -> Result<ScanStats, ScanError> {
-    match audit_source_and_record_after_scan_outcome(
+    match audit_source_and_record_with_budget_and_progress_and_writer_with_request(
         db,
         cancel,
         budget,
         completed_at,
-        Some(on_progress),
+        on_progress,
         writer,
-        || {},
-        || {},
+        None,
     )? {
         ManifestAuditOutcome::Complete {
             stats,
@@ -212,6 +214,33 @@ pub fn audit_source_and_record_with_budget_and_progress_and_writer(
     }
 }
 
+/// Run a bounded audit with an optional request-bound authority for its complete manifest commit.
+///
+/// A `None` request preserves the public scanner behavior and returns an unbound completion
+/// result. Only the native source-processing path supplies a request, allowing the resulting
+/// commit to mint a clearing receipt for that exact retained boundary.
+pub fn audit_source_and_record_with_budget_and_progress_and_writer_with_request(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    budget: ContentAuditBudget,
+    completed_at: i64,
+    on_progress: &mut impl FnMut(usize, &Path),
+    writer: &impl ScanWriter,
+    audit_request: Option<&SourceAuditRequest>,
+) -> Result<ManifestAuditOutcome, ScanError> {
+    audit_source_and_record_after_scan_outcome(
+        db,
+        cancel,
+        budget,
+        completed_at,
+        Some(on_progress),
+        writer,
+        audit_request,
+        || {},
+        || {},
+    )
+}
+
 /// Outcome of a source manifest audit with bounded content verification.
 ///
 /// Manifest traversal coverage is represented independently from resumable content
@@ -225,8 +254,8 @@ pub enum ManifestAuditOutcome {
         stats: ScanStats,
         /// Content verification stopped after a durable checkpoint, if applicable.
         content_incomplete: Option<String>,
-        /// Physical root identity revalidated immediately before the manifest commit.
-        root_identity: String,
+        /// Opaque authority from the complete manifest commit and held source-root capability.
+        audit_commit: SourceAuditCommit,
     },
     /// Manifest traversal or reconciliation was uncertain after a committed checkpoint.
     Incomplete {
@@ -255,6 +284,7 @@ pub fn audit_source_and_record_with_budget_and_progress_and_writer_outcome(
         completed_at,
         Some(on_progress),
         writer,
+        None,
         || {},
         || {},
     )
@@ -277,6 +307,7 @@ fn audit_source_and_record_after_scan(
         completed_at,
         on_progress,
         writer,
+        None,
         before_record,
         after_scan,
     )? {
@@ -307,6 +338,7 @@ fn audit_source_and_record_after_scan_outcome(
     completed_at: i64,
     on_progress: Option<&mut dyn FnMut(usize, &Path)>,
     writer: &impl ScanWriter,
+    audit_request: Option<&SourceAuditRequest>,
     before_record: impl FnOnce(),
     after_scan: impl FnOnce(),
 ) -> Result<ManifestAuditOutcome, ScanError> {
@@ -336,14 +368,15 @@ fn audit_source_and_record_after_scan_outcome(
         Err(error) => return Err(error),
     };
     before_record();
-    let committed_root_identity = match record_manifest_audit_completion(
+    let audit_commit = match record_manifest_audit_completion(
         db,
         &mut stats,
         completed_at,
         writer,
         &source_root,
+        audit_request,
     ) {
-        Ok(root_identity) => root_identity,
+        Ok(audit_commit) => audit_commit,
         Err(error) => {
             if stats.committed_delta.revision > 0 {
                 return Ok(ManifestAuditOutcome::Incomplete {
@@ -380,7 +413,7 @@ fn audit_source_and_record_after_scan_outcome(
             return Ok(ManifestAuditOutcome::Incomplete {
                 committed: stats,
                 error: error.to_string(),
-                root_identity: committed_root_identity.clone(),
+                root_identity: held_root_identity,
             });
         }
         Err(error) => return Err(error),
@@ -389,7 +422,7 @@ fn audit_source_and_record_after_scan_outcome(
         return Ok(ManifestAuditOutcome::Complete {
             stats,
             content_incomplete,
-            root_identity: committed_root_identity.clone(),
+            audit_commit: audit_commit.clone(),
         });
     }
     finalize_pending_rename_completion(
@@ -402,7 +435,7 @@ fn audit_source_and_record_after_scan_outcome(
     Ok(ManifestAuditOutcome::Complete {
         stats,
         content_incomplete,
-        root_identity: committed_root_identity,
+        audit_commit,
     })
 }
 
@@ -412,7 +445,8 @@ fn record_manifest_audit_completion(
     completed_at: i64,
     writer: &impl ScanWriter,
     source_root: &SourceRootCapability,
-) -> Result<String, ScanError> {
+    audit_request: Option<&SourceAuditRequest>,
+) -> Result<SourceAuditCommit, ScanError> {
     source_root.ensure_current_generation()?;
     let before = stats.manifest_before.clone();
     let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
@@ -436,9 +470,16 @@ fn record_manifest_audit_completion(
     }
     batch.complete_manifest_audit(completed_at)?;
     source_root.ensure_current_generation()?;
-    let committed = batch.commit_with_manifest_snapshot()?;
-    super::super::manifest::publish_committed_delta(stats, before, committed);
-    Ok(source_root.generation().to_owned())
+    let (audit_commit, committed_manifest) = batch.commit_with_manifest_snapshot_and_audit(
+        RootIdentity::from_bytes(source_root.generation().as_bytes().to_vec()),
+        audit_request,
+    )?;
+    super::super::manifest::publish_committed_delta(
+        stats,
+        before,
+        (audit_commit.committed_source_revision(), committed_manifest),
+    );
+    Ok(audit_commit)
 }
 
 #[cfg(test)]
@@ -476,6 +517,7 @@ pub(crate) fn audit_source_and_record_with_post_scan_hook_outcome(
         completed_at,
         None,
         &UncoordinatedScanWriter,
+        None,
         || {},
         after_scan,
     )

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -195,6 +195,7 @@ pub fn audit_source_and_record_with_budget_and_progress_and_writer(
         ManifestAuditOutcome::Complete {
             stats,
             content_incomplete,
+            ..
         } => match content_incomplete {
             Some(error) => Err(ScanError::Incomplete {
                 committed: Box::new(stats),
@@ -202,7 +203,9 @@ pub fn audit_source_and_record_with_budget_and_progress_and_writer(
             }),
             None => Ok(stats),
         },
-        ManifestAuditOutcome::Incomplete { committed, error } => Err(ScanError::Incomplete {
+        ManifestAuditOutcome::Incomplete {
+            committed, error, ..
+        } => Err(ScanError::Incomplete {
             committed: Box::new(committed),
             error,
         }),
@@ -222,6 +225,8 @@ pub enum ManifestAuditOutcome {
         stats: ScanStats,
         /// Content verification stopped after a durable checkpoint, if applicable.
         content_incomplete: Option<String>,
+        /// Physical root identity revalidated immediately before the manifest commit.
+        root_identity: String,
     },
     /// Manifest traversal or reconciliation was uncertain after a committed checkpoint.
     Incomplete {
@@ -229,6 +234,8 @@ pub enum ManifestAuditOutcome {
         committed: ScanStats,
         /// Diagnostic describing why authoritative coverage remains incomplete.
         error: String,
+        /// Physical root identity held while the partial manifest commit was attempted.
+        root_identity: String,
     },
 }
 
@@ -276,6 +283,7 @@ fn audit_source_and_record_after_scan(
         ManifestAuditOutcome::Complete {
             stats,
             content_incomplete,
+            ..
         } => match content_incomplete {
             Some(error) => Err(ScanError::Incomplete {
                 committed: Box::new(stats),
@@ -283,7 +291,9 @@ fn audit_source_and_record_after_scan(
             }),
             None => Ok(stats),
         },
-        ManifestAuditOutcome::Incomplete { committed, error } => Err(ScanError::Incomplete {
+        ManifestAuditOutcome::Incomplete {
+            committed, error, ..
+        } => Err(ScanError::Incomplete {
             committed: Box::new(committed),
             error,
         }),
@@ -303,6 +313,7 @@ fn audit_source_and_record_after_scan_outcome(
     let root = ensure_root_dir(db)?;
     let source_root = SourceRootCapability::open(&root)?;
     source_root.ensure_current_generation()?;
+    let held_root_identity = source_root.generation().to_owned();
     let mut stats = match scan_with_writer_using_root(
         db,
         &root,
@@ -319,22 +330,31 @@ fn audit_source_and_record_after_scan_outcome(
             return Ok(ManifestAuditOutcome::Incomplete {
                 committed: *committed,
                 error,
+                root_identity: held_root_identity.clone(),
             });
         }
         Err(error) => return Err(error),
     };
     before_record();
-    if let Err(error) =
-        record_manifest_audit_completion(db, &mut stats, completed_at, writer, &source_root)
-    {
-        if stats.committed_delta.revision > 0 {
-            return Ok(ManifestAuditOutcome::Incomplete {
-                committed: stats,
-                error: error.to_string(),
-            });
+    let committed_root_identity = match record_manifest_audit_completion(
+        db,
+        &mut stats,
+        completed_at,
+        writer,
+        &source_root,
+    ) {
+        Ok(root_identity) => root_identity,
+        Err(error) => {
+            if stats.committed_delta.revision > 0 {
+                return Ok(ManifestAuditOutcome::Incomplete {
+                    committed: stats,
+                    error: error.to_string(),
+                    root_identity: held_root_identity,
+                });
+            }
+            return Err(error);
         }
-        return Err(error);
-    }
+    };
     after_scan();
     let verification = super::super::scan_hash::verify_content_batch_with_source_root(
         db,
@@ -360,6 +380,7 @@ fn audit_source_and_record_after_scan_outcome(
             return Ok(ManifestAuditOutcome::Incomplete {
                 committed: stats,
                 error: error.to_string(),
+                root_identity: committed_root_identity.clone(),
             });
         }
         Err(error) => return Err(error),
@@ -368,6 +389,7 @@ fn audit_source_and_record_after_scan_outcome(
         return Ok(ManifestAuditOutcome::Complete {
             stats,
             content_incomplete,
+            root_identity: committed_root_identity.clone(),
         });
     }
     finalize_pending_rename_completion(
@@ -380,6 +402,7 @@ fn audit_source_and_record_after_scan_outcome(
     Ok(ManifestAuditOutcome::Complete {
         stats,
         content_incomplete,
+        root_identity: committed_root_identity,
     })
 }
 
@@ -389,7 +412,7 @@ fn record_manifest_audit_completion(
     completed_at: i64,
     writer: &impl ScanWriter,
     source_root: &SourceRootCapability,
-) -> Result<(), ScanError> {
+) -> Result<String, ScanError> {
     source_root.ensure_current_generation()?;
     let before = stats.manifest_before.clone();
     let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
@@ -415,7 +438,7 @@ fn record_manifest_audit_completion(
     source_root.ensure_current_generation()?;
     let committed = batch.commit_with_manifest_snapshot()?;
     super::super::manifest::publish_committed_delta(stats, before, committed);
-    Ok(())
+    Ok(source_root.generation().to_owned())
 }
 
 #[cfg(test)]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -1001,7 +1001,10 @@ fn typed_manifest_audit_outcome_retains_coverage_barrier_for_unreadable_traversa
     .unwrap();
     drop(failure);
 
-    let ManifestAuditOutcome::Incomplete { committed, error } = outcome else {
+    let ManifestAuditOutcome::Incomplete {
+        committed, error, ..
+    } = outcome
+    else {
         panic!("uncertain traversal must retain the manifest coverage barrier");
     };
     assert!(error.contains("retry required"));
@@ -1074,6 +1077,7 @@ fn typed_manifest_audit_outcome_keeps_coverage_complete_when_content_pauses() {
     let ManifestAuditOutcome::Complete {
         stats,
         content_incomplete,
+        ..
     } = outcome
     else {
         panic!("content verification pause must not downgrade manifest coverage");
@@ -1106,7 +1110,10 @@ fn typed_manifest_audit_outcome_retains_barrier_for_noncheckpoint_verification_e
     std::fs::remove_dir(&source_root).unwrap();
     std::fs::rename(&displaced, &source_root).unwrap();
 
-    let ManifestAuditOutcome::Incomplete { committed, error } = outcome else {
+    let ManifestAuditOutcome::Incomplete {
+        committed, error, ..
+    } = outcome
+    else {
         panic!("non-checkpoint verification errors must retain the recovery barrier");
     };
     assert!(error.contains("generation changed"));

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
@@ -66,6 +66,11 @@ impl SourceRootCapability {
         })
     }
 
+    /// Borrow the physical identity captured by the held source-root capability.
+    pub(super) fn generation(&self) -> &str {
+        &self.generation
+    }
+
     /// Revalidate that the configured ambient path still names this retained root.
     pub(super) fn ensure_current_generation(&self) -> Result<(), ScanError> {
         let Ok(metadata) = fs::metadata(&self.root) else {

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -110,6 +110,11 @@ pub(in crate::native_app) enum GuiMessage {
         source_id: String,
         reason: &'static str,
     },
+    /// A proofless live watcher handoff requires a source-scoped authoritative manifest audit.
+    /// The request is opaque typed evidence; the source-processing owner performs the audit.
+    SourceWatcherManifestAuditRequested {
+        request: wavecrate_library::sample_sources::reconciliation::SourceAuditRequest,
+    },
     /// A completed fallback audit produced a barrier that must be persisted by the source
     /// processing owner. This message carries only typed in-memory evidence; it performs no I/O.
     SourceWatcherCheckpointReady(RevisionBoundCheckpoint),
@@ -130,6 +135,7 @@ pub(in crate::native_app) enum GuiMessage {
         lifecycle_generation: u64,
         source_revision: Option<u64>,
         complete: bool,
+        receipt: Option<wavecrate_library::sample_sources::reconciliation::SourceAuditReceipt>,
     },
     NormalizationProgress(NormalizationProgress),
     NormalizationFinished(NormalizationResult),

--- a/src/native_app/app/source_processing_events.rs
+++ b/src/native_app/app/source_processing_events.rs
@@ -59,11 +59,13 @@ fn map_event(event: SourceProcessingEvent) -> GuiMessage {
             lifecycle,
             source_revision,
             complete,
+            receipt,
         } => GuiMessage::SourceManifestAuditFinished {
             source_id: lifecycle.source_id,
             lifecycle_generation: lifecycle.generation,
             source_revision,
             complete,
+            receipt,
         },
         SourceProcessingEvent::Completed => {
             GuiMessage::SourceProcessingProgress(SourceProcessingProgress {
@@ -460,12 +462,14 @@ mod tests {
                 lifecycle: SourceProcessingLifecycle::new("source", 23),
                 source_revision: Some(41),
                 complete: true,
+                receipt: None,
             }),
             GuiMessage::SourceManifestAuditFinished {
                 source_id,
                 lifecycle_generation: 23,
                 source_revision: Some(41),
                 complete: true,
+                receipt: None,
             } if source_id == "source"
         ));
     }

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -14,6 +14,7 @@ const WATCHER_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const SOURCE_CHANGE_DEBOUNCE: Duration = Duration::from_millis(400);
 const MAX_PENDING_PATHS_PER_SOURCE: usize = 512;
 const WATCHER_EVENT_QUEUE_CAPACITY: usize = 256;
+const MAX_PENDING_CAPTURE_CONTEXTS: usize = WATCHER_EVENT_QUEUE_CAPACITY;
 const WATCHER_RESTART_MIN: Duration = Duration::from_secs(1);
 const WATCHER_RESTART_MAX: Duration = Duration::from_secs(60);
 const WATCHER_START_TIMEOUT: Duration = Duration::from_secs(5);

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -160,6 +160,23 @@ impl AdmissionLifecycle {
         self.owner.lane(source_id)
     }
 
+    /// Check a queued audit request against the owner-held current capturing lane.
+    ///
+    /// This is deliberately pure: it observes only the in-memory source, root, generation, and
+    /// lifecycle identity owned by the admission supervisor. A request from a stopped lane or a
+    /// replaced root/generation is never eligible for watcher transport.
+    pub(super) fn request_matches_current_capturing_lane(
+        &self,
+        request: &SourceAuditRequest,
+    ) -> bool {
+        self.lane_for_capture(request.source_id())
+            .is_some_and(|lane| {
+                lane.lifecycle() == ReconciliationLifecycle::Capturing
+                    && lane.root_identity() == request.root_identity()
+                    && lane.generation() == request.generation()
+            })
+    }
+
     /// Build the existing bounded request for the current owner-authoritative source lane.
     pub(super) fn source_audit_request_for_current_lane(
         &self,
@@ -468,6 +485,54 @@ mod tests {
         assert!(new.generation() > old.generation());
         assert_eq!(new.lifecycle(), ReconciliationLifecycle::Capturing);
         assert_eq!(lifecycle.owner.supervisor().in_flight(), 0);
+    }
+
+    #[test]
+    fn audit_request_matches_only_the_current_capturing_root_and_generation() {
+        let initial_source = source("request-fence", "root-a");
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(1, 1, 16));
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&initial_source),
+                &watched(&[("root-a", Some(b"identity-a"))]),
+            )
+            .expect("old binding");
+        let old_request = lifecycle
+            .source_audit_request_for_current_lane(&initial_source.id)
+            .expect("old lane request")
+            .0;
+        assert!(lifecycle.request_matches_current_capturing_lane(&old_request));
+
+        let replacement = source("request-fence", "root-b");
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&replacement),
+                &watched(&[("root-b", Some(b"identity-b"))]),
+            )
+            .expect("root rebind");
+        let rebound_request = lifecycle
+            .source_audit_request_for_current_lane(&replacement.id)
+            .expect("rebound lane request")
+            .0;
+        assert!(!lifecycle.request_matches_current_capturing_lane(&old_request));
+        assert!(lifecycle.request_matches_current_capturing_lane(&rebound_request));
+        assert!(rebound_request.generation() > old_request.generation());
+
+        lifecycle.fence_all().expect("stop current lane");
+        assert!(!lifecycle.request_matches_current_capturing_lane(&rebound_request));
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&replacement),
+                &watched(&[("root-b", Some(b"identity-b"))]),
+            )
+            .expect("restart current lane");
+        let restarted_request = lifecycle
+            .source_audit_request_for_current_lane(&replacement.id)
+            .expect("restarted lane request")
+            .0;
+        assert!(!lifecycle.request_matches_current_capturing_lane(&rebound_request));
+        assert!(lifecycle.request_matches_current_capturing_lane(&restarted_request));
+        assert!(restarted_request.generation() > rebound_request.generation());
     }
 
     #[test]

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -4,13 +4,11 @@ use std::collections::HashSet;
 
 use wavecrate::sample_sources::{SampleSource, SourceId};
 use wavecrate_library::sample_sources::reconciliation::{
-    AdmissionOwnerError, RawObservationLimits, ReconciliationAdmissionLimits,
+    AdapterError, AdmissionOwnerError, DispatchTicket, DispatchedObservation, LiveAuditAdmission,
+    OwnedAdmissionLane, RawObservationLimits, ReconciliationAdmissionLimits,
     ReconciliationAdmissionOwner, ReconciliationAdmissionSupervisor, ReconciliationLifecycle,
-    RootIdentity,
+    RootIdentity, SyntheticObservationBatch,
 };
-
-#[cfg(test)]
-use wavecrate_library::sample_sources::reconciliation::OwnedAdmissionLane;
 
 use super::roots::{WatchedRootIdentities, registered_root_identity};
 
@@ -47,7 +45,7 @@ impl AdmissionLifecycle {
     }
 
     #[cfg(test)]
-    fn with_limits(limits: ReconciliationAdmissionLimits) -> Self {
+    pub(super) fn with_limits(limits: ReconciliationAdmissionLimits) -> Self {
         Self::from_limits(limits)
     }
 
@@ -153,9 +151,70 @@ impl AdmissionLifecycle {
         Ok(())
     }
 
+    /// Return the owner-authoritative lane snapshot used to bind a live capture.
+    pub(super) fn lane_for_capture(&self, source_id: &SourceId) -> Option<OwnedAdmissionLane> {
+        if self.admission_closed {
+            return None;
+        }
+        self.owner.lane(source_id)
+    }
+
+    /// Admit live evidence through the existing owner-held adapter.
+    pub(super) fn admit_live_with_correlation(
+        &mut self,
+        batch: SyntheticObservationBatch,
+    ) -> Result<LiveAuditAdmission, AdapterError> {
+        self.owner.admit_live_with_correlation(batch)
+    }
+
+    /// Select the next owner-scheduled live envelope.
+    pub(super) fn dispatch_next(&mut self) -> Option<DispatchedObservation> {
+        if self.admission_closed {
+            return None;
+        }
+        self.owner.dispatch_next()
+    }
+
+    /// Advance an owner-scheduled envelope through its handoff phases.
+    pub(super) fn mark_dispatched(
+        &mut self,
+        ticket: DispatchTicket,
+    ) -> Result<(), wavecrate_library::sample_sources::reconciliation::AdmissionError> {
+        self.owner.mark_dispatched(ticket)
+    }
+
+    pub(super) fn mark_applied(
+        &mut self,
+        ticket: DispatchTicket,
+    ) -> Result<(), wavecrate_library::sample_sources::reconciliation::AdmissionError> {
+        self.owner.mark_applied(ticket)
+    }
+
+    pub(super) fn mark_unproven_audit_handed_off(
+        &mut self,
+        ticket: DispatchTicket,
+    ) -> Result<(), wavecrate_library::sample_sources::reconciliation::AdmissionError> {
+        self.owner.mark_unproven_audit_handed_off(ticket)
+    }
+
+    pub(super) fn max_in_flight(&self) -> usize {
+        self.owner.max_in_flight()
+    }
+
+    pub(super) fn in_flight(&self) -> usize {
+        self.owner.supervisor().in_flight()
+    }
+
+    #[cfg(test)]
+    pub(super) fn retained_uncertainties(
+        &self,
+    ) -> &[wavecrate_library::sample_sources::reconciliation::RetainedUncertainty] {
+        self.owner.supervisor().retained_uncertainties()
+    }
+
     #[cfg(test)]
     fn lane(&self, source_id: &SourceId) -> Option<OwnedAdmissionLane> {
-        self.owner.lane(source_id)
+        self.lane_for_capture(source_id)
     }
 }
 

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -5,9 +5,9 @@ use std::collections::HashSet;
 use wavecrate::sample_sources::{SampleSource, SourceId};
 use wavecrate_library::sample_sources::reconciliation::{
     AdapterError, AdmissionOwnerError, DispatchTicket, DispatchedObservation, LiveAuditAdmission,
-    OwnedAdmissionLane, RawObservationLimits, ReconciliationAdmissionLimits,
-    ReconciliationAdmissionOwner, ReconciliationAdmissionSupervisor, ReconciliationLifecycle,
-    RootIdentity, SyntheticObservationBatch,
+    OwnedAdmissionLane, RawObservationLimits, ReconciliationAcknowledgementOutcome,
+    ReconciliationAdmissionLimits, ReconciliationAdmissionOwner, ReconciliationAdmissionSupervisor,
+    ReconciliationLifecycle, RootIdentity, SourceAuditReceipt, SyntheticObservationBatch,
 };
 
 use super::roots::{WatchedRootIdentities, registered_root_identity};
@@ -195,6 +195,17 @@ impl AdmissionLifecycle {
         ticket: DispatchTicket,
     ) -> Result<(), wavecrate_library::sample_sources::reconciliation::AdmissionError> {
         self.owner.mark_unproven_audit_handed_off(ticket)
+    }
+
+    /// Apply a complete source-audit receipt through the owner-authoritative typed acknowledgement.
+    ///
+    /// Receipts are checked against the currently capturing source/root/generation lane by the
+    /// owner. No receipt can grant continuity or checkpoint authority.
+    pub(super) fn acknowledge_source_audit_receipt(
+        &mut self,
+        receipt: &SourceAuditReceipt,
+    ) -> ReconciliationAcknowledgementOutcome {
+        self.owner.acknowledge_source_audit_receipt(receipt)
     }
 
     pub(super) fn max_in_flight(&self) -> usize {

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -7,7 +7,8 @@ use wavecrate_library::sample_sources::reconciliation::{
     AdapterError, AdmissionOwnerError, DispatchTicket, DispatchedObservation, LiveAuditAdmission,
     OwnedAdmissionLane, RawObservationLimits, ReconciliationAcknowledgementOutcome,
     ReconciliationAdmissionLimits, ReconciliationAdmissionOwner, ReconciliationAdmissionSupervisor,
-    ReconciliationLifecycle, RootIdentity, SourceAuditReceipt, SyntheticObservationBatch,
+    ReconciliationLifecycle, RootIdentity, SourceAuditReceipt, SourceAuditRequest,
+    SyntheticObservationBatch,
 };
 
 use super::roots::{WatchedRootIdentities, registered_root_identity};
@@ -157,6 +158,14 @@ impl AdmissionLifecycle {
             return None;
         }
         self.owner.lane(source_id)
+    }
+
+    /// Build the existing bounded request for the current owner-authoritative source lane.
+    pub(super) fn source_audit_request_for_current_lane(
+        &self,
+        source_id: &SourceId,
+    ) -> Option<SourceAuditRequest> {
+        self.owner.source_audit_request_for_current_lane(source_id)
     }
 
     /// Admit live evidence through the existing owner-held adapter.

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -164,8 +164,27 @@ impl AdmissionLifecycle {
     pub(super) fn source_audit_request_for_current_lane(
         &self,
         source_id: &SourceId,
-    ) -> Option<SourceAuditRequest> {
-        self.owner.source_audit_request_for_current_lane(source_id)
+    ) -> Option<(SourceAuditRequest, bool)> {
+        let request = self
+            .owner
+            .source_audit_request_for_current_lane(source_id)?;
+        let marker_backed = self.source_audit_request_is_marker_backed(&request);
+        Some((request, marker_backed))
+    }
+
+    pub(super) fn source_audit_request_is_marker_backed(
+        &self,
+        request: &SourceAuditRequest,
+    ) -> bool {
+        self.owner
+            .supervisor()
+            .retained_uncertainties()
+            .iter()
+            .any(|marker| {
+                marker.source_id() == Some(request.source_id())
+                    && marker.root_identity() == Some(request.root_identity())
+                    && marker.generation() == Some(request.generation())
+            })
     }
 
     /// Admit live evidence through the existing owner-held adapter.
@@ -219,6 +238,10 @@ impl AdmissionLifecycle {
 
     pub(super) fn max_in_flight(&self) -> usize {
         self.owner.max_in_flight()
+    }
+
+    pub(super) fn max_source_audit_request_entries(&self) -> usize {
+        self.owner.max_source_audit_request_entries()
     }
 
     pub(super) fn in_flight(&self) -> usize {

--- a/src/native_app/sample_library/source_watcher/capture.rs
+++ b/src/native_app/sample_library/source_watcher/capture.rs
@@ -1,14 +1,50 @@
-use notify::Event;
+#![cfg_attr(not(test), allow(dead_code))]
+
+use notify::{
+    Event, EventKind,
+    event::{EventAttributes, Flag},
+};
+use std::{
+    ffi::OsString,
+    path::{Component, Path, PathBuf},
+};
+use wavecrate::sample_sources::SourceId;
+use wavecrate_library::sample_sources::reconciliation::{
+    BackendStreamIdentity, CaptureBoundary, ObservationUncertainty, RawEventKind, RawObservation,
+    RawObservationLimits, RawObservationMetadata, RawObservationProvenance, RawObservedPath,
+    RawPathHint, RawPathRole, RootIdentity, RootRelativePath, RootRelativePathError,
+    SyntheticObservationBatch, WatcherGeneration,
+};
 
 pub(super) const MAX_CAPTURE_PATHS: usize = 4_096;
 pub(super) const MAX_CAPTURE_PATH_BYTES: usize = 256 * 1_024;
 pub(super) const MAX_CAPTURE_METADATA_BYTES: usize = 256 * 1_024;
+const MAX_RAW_OBSERVATIONS_PER_CAPTURE: usize = 1;
+const RAW_FLAG_RESCAN: u64 = 1 << 0;
+const RAW_EVENT_KIND_METADATA_BYTES: usize = 1;
+const RAW_UNCERTAINTY_METADATA_BYTES: usize = std::mem::size_of::<u16>();
+const RAW_PATH_ROLE_AND_HINT_METADATA_BYTES: usize = 2;
 
 #[derive(Debug)]
 pub(super) enum SourceWatcherCapture {
     Notify { stream_id: u64, event: Event },
     Error { stream_id: u64 },
     Overflow { stream_id: u64 },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum CaptureAdmissionError {
+    PathOutsideSourceRoot {
+        path: PathBuf,
+    },
+    InvalidRelativePath {
+        path: PathBuf,
+        error: RootRelativePathError,
+    },
+    MetadataValueOverflow {
+        field: &'static str,
+        value: usize,
+    },
 }
 
 pub(super) fn capture_event(event: notify::Result<Event>) -> SourceWatcherCapture {
@@ -24,14 +60,7 @@ pub(super) fn capture_event(event: notify::Result<Event>) -> SourceWatcherCaptur
         let total = total.checked_add(path.as_os_str().as_encoded_bytes().len())?;
         (total <= MAX_CAPTURE_PATH_BYTES).then_some(total)
     });
-    let metadata_bytes = captured_event
-        .attrs
-        .info()
-        .into_iter()
-        .chain(captured_event.attrs.source())
-        .try_fold(0usize, |total, metadata| {
-            total.checked_add(metadata.as_bytes().len())
-        });
+    let metadata_bytes = raw_metadata_bytes(&captured_event);
     if path_bytes.is_none()
         || metadata_bytes.map_or(true, |bytes| bytes > MAX_CAPTURE_METADATA_BYTES)
     {
@@ -44,15 +73,523 @@ pub(super) fn capture_event(event: notify::Result<Event>) -> SourceWatcherCaptur
     }
 }
 
+/// Conservatively account for every raw metadata byte this adapter can retain.
+///
+/// The raw model always charges the event kind and may charge uncertainty, so those bytes are
+/// reserved for every event. Each path reserves both its role and optional hint byte. Optional
+/// Notify attributes are accounted exactly when the callback can retain them.
+fn raw_metadata_bytes(event: &Event) -> Option<usize> {
+    let path_metadata_bytes = event
+        .paths
+        .len()
+        .checked_mul(RAW_PATH_ROLE_AND_HINT_METADATA_BYTES)?;
+    let mut total = RAW_EVENT_KIND_METADATA_BYTES
+        .checked_add(RAW_UNCERTAINTY_METADATA_BYTES)?
+        .checked_add(path_metadata_bytes)?;
+
+    if event.attrs.flag() == Some(Flag::Rescan) {
+        total = total.checked_add(std::mem::size_of::<u64>())?;
+    }
+    if event.attrs.tracker().is_some() {
+        total = total.checked_add(std::mem::size_of::<u64>())?;
+    }
+    if event.attrs.process_id().is_some() {
+        total = total.checked_add(std::mem::size_of::<u32>())?;
+    }
+
+    event
+        .attrs
+        .info()
+        .into_iter()
+        .chain(event.attrs.source())
+        .try_fold(total, |total, metadata| {
+            total.checked_add(metadata.as_bytes().len())
+        })
+}
+
+/// Convert one bounded native capture into the pure reconciliation admission shape.
+///
+/// The capture already carries its backend stream identity. A notify event is converted using
+/// lexical path operations only; the source root is never read or canonicalized here.
+pub(super) fn capture_to_observation_batch(
+    capture: SourceWatcherCapture,
+    source_root: &Path,
+    source_id: SourceId,
+    root_identity: RootIdentity,
+    watcher_generation: WatcherGeneration,
+    capture_boundary: CaptureBoundary,
+) -> Result<SyntheticObservationBatch, CaptureAdmissionError> {
+    match capture {
+        SourceWatcherCapture::Notify { stream_id, event } => event_observation_batch(
+            event,
+            source_root,
+            source_id,
+            root_identity,
+            stream_id,
+            watcher_generation,
+            capture_boundary,
+        ),
+        SourceWatcherCapture::Error { stream_id } => Ok(marker_batch(
+            RawEventKind::Error,
+            ObservationUncertainty::BACKEND_ERROR,
+            source_id,
+            root_identity,
+            stream_id,
+            watcher_generation,
+            capture_boundary,
+        )),
+        SourceWatcherCapture::Overflow { stream_id } => Ok(marker_batch(
+            RawEventKind::Overflow,
+            ObservationUncertainty::OVERFLOW,
+            source_id,
+            root_identity,
+            stream_id,
+            watcher_generation,
+            capture_boundary,
+        )),
+    }
+}
+
+/// Convert a notify event while retaining bounded overflow as a typed raw marker.
+pub(super) fn event_to_observation_batch(
+    event: Event,
+    source_root: &Path,
+    source_id: SourceId,
+    root_identity: RootIdentity,
+    stream_id: u64,
+    watcher_generation: WatcherGeneration,
+    capture_boundary: CaptureBoundary,
+) -> Result<SyntheticObservationBatch, CaptureAdmissionError> {
+    let bounded = capture_event(Ok(event));
+    let capture = match bounded {
+        SourceWatcherCapture::Notify { event, .. } => {
+            SourceWatcherCapture::Notify { stream_id, event }
+        }
+        SourceWatcherCapture::Error { .. } => SourceWatcherCapture::Error { stream_id },
+        SourceWatcherCapture::Overflow { .. } => SourceWatcherCapture::Overflow { stream_id },
+    };
+    capture_to_observation_batch(
+        capture,
+        source_root,
+        source_id,
+        root_identity,
+        watcher_generation,
+        capture_boundary,
+    )
+}
+
+fn event_observation(
+    event: Event,
+    source_root: &Path,
+) -> Result<RawObservation, CaptureAdmissionError> {
+    let rescan = event.attrs.flag() == Some(Flag::Rescan);
+    let metadata = observation_metadata(&event.attrs)?;
+    event_observation_with_metadata(event, source_root, metadata, rescan)
+}
+
+fn event_observation_with_metadata(
+    event: Event,
+    source_root: &Path,
+    metadata: RawObservationMetadata,
+    rescan: bool,
+) -> Result<RawObservation, CaptureAdmissionError> {
+    let Event { kind, paths, .. } = event;
+    let path_count = paths.len();
+    let mapping = map_event_kind(kind, path_count);
+    let mut relative_paths = Vec::with_capacity(path_count);
+    let mut root_observed = false;
+
+    for path in paths {
+        match relative_path(source_root, path)? {
+            Some(path) => relative_paths.push(path),
+            None => root_observed = true,
+        }
+    }
+
+    if root_observed {
+        let observation = RawObservation::new(
+            RawEventKind::RootChanged,
+            relative_paths
+                .into_iter()
+                .map(|path| RawObservedPath::new(path, RawPathRole::Subject))
+                .collect(),
+        )
+        .with_metadata(metadata);
+        let mut uncertainty = mapping.uncertainty | ObservationUncertainty::PATH_COVERAGE;
+        if rescan {
+            uncertainty |= ObservationUncertainty::PATH_COVERAGE;
+        }
+        return Ok(observation.with_uncertainty(uncertainty));
+    }
+
+    let mut uncertainty = mapping.uncertainty;
+    if relative_paths.is_empty() {
+        uncertainty |= ObservationUncertainty::PATH_COVERAGE;
+    }
+    if rescan {
+        uncertainty |= ObservationUncertainty::PATH_COVERAGE;
+    }
+
+    let observed_paths = relative_paths
+        .into_iter()
+        .enumerate()
+        .map(|(index, path)| {
+            let observed = RawObservedPath::new(path, mapping.role(index));
+            match mapping.hint {
+                Some(hint) => observed.with_hint(hint),
+                None => observed,
+            }
+        })
+        .collect();
+    Ok(RawObservation::new(mapping.kind, observed_paths)
+        .with_metadata(metadata)
+        .with_uncertainty(uncertainty))
+}
+
+fn observation_metadata(
+    attrs: &EventAttributes,
+) -> Result<RawObservationMetadata, CaptureAdmissionError> {
+    observation_metadata_from_values(
+        attrs.flag(),
+        attrs.tracker(),
+        attrs.info(),
+        attrs.source(),
+        attrs.process_id(),
+    )
+}
+
+fn observation_metadata_from_values(
+    flag: Option<Flag>,
+    tracker: Option<usize>,
+    info: Option<&str>,
+    source: Option<&str>,
+    process_id: Option<u32>,
+) -> Result<RawObservationMetadata, CaptureAdmissionError> {
+    let mut metadata = RawObservationMetadata::new();
+    if flag == Some(Flag::Rescan) {
+        metadata = metadata.with_flags(RAW_FLAG_RESCAN);
+    }
+    if let Some(tracker) = tracker {
+        let tracker =
+            u64::try_from(tracker).map_err(|_| CaptureAdmissionError::MetadataValueOverflow {
+                field: "tracker",
+                value: tracker,
+            })?;
+        metadata = metadata.with_rename_cookie(tracker);
+    }
+    if let Some(info) = info {
+        metadata = metadata.with_detail(OsString::from(info));
+    }
+    if let Some(source) = source {
+        metadata = metadata.with_source(OsString::from(source));
+    }
+    if let Some(process_id) = process_id {
+        metadata = metadata.with_process_id(process_id);
+    }
+    Ok(metadata)
+}
+
+fn event_observation_batch(
+    event: Event,
+    source_root: &Path,
+    source_id: SourceId,
+    root_identity: RootIdentity,
+    stream_id: u64,
+    watcher_generation: WatcherGeneration,
+    capture_boundary: CaptureBoundary,
+) -> Result<SyntheticObservationBatch, CaptureAdmissionError> {
+    let observation = event_observation(event, source_root)?;
+    Ok(batch(
+        observation,
+        source_id,
+        root_identity,
+        stream_id,
+        watcher_generation,
+        capture_boundary,
+    ))
+}
+
+fn marker_batch(
+    kind: RawEventKind,
+    uncertainty: ObservationUncertainty,
+    source_id: SourceId,
+    root_identity: RootIdentity,
+    stream_id: u64,
+    watcher_generation: WatcherGeneration,
+    capture_boundary: CaptureBoundary,
+) -> SyntheticObservationBatch {
+    batch(
+        RawObservation::new(kind, Vec::new()).with_uncertainty(uncertainty),
+        source_id,
+        root_identity,
+        stream_id,
+        watcher_generation,
+        capture_boundary,
+    )
+}
+
+fn batch(
+    observation: RawObservation,
+    source_id: SourceId,
+    root_identity: RootIdentity,
+    stream_id: u64,
+    watcher_generation: WatcherGeneration,
+    capture_boundary: CaptureBoundary,
+) -> SyntheticObservationBatch {
+    let provenance = RawObservationProvenance::new(
+        source_id,
+        Some(root_identity),
+        Some(BackendStreamIdentity::from_bytes(
+            stream_id.to_be_bytes().to_vec(),
+        )),
+        watcher_generation,
+        capture_boundary,
+    );
+    SyntheticObservationBatch::new(
+        provenance,
+        vec![observation],
+        native_raw_observation_limits(),
+    )
+}
+
+fn native_raw_observation_limits() -> RawObservationLimits {
+    RawObservationLimits::new(
+        MAX_RAW_OBSERVATIONS_PER_CAPTURE,
+        MAX_CAPTURE_PATH_BYTES,
+        MAX_CAPTURE_METADATA_BYTES,
+    )
+    .expect("native raw observation limits")
+}
+
+#[derive(Clone, Copy)]
+struct EventMapping {
+    kind: RawEventKind,
+    path_shape: PathShape,
+    uncertainty: ObservationUncertainty,
+    hint: Option<RawPathHint>,
+}
+
+#[derive(Clone, Copy)]
+enum PathShape {
+    Subject,
+    RenameBoth,
+    RenameSource,
+    RenameDestination,
+}
+
+impl EventMapping {
+    fn role(self, index: usize) -> RawPathRole {
+        match self.path_shape {
+            PathShape::Subject => RawPathRole::Subject,
+            PathShape::RenameBoth => match index {
+                0 => RawPathRole::RenameSource,
+                _ => RawPathRole::RenameDestination,
+            },
+            PathShape::RenameSource => RawPathRole::RenameSource,
+            PathShape::RenameDestination => RawPathRole::RenameDestination,
+        }
+    }
+}
+
+fn map_event_kind(kind: EventKind, path_count: usize) -> EventMapping {
+    use notify::event::{CreateKind, DataChange, MetadataKind, ModifyKind, RemoveKind, RenameMode};
+
+    match kind {
+        EventKind::Create(create_kind) => match create_kind {
+            CreateKind::File => EventMapping {
+                kind: RawEventKind::Create,
+                path_shape: PathShape::Subject,
+                uncertainty: ObservationUncertainty::empty(),
+                hint: None,
+            },
+            CreateKind::Folder => EventMapping {
+                kind: RawEventKind::Create,
+                path_shape: PathShape::Subject,
+                uncertainty: ObservationUncertainty::empty(),
+                hint: Some(RawPathHint::Directory),
+            },
+            CreateKind::Any => EventMapping {
+                kind: RawEventKind::Create,
+                path_shape: PathShape::Subject,
+                uncertainty: ObservationUncertainty::empty(),
+                hint: Some(RawPathHint::Unknown),
+            },
+            CreateKind::Other => unsupported_mapping(),
+        },
+        EventKind::Modify(modify_kind) => match modify_kind {
+            ModifyKind::Data(DataChange::Any | DataChange::Size | DataChange::Content)
+            | ModifyKind::Metadata(MetadataKind::Any)
+            | ModifyKind::Metadata(MetadataKind::AccessTime)
+            | ModifyKind::Metadata(MetadataKind::WriteTime)
+            | ModifyKind::Metadata(MetadataKind::Permissions)
+            | ModifyKind::Metadata(MetadataKind::Ownership)
+            | ModifyKind::Metadata(MetadataKind::Extended)
+            | ModifyKind::Metadata(MetadataKind::Other)
+            | ModifyKind::Any => EventMapping {
+                kind: RawEventKind::Modify,
+                path_shape: PathShape::Subject,
+                uncertainty: ObservationUncertainty::empty(),
+                hint: None,
+            },
+            ModifyKind::Name(rename_mode) => match rename_mode {
+                RenameMode::Both if path_count == 2 => EventMapping {
+                    kind: RawEventKind::Rename,
+                    path_shape: PathShape::RenameBoth,
+                    uncertainty: ObservationUncertainty::empty(),
+                    hint: None,
+                },
+                RenameMode::From if path_count == 1 => EventMapping {
+                    kind: RawEventKind::Rename,
+                    path_shape: PathShape::RenameSource,
+                    uncertainty: ObservationUncertainty::PATH_COVERAGE,
+                    hint: None,
+                },
+                RenameMode::To if path_count == 1 => EventMapping {
+                    kind: RawEventKind::Rename,
+                    path_shape: PathShape::RenameDestination,
+                    uncertainty: ObservationUncertainty::PATH_COVERAGE,
+                    hint: None,
+                },
+                RenameMode::Any
+                | RenameMode::From
+                | RenameMode::To
+                | RenameMode::Both
+                | RenameMode::Other => EventMapping {
+                    kind: RawEventKind::Rename,
+                    path_shape: PathShape::Subject,
+                    uncertainty: ObservationUncertainty::PATH_COVERAGE,
+                    hint: None,
+                },
+            },
+            ModifyKind::Data(DataChange::Other) | ModifyKind::Other => unsupported_mapping(),
+        },
+        EventKind::Remove(remove_kind) => match remove_kind {
+            RemoveKind::File => EventMapping {
+                kind: RawEventKind::Delete,
+                path_shape: PathShape::Subject,
+                uncertainty: ObservationUncertainty::empty(),
+                hint: None,
+            },
+            RemoveKind::Folder => EventMapping {
+                kind: RawEventKind::Delete,
+                path_shape: PathShape::Subject,
+                uncertainty: ObservationUncertainty::empty(),
+                hint: Some(RawPathHint::Directory),
+            },
+            RemoveKind::Any => EventMapping {
+                kind: RawEventKind::Delete,
+                path_shape: PathShape::Subject,
+                uncertainty: ObservationUncertainty::empty(),
+                hint: Some(RawPathHint::Unknown),
+            },
+            RemoveKind::Other => unsupported_mapping(),
+        },
+        EventKind::Any | EventKind::Access(_) | EventKind::Other => unsupported_mapping(),
+    }
+}
+
+fn unsupported_mapping() -> EventMapping {
+    EventMapping {
+        kind: RawEventKind::Unsupported,
+        path_shape: PathShape::Subject,
+        uncertainty: ObservationUncertainty::PATH_COVERAGE,
+        hint: None,
+    }
+}
+
+fn relative_path(
+    source_root: &Path,
+    path: PathBuf,
+) -> Result<Option<PathBuf>, CaptureAdmissionError> {
+    let relative = path
+        .strip_prefix(source_root)
+        .map_err(|_| CaptureAdmissionError::PathOutsideSourceRoot { path: path.clone() })?
+        .to_path_buf();
+    if relative
+        .components()
+        .all(|component| matches!(component, Component::CurDir))
+    {
+        return Ok(None);
+    }
+    RootRelativePath::try_from_path(relative.clone())
+        .map(RootRelativePath::into_path)
+        .map(Some)
+        .map_err(|error| CaptureAdmissionError::InvalidRelativePath { path, error })
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_CAPTURE_METADATA_BYTES, MAX_CAPTURE_PATH_BYTES, MAX_CAPTURE_PATHS,
-        SourceWatcherCapture, capture_event,
+        CaptureAdmissionError, MAX_CAPTURE_METADATA_BYTES, MAX_CAPTURE_PATH_BYTES,
+        MAX_CAPTURE_PATHS, RAW_PATH_ROLE_AND_HINT_METADATA_BYTES, SourceWatcherCapture,
+        capture_event, capture_to_observation_batch, event_observation_with_metadata,
+        event_to_observation_batch, observation_metadata_from_values,
     };
-    use notify::event::EventAttributes;
+    use notify::event::{
+        AccessKind, AccessMode, CreateKind, DataChange, EventAttributes, Flag, ModifyKind,
+        RemoveKind, RenameMode,
+    };
     use notify::{Event, EventKind};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+    use wavecrate::sample_sources::SourceId;
+    use wavecrate_library::sample_sources::reconciliation::{
+        CaptureBoundary, ObservationUncertainty, RawEventKind, RawObservationEnvelope, RawPathHint,
+        RawPathRole, RootIdentity, RootRelativePathError, WatcherGeneration,
+    };
+
+    fn boundary() -> CaptureBoundary {
+        CaptureBoundary::try_new(123, None, None).expect("capture boundary")
+    }
+
+    fn event_at_raw_metadata_boundary(metadata_bytes: usize) -> Event {
+        let fixed_metadata_bytes = 1usize
+            .checked_add(std::mem::size_of::<u16>())
+            .and_then(|bytes| bytes.checked_add(RAW_PATH_ROLE_AND_HINT_METADATA_BYTES))
+            .and_then(|bytes| bytes.checked_add(std::mem::size_of::<u64>()))
+            .and_then(|bytes| bytes.checked_add(std::mem::size_of::<u64>()))
+            .and_then(|bytes| bytes.checked_add(std::mem::size_of::<u32>()))
+            .expect("fixed metadata bytes");
+        let info_bytes = metadata_bytes
+            .checked_sub(fixed_metadata_bytes)
+            .expect("metadata boundary has room for fixed fields");
+
+        let mut attrs = EventAttributes::new();
+        attrs.set_flag(Flag::Rescan);
+        attrs.set_tracker(73);
+        attrs.set_info(&"i".repeat(info_bytes));
+        attrs.set_process_id(42);
+        Event {
+            kind: EventKind::Create(CreateKind::Folder),
+            paths: vec![PathBuf::from("source-root/folder")],
+            attrs,
+        }
+    }
+
+    fn event(kind: EventKind, root: &Path, names: &[&str]) -> Event {
+        Event {
+            kind,
+            paths: names.iter().map(|name| root.join(name)).collect(),
+            attrs: EventAttributes::default(),
+        }
+    }
+
+    fn observation(
+        event: Event,
+        root: &Path,
+    ) -> wavecrate_library::sample_sources::reconciliation::RawObservation {
+        event_to_observation_batch(
+            event,
+            root,
+            SourceId::from_string("capture-test-source"),
+            RootIdentity::from_bytes(b"root".to_vec()),
+            7,
+            WatcherGeneration::new(3),
+            boundary(),
+        )
+        .expect("observation batch")
+        .observations()[0]
+            .clone()
+    }
 
     #[test]
     fn accepted_event_preserves_kind_paths_and_attributes() {
@@ -152,6 +689,39 @@ mod tests {
     }
 
     #[test]
+    fn metadata_boundary_includes_path_and_optional_raw_overhead() {
+        let accepted = event_at_raw_metadata_boundary(MAX_CAPTURE_METADATA_BYTES);
+        assert!(matches!(
+            capture_event(Ok(accepted)),
+            SourceWatcherCapture::Notify { .. }
+        ));
+
+        let accepted_batch = event_to_observation_batch(
+            event_at_raw_metadata_boundary(MAX_CAPTURE_METADATA_BYTES),
+            Path::new("source-root"),
+            SourceId::from_string("capture-test-source"),
+            RootIdentity::from_bytes(b"root".to_vec()),
+            7,
+            WatcherGeneration::new(3),
+            boundary(),
+        )
+        .expect("accepted boundary event");
+        let (provenance, observations, limits) = accepted_batch.into_parts();
+        let envelope = RawObservationEnvelope::try_new(provenance, observations, limits)
+            .expect("boundary event fits the raw envelope");
+        assert_eq!(
+            envelope.accounting().metadata_bytes(),
+            MAX_CAPTURE_METADATA_BYTES
+        );
+
+        let rejected = event_at_raw_metadata_boundary(MAX_CAPTURE_METADATA_BYTES + 1);
+        assert!(matches!(
+            capture_event(Ok(rejected)),
+            SourceWatcherCapture::Overflow { .. }
+        ));
+    }
+
+    #[test]
     fn notify_error_is_reduced_to_a_bounded_marker() {
         let error = notify::Error::generic(&"x".repeat(MAX_CAPTURE_METADATA_BYTES + 1))
             .set_paths(vec![PathBuf::from("error-path")]);
@@ -160,5 +730,439 @@ mod tests {
             capture_event(Err(error)),
             SourceWatcherCapture::Error { .. }
         ));
+    }
+
+    #[test]
+    fn notify_kinds_map_to_conservative_raw_kinds_and_roles() {
+        let root = Path::new("source-root");
+
+        let created_folder = observation(
+            event(EventKind::Create(CreateKind::Folder), root, &["folder"]),
+            root,
+        );
+        assert_eq!(created_folder.kind(), RawEventKind::Create);
+        assert_eq!(created_folder.paths()[0].role(), RawPathRole::Subject);
+        assert_eq!(
+            created_folder.paths()[0].hint(),
+            Some(RawPathHint::Directory)
+        );
+
+        let modified = observation(
+            event(
+                EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+                root,
+                &["sample.wav"],
+            ),
+            root,
+        );
+        assert_eq!(modified.kind(), RawEventKind::Modify);
+        assert_eq!(modified.paths()[0].role(), RawPathRole::Subject);
+
+        let removed_folder = observation(
+            event(EventKind::Remove(RemoveKind::Folder), root, &["folder"]),
+            root,
+        );
+        assert_eq!(removed_folder.kind(), RawEventKind::Delete);
+        assert_eq!(
+            removed_folder.paths()[0].hint(),
+            Some(RawPathHint::Directory)
+        );
+
+        let renamed = observation(
+            event(
+                EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+                root,
+                &["old.wav", "new.wav"],
+            ),
+            root,
+        );
+        assert_eq!(renamed.kind(), RawEventKind::Rename);
+        assert_eq!(
+            renamed
+                .paths()
+                .iter()
+                .map(|path| path.role())
+                .collect::<Vec<_>>(),
+            vec![RawPathRole::RenameSource, RawPathRole::RenameDestination]
+        );
+        assert!(renamed.uncertainty().is_empty());
+
+        let incomplete_rename = observation(
+            event(
+                EventKind::Modify(ModifyKind::Name(RenameMode::From)),
+                root,
+                &["old.wav"],
+            ),
+            root,
+        );
+        assert_eq!(incomplete_rename.kind(), RawEventKind::Rename);
+        assert_eq!(
+            incomplete_rename.paths()[0].role(),
+            RawPathRole::RenameSource
+        );
+        assert!(
+            incomplete_rename
+                .uncertainty()
+                .contains(ObservationUncertainty::PATH_COVERAGE)
+        );
+
+        let ambiguous_rename = observation(
+            event(
+                EventKind::Modify(ModifyKind::Name(RenameMode::Any)),
+                root,
+                &["one.wav", "two.wav"],
+            ),
+            root,
+        );
+        assert_eq!(ambiguous_rename.kind(), RawEventKind::Rename);
+        assert!(
+            ambiguous_rename
+                .paths()
+                .iter()
+                .all(|path| path.role() == RawPathRole::Subject)
+        );
+        assert!(
+            ambiguous_rename
+                .uncertainty()
+                .contains(ObservationUncertainty::PATH_COVERAGE)
+        );
+
+        let unsupported = observation(
+            event(
+                EventKind::Access(AccessKind::Open(AccessMode::Write)),
+                root,
+                &["sample.wav"],
+            ),
+            root,
+        );
+        assert_eq!(unsupported.kind(), RawEventKind::Unsupported);
+        assert!(
+            unsupported
+                .uncertainty()
+                .contains(ObservationUncertainty::PATH_COVERAGE)
+        );
+
+        let unsupported_modify = observation(
+            event(EventKind::Modify(ModifyKind::Other), root, &["sample.wav"]),
+            root,
+        );
+        assert_eq!(unsupported_modify.kind(), RawEventKind::Unsupported);
+    }
+
+    #[test]
+    fn relative_conversion_preserves_event_order_and_duplicate_paths() {
+        let root = Path::new("source-root");
+        let paths = vec![
+            root.join("third.wav"),
+            root.join("first.wav"),
+            root.join("first.wav"),
+        ];
+        let observed = observation(
+            Event {
+                kind: EventKind::Modify(ModifyKind::Data(DataChange::Any)),
+                paths,
+                attrs: EventAttributes::default(),
+            },
+            root,
+        );
+
+        assert_eq!(
+            observed
+                .paths()
+                .iter()
+                .map(|path| path.path())
+                .collect::<Vec<_>>(),
+            vec![
+                Path::new("third.wav"),
+                Path::new("first.wav"),
+                Path::new("first.wav")
+            ]
+        );
+    }
+
+    #[test]
+    fn notify_metadata_is_retained_on_path_and_root_observations() {
+        let root = Path::new("source-root");
+        let mut attrs = EventAttributes::new();
+        attrs.set_flag(Flag::Rescan);
+        attrs.set_tracker(73);
+        attrs.set_info("capture metadata");
+        attrs.set_process_id(42);
+        let metadata = observation_metadata_from_values(
+            attrs.flag(),
+            attrs.tracker(),
+            attrs.info(),
+            Some("notify backend"),
+            attrs.process_id(),
+        )
+        .expect("metadata");
+        let path_observation = event_observation_with_metadata(
+            Event {
+                kind: EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+                paths: vec![root.join("sample.wav")],
+                attrs: attrs.clone(),
+            },
+            root,
+            metadata.clone(),
+            true,
+        )
+        .expect("path observation");
+        assert_eq!(path_observation.metadata().flags(), 1);
+        assert_eq!(path_observation.metadata().rename_cookie(), Some(73));
+        assert_eq!(
+            path_observation
+                .metadata()
+                .detail()
+                .and_then(|detail| detail.to_str()),
+            Some("capture metadata")
+        );
+        assert_eq!(
+            path_observation
+                .metadata()
+                .source()
+                .and_then(|source| source.to_str()),
+            Some("notify backend")
+        );
+        assert_eq!(path_observation.metadata().process_id(), Some(42));
+        assert_eq!(path_observation.paths()[0].path(), Path::new("sample.wav"));
+
+        let root_observation = event_observation_with_metadata(
+            Event {
+                kind: EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+                paths: vec![root.to_path_buf()],
+                attrs: attrs.clone(),
+            },
+            root,
+            metadata,
+            true,
+        )
+        .expect("root observation");
+        assert_eq!(root_observation.kind(), RawEventKind::RootChanged);
+        assert_eq!(root_observation.metadata().flags(), 1);
+        assert_eq!(root_observation.metadata().rename_cookie(), Some(73));
+        assert_eq!(
+            root_observation
+                .metadata()
+                .detail()
+                .and_then(|detail| detail.to_str()),
+            Some("capture metadata")
+        );
+        assert_eq!(
+            root_observation
+                .metadata()
+                .source()
+                .and_then(|source| source.to_str()),
+            Some("notify backend")
+        );
+        assert_eq!(root_observation.metadata().process_id(), Some(42));
+
+        let callback_batch = event_to_observation_batch(
+            Event {
+                kind: EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+                paths: vec![root.join("sample.wav")],
+                attrs,
+            },
+            root,
+            SourceId::from_string("capture-metadata-source"),
+            RootIdentity::from_bytes(b"root".to_vec()),
+            7,
+            WatcherGeneration::new(3),
+            boundary(),
+        )
+        .expect("callback observation");
+        let callback_observation = &callback_batch.observations()[0];
+        assert_eq!(callback_observation.metadata().flags(), 1);
+        assert_eq!(callback_observation.metadata().rename_cookie(), Some(73));
+        assert_eq!(
+            callback_observation
+                .metadata()
+                .detail()
+                .and_then(|detail| detail.to_str()),
+            Some("capture metadata")
+        );
+        assert_eq!(callback_observation.metadata().process_id(), Some(42));
+        assert_eq!(
+            callback_batch
+                .provenance()
+                .capture_boundary()
+                .first_sequence(),
+            None
+        );
+        assert_eq!(
+            callback_batch
+                .provenance()
+                .capture_boundary()
+                .last_sequence(),
+            None
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_conversion_preserves_non_utf8_path_bytes() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let root = Path::new("source-root");
+        let name = OsString::from_vec(vec![b'c', b'u', b't', 0xff, b'.', b'w', b'a', b'v']);
+        let mut path = root.to_path_buf();
+        path.push(&name);
+        let observed = observation(
+            Event {
+                kind: EventKind::Create(CreateKind::File),
+                paths: vec![path],
+                attrs: EventAttributes::default(),
+            },
+            root,
+        );
+
+        assert_eq!(
+            observed.paths()[0].path().as_os_str().as_encoded_bytes(),
+            b"cut\xff.wav"
+        );
+    }
+
+    #[test]
+    fn paths_outside_or_traversing_the_source_root_are_rejected() {
+        let root = Path::new("source-root");
+        let outside = PathBuf::from("other-root/sample.wav");
+        let outside_result = event_to_observation_batch(
+            Event {
+                kind: EventKind::Create(CreateKind::File),
+                paths: vec![outside.clone()],
+                attrs: EventAttributes::default(),
+            },
+            root,
+            SourceId::from_string("capture-test-source"),
+            RootIdentity::from_bytes(b"root".to_vec()),
+            7,
+            WatcherGeneration::new(3),
+            boundary(),
+        );
+        assert_eq!(
+            outside_result,
+            Err(CaptureAdmissionError::PathOutsideSourceRoot { path: outside })
+        );
+
+        let traversal = root.join("../escape.wav");
+        let traversal_result = event_to_observation_batch(
+            Event {
+                kind: EventKind::Create(CreateKind::File),
+                paths: vec![traversal.clone()],
+                attrs: EventAttributes::default(),
+            },
+            root,
+            SourceId::from_string("capture-test-source"),
+            RootIdentity::from_bytes(b"root".to_vec()),
+            7,
+            WatcherGeneration::new(3),
+            boundary(),
+        );
+        assert_eq!(
+            traversal_result,
+            Err(CaptureAdmissionError::InvalidRelativePath {
+                path: traversal,
+                error: RootRelativePathError::ParentTraversal,
+            })
+        );
+    }
+
+    #[test]
+    fn overflow_and_error_captures_become_bounded_uncertainty_markers() {
+        let root = Path::new("source-root");
+        let overflow = capture_to_observation_batch(
+            SourceWatcherCapture::Overflow { stream_id: 41 },
+            root,
+            SourceId::from_string("capture-test-source"),
+            RootIdentity::from_bytes(b"root".to_vec()),
+            WatcherGeneration::new(3),
+            boundary(),
+        )
+        .expect("overflow marker batch");
+        assert_eq!(overflow.observations()[0].kind(), RawEventKind::Overflow);
+        assert!(
+            overflow.observations()[0]
+                .uncertainty()
+                .contains(ObservationUncertainty::OVERFLOW)
+        );
+        assert!(overflow.observations()[0].paths().is_empty());
+
+        let error = capture_to_observation_batch(
+            SourceWatcherCapture::Error { stream_id: 41 },
+            root,
+            SourceId::from_string("capture-test-source"),
+            RootIdentity::from_bytes(b"root".to_vec()),
+            WatcherGeneration::new(3),
+            boundary(),
+        )
+        .expect("error marker batch");
+        assert_eq!(error.observations()[0].kind(), RawEventKind::Error);
+        assert!(
+            error.observations()[0]
+                .uncertainty()
+                .contains(ObservationUncertainty::BACKEND_ERROR)
+        );
+        assert!(error.observations()[0].paths().is_empty());
+
+        let oversized = Event {
+            kind: EventKind::Any,
+            paths: (0..=MAX_CAPTURE_PATHS)
+                .map(|index| root.join(format!("{index}.wav")))
+                .collect(),
+            attrs: EventAttributes::default(),
+        };
+        let oversized_batch = event_to_observation_batch(
+            oversized,
+            root,
+            SourceId::from_string("capture-test-source"),
+            RootIdentity::from_bytes(b"root".to_vec()),
+            41,
+            WatcherGeneration::new(3),
+            boundary(),
+        )
+        .expect("oversized event marker batch");
+        assert_eq!(
+            oversized_batch.observations()[0].kind(),
+            RawEventKind::Overflow
+        );
+    }
+
+    #[test]
+    fn batch_provenance_retains_supplied_identity_and_capture_boundary() {
+        let root = Path::new("source-root");
+        let capture_boundary =
+            CaptureBoundary::try_new(9_001, Some(12), Some(13)).expect("capture boundary");
+        let stream_id = 0x0102_0304_0506_0708;
+        let batch = event_to_observation_batch(
+            event(EventKind::Create(CreateKind::File), root, &["sample.wav"]),
+            root,
+            SourceId::from_string("exact-source"),
+            RootIdentity::from_bytes(vec![0, 0xff, 7]),
+            stream_id,
+            WatcherGeneration::new(44),
+            capture_boundary,
+        )
+        .expect("provenance batch");
+        let provenance = batch.provenance();
+
+        assert_eq!(provenance.source_id().as_str(), "exact-source");
+        assert_eq!(
+            provenance
+                .root_identity()
+                .expect("root identity")
+                .as_bytes(),
+            &[0, 0xff, 7]
+        );
+        assert_eq!(
+            provenance
+                .backend_stream_identity()
+                .expect("stream identity")
+                .as_bytes(),
+            &stream_id.to_be_bytes()
+        );
+        assert_eq!(provenance.watcher_generation(), WatcherGeneration::new(44));
+        assert_eq!(provenance.capture_boundary(), capture_boundary);
+        assert_eq!(capture_boundary.captured_at(), 9_001);
+        assert_eq!(capture_boundary.first_sequence(), Some(12));
+        assert_eq!(capture_boundary.last_sequence(), Some(13));
     }
 }

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -13,7 +13,8 @@ use std::{
 use wavecrate::sample_sources::{SampleSource, SourceId};
 use wavecrate_library::sample_sources::reconciliation::{
     AdmissionOutcome, BackendStreamIdentity, CaptureBoundary, DispatchTicket, LiveAuditCorrelation,
-    ReconciliationLifecycle, ReconciliationScopeKind, RootIdentity, WatcherGeneration,
+    ReconciliationLifecycle, ReconciliationScopeKind, RootIdentity, SourceAuditReceipt,
+    WatcherGeneration,
 };
 
 use super::admission_lifecycle::AdmissionLifecycle;
@@ -350,6 +351,15 @@ impl GuiSourceWatcherHandle {
             });
     }
 
+    pub(in crate::native_app) fn acknowledge_source_audit_receipt(
+        &self,
+        receipt: SourceAuditReceipt,
+    ) {
+        let _ = self
+            .command_tx
+            .send(GuiSourceWatchCommand::AcknowledgeSourceAuditReceipt { receipt });
+    }
+
     #[cfg(test)]
     pub(in crate::native_app) fn request_full_reconciliation(&self) {
         let _ = self
@@ -436,6 +446,9 @@ enum GuiSourceWatchCommand {
         source_id: SourceId,
         echoes: Vec<CommittedWatcherEcho>,
         cursor: RevisionFirstCursor,
+    },
+    AcknowledgeSourceAuditReceipt {
+        receipt: SourceAuditReceipt,
     },
     FinishJournalBarrierAudit {
         source_id: String,
@@ -530,6 +543,15 @@ fn run_source_watcher(
                     &echoes,
                     cursor,
                     Instant::now(),
+                );
+            }
+            Ok(GuiSourceWatchCommand::AcknowledgeSourceAuditReceipt { receipt }) => {
+                let outcome = admission_lifecycle.acknowledge_source_audit_receipt(&receipt);
+                tracing::debug!(
+                    cleared_markers = outcome.cleared_markers(),
+                    remaining_markers = outcome.remaining_markers(),
+                    complete = receipt.is_complete(),
+                    "Applied source manifest audit receipt to retained watcher uncertainty"
                 );
             }
             Ok(GuiSourceWatchCommand::FinishJournalBarrierAudit {
@@ -964,6 +986,7 @@ fn run_source_watcher(
             &mut pending_capture_contexts,
             now,
         );
+        flush_pending_audit_requests(&mut state, &message_tx);
 
         if watcher_failed || root_invalidated {
             fence_watcher_admission(&mut admission_lifecycle, "watcher capture retirement");
@@ -1381,8 +1404,13 @@ fn handoff_dispatched_capture(
             .scopes()
             .iter()
             .any(|scope| scope.kind() == ReconciliationScopeKind::SourceAudit);
-    if source_audit {
+    if source_audit || context.correlation.is_some() {
         widen_source(state, &context.source_root, now);
+        if let Some(correlation) = context.correlation.as_ref() {
+            state
+                .pending_audit_requests
+                .push(correlation.audit_request());
+        }
         return (true, false);
     }
 
@@ -1493,9 +1521,20 @@ fn dispatch_pending_capture_contexts(
             pending_contexts.insert(ticket, context);
             break;
         }
-        let _correlation = context.correlation;
     }
     root_invalidated
+}
+
+fn flush_pending_audit_requests(state: &mut GuiSourceWatchState, message_tx: &Sender<GuiMessage>) {
+    for request in state.pending_audit_requests.drain(..) {
+        if message_tx
+            .send(GuiMessage::SourceWatcherManifestAuditRequested { request })
+            .is_err()
+        {
+            tracing::warn!("Source-processing request channel closed before live audit handoff");
+            break;
+        }
+    }
 }
 
 fn drain_watcher_captures(
@@ -2478,6 +2517,18 @@ mod lifecycle_tests {
         assert_eq!(marker.capture_boundary(), Some(boundary));
         assert_eq!(marker.scope(), ReconciliationScopeKind::SourceAudit);
         assert!(marker.reasons().contains(&UncertaintyReason::LiveUnproven));
+        let request = state
+            .pending_audit_requests
+            .pop()
+            .expect("proofless handoff audit request");
+        assert_eq!(request.source_id(), &source.id);
+        assert_eq!(request.root_identity(), &expected_root_identity);
+        assert_eq!(request.generation(), expected_generation);
+        assert_eq!(request.boundary(), marker.boundary());
+        let receipt = request.complete(42, expected_root_identity);
+        let acknowledgement = admission.acknowledge_source_audit_receipt(&receipt);
+        assert_eq!(acknowledgement.cleared_markers(), 1);
+        assert_eq!(admission.retained_uncertainties().len(), 0);
         assert_eq!(
             state
                 .pending

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -489,6 +489,7 @@ fn run_source_watcher(
     let mut state = GuiSourceWatchState::default();
     state.set_sources(initial_sources);
     let mut admission_lifecycle = AdmissionLifecycle::new();
+    state.set_audit_request_capacity(admission_lifecycle.max_source_audit_request_entries());
     let mut pending_capture_contexts = HashMap::<DispatchTicket, PendingCaptureContext>::new();
     let mut next_restart = Instant::now();
     let mut restart_delay = WATCHER_RESTART_MIN;
@@ -986,7 +987,7 @@ fn run_source_watcher(
             &mut pending_capture_contexts,
             now,
         );
-        flush_pending_audit_requests(&mut state, &message_tx);
+        flush_pending_audit_requests(&mut state, &message_tx, now);
 
         if watcher_failed || root_invalidated {
             fence_watcher_admission(&mut admission_lifecycle, "watcher capture retirement");
@@ -1258,8 +1259,10 @@ fn admit_capture_target(
         .max_in_flight()
         .min(super::MAX_PENDING_CAPTURE_CONTEXTS);
     if pending_contexts.len() >= context_limit {
-        if let Some(request) = admission.source_audit_request_for_current_lane(&target.source_id) {
-            state.pending_audit_requests.push(request);
+        if let Some((request, marker_backed)) =
+            admission.source_audit_request_for_current_lane(&target.source_id)
+        {
+            state.enqueue_audit_request(request, marker_backed);
         }
         tracing::warn!(
             source_id = target.source_id.as_str(),
@@ -1319,10 +1322,13 @@ fn admit_capture_target(
     let outcome = live.admission().outcome().clone();
     let audit_request_to_queue = match &outcome {
         AdmissionOutcome::Accepted(_) if live.correlation().is_some() => None,
-        _ => live.audit_request().cloned(),
+        _ => live.audit_request().cloned().map(|request| {
+            let marker_backed = admission.source_audit_request_is_marker_backed(&request);
+            (request, marker_backed)
+        }),
     };
-    if let Some(request) = audit_request_to_queue {
-        state.pending_audit_requests.push(request);
+    if let Some((request, marker_backed)) = audit_request_to_queue {
+        state.enqueue_audit_request(request, marker_backed);
     }
     match outcome {
         AdmissionOutcome::Accepted(ticket) => {
@@ -1417,9 +1423,7 @@ fn handoff_dispatched_capture(
     if source_audit || context.correlation.is_some() {
         widen_source(state, &context.source_root, now);
         if let Some(correlation) = context.correlation.as_ref() {
-            state
-                .pending_audit_requests
-                .push(correlation.audit_request());
+            state.enqueue_audit_request(correlation.audit_request(), true);
         }
         return (true, false);
     }
@@ -1535,8 +1539,18 @@ fn dispatch_pending_capture_contexts(
     root_invalidated
 }
 
-fn flush_pending_audit_requests(state: &mut GuiSourceWatchState, message_tx: &Sender<GuiMessage>) {
-    for request in state.pending_audit_requests.drain(..) {
+fn flush_pending_audit_requests(
+    state: &mut GuiSourceWatchState,
+    message_tx: &Sender<GuiMessage>,
+    now: Instant,
+) {
+    if state.pending_audit_requests.conservative_recovery_latched() {
+        state.mark_all_overflowed(now);
+        state
+            .pending_audit_requests
+            .clear_conservative_recovery_latch();
+    }
+    while let Some(request) = state.pending_audit_requests.front().cloned() {
         if message_tx
             .send(GuiMessage::SourceWatcherManifestAuditRequested { request })
             .is_err()
@@ -1544,6 +1558,7 @@ fn flush_pending_audit_requests(state: &mut GuiSourceWatchState, message_tx: &Se
             tracing::warn!("Source-processing request channel closed before live audit handoff");
             break;
         }
+        state.pending_audit_requests.pop_front();
     }
 }
 
@@ -2465,6 +2480,7 @@ mod lifecycle_tests {
         let source = source_with_root("identity-bound", directory.path());
         let mut state = source_watcher_state(vec![source.clone()]);
         let mut admission = configured_admission(&state.sources);
+        state.set_audit_request_capacity(admission.max_source_audit_request_entries());
         let capture = notify_capture(directory.path(), 17, &["sample.wav"]);
         let boundary = exact_boundary(77);
         let mut targets = source_capture_targets(&capture, &state.sources);
@@ -2530,7 +2546,7 @@ mod lifecycle_tests {
         assert!(marker.reasons().contains(&UncertaintyReason::LiveUnproven));
         let request = state
             .pending_audit_requests
-            .pop()
+            .pop_front()
             .expect("proofless handoff audit request");
         assert_eq!(request.source_id(), &source.id);
         assert_eq!(request.root_identity(), &expected_root_identity);
@@ -2546,6 +2562,100 @@ mod lifecycle_tests {
             [Path::new("sample.wav").to_path_buf()]
                 .into_iter()
                 .collect()
+        );
+    }
+
+    #[test]
+    fn audit_request_queue_coalesces_identity_and_latches_on_fallback_overflow() {
+        let first_directory = tempfile::tempdir().expect("first source root");
+        let second_directory = tempfile::tempdir().expect("second source root");
+        let first = source_with_root("queue-first", first_directory.path());
+        let second = source_with_root("queue-second", second_directory.path());
+        let sources = vec![first.clone(), second.clone()];
+        let mut state = source_watcher_state(sources.clone());
+        let mut admission = limited_admission(&sources, 1);
+        state.set_audit_request_capacity(1);
+        let mut pending_contexts = HashMap::new();
+
+        let capture = notify_capture(&first.root, 301, &["first.wav"]);
+        let target = source_capture_targets(&capture, &state.sources)
+            .pop()
+            .expect("first source target");
+        admit_capture_target(
+            &mut state,
+            &mut admission,
+            &capture,
+            exact_boundary(301),
+            target,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        dispatch_pending_capture_contexts(
+            &mut state,
+            &mut admission,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        state.pending_audit_requests.clear();
+
+        let (first_request, marker_backed) = admission
+            .source_audit_request_for_current_lane(&first.id)
+            .expect("first source audit request");
+        assert!(marker_backed);
+        state.enqueue_audit_request(first_request.clone(), true);
+        assert_eq!(state.pending_audit_requests.len(), 1);
+        assert_eq!(
+            state
+                .pending_audit_requests
+                .front()
+                .expect("first queued request")
+                .identity(),
+            first_request.identity()
+        );
+
+        let capture = notify_capture(&first.root, 301, &["second.wav"]);
+        let target = source_capture_targets(&capture, &state.sources)
+            .pop()
+            .expect("second source target");
+        admit_capture_target(
+            &mut state,
+            &mut admission,
+            &capture,
+            exact_boundary(302),
+            target,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        let (covering_request, marker_backed) = admission
+            .source_audit_request_for_current_lane(&first.id)
+            .expect("covering source audit request");
+        assert!(marker_backed);
+        assert_eq!(covering_request.identity(), first_request.identity());
+        assert!(covering_request.boundary().covers(first_request.boundary()));
+        state.enqueue_audit_request(covering_request.clone(), true);
+        assert_eq!(state.pending_audit_requests.len(), 1);
+        let queued = state
+            .pending_audit_requests
+            .front()
+            .expect("coalesced request");
+        assert_eq!(queued.identity(), first_request.identity());
+        assert_eq!(queued.boundary(), covering_request.boundary());
+
+        let (fallback_request, marker_backed) = admission
+            .source_audit_request_for_current_lane(&second.id)
+            .expect("second source audit request");
+        assert!(!marker_backed);
+        assert_ne!(fallback_request.identity(), first_request.identity());
+        state.enqueue_audit_request(fallback_request, false);
+        assert!(state.pending_audit_requests.len() <= 1);
+        assert!(state.pending_audit_requests.conservative_recovery_latched());
+        assert_eq!(
+            state
+                .pending_audit_requests
+                .front()
+                .expect("marker-backed request retained")
+                .identity(),
+            first_request.identity()
         );
     }
 
@@ -2716,6 +2826,7 @@ mod lifecycle_tests {
         let overflow_source = sources.last().cloned().expect("overflow source");
         let mut state = source_watcher_state(sources.clone());
         let mut admission = configured_admission(&sources);
+        state.set_audit_request_capacity(admission.max_source_audit_request_entries());
         let mut pending_contexts = HashMap::new();
 
         for (index, source) in sources
@@ -2778,7 +2889,7 @@ mod lifecycle_tests {
         );
         let request = state
             .pending_audit_requests
-            .first()
+            .front()
             .expect("full-context source audit request");
         assert_eq!(request.source_id(), &overflow_source.id);
         assert_eq!(request.root_identity(), lane.root_identity());

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -1484,11 +1484,11 @@ fn handoff_dispatched_capture(
             .scopes()
             .iter()
             .any(|scope| scope.kind() == ReconciliationScopeKind::SourceAudit);
-    if source_audit || context.correlation.is_some() {
+    if let Some(correlation) = context.correlation.as_ref() {
+        state.enqueue_audit_request(correlation.audit_request(), true);
+    }
+    if source_audit {
         widen_source(state, &context.source_root, now);
-        if let Some(correlation) = context.correlation.as_ref() {
-            state.enqueue_audit_request(correlation.audit_request(), true);
-        }
         return (true, false);
     }
 
@@ -2638,6 +2638,13 @@ mod lifecycle_tests {
             [Path::new("sample.wav").to_path_buf()]
                 .into_iter()
                 .collect()
+        );
+        assert!(
+            !state
+                .pending
+                .get(source.id.as_str())
+                .expect("compatibility refresh handoff")
+                .overflowed
         );
     }
 

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -1236,19 +1236,6 @@ fn admit_capture_target(
     pending_contexts: &mut HashMap<DispatchTicket, PendingCaptureContext>,
     now: Instant,
 ) {
-    let context_limit = admission
-        .max_in_flight()
-        .min(super::MAX_PENDING_CAPTURE_CONTEXTS);
-    if pending_contexts.len() >= context_limit {
-        tracing::warn!(
-            source_id = target.source_id.as_str(),
-            context_limit,
-            "Native watcher admission context pressure widened source"
-        );
-        widen_source(state, &target.source_root, now);
-        return;
-    }
-
     let Some(lane) = admission.lane_for_capture(&target.source_id) else {
         tracing::warn!(
             source_id = target.source_id.as_str(),
@@ -1262,6 +1249,22 @@ fn admit_capture_target(
             source_id = target.source_id.as_str(),
             generation = lane.generation().get(),
             "Native watcher capture arrived outside a capturing admission lane"
+        );
+        widen_source(state, &target.source_root, now);
+        return;
+    }
+
+    let context_limit = admission
+        .max_in_flight()
+        .min(super::MAX_PENDING_CAPTURE_CONTEXTS);
+    if pending_contexts.len() >= context_limit {
+        if let Some(request) = admission.source_audit_request_for_current_lane(&target.source_id) {
+            state.pending_audit_requests.push(request);
+        }
+        tracing::warn!(
+            source_id = target.source_id.as_str(),
+            context_limit,
+            "Native watcher admission context pressure widened source"
         );
         widen_source(state, &target.source_root, now);
         return;
@@ -1984,6 +1987,7 @@ pub(super) fn doubled_backoff(current: Duration) -> Duration {
 
 #[cfg(test)]
 mod lifecycle_tests {
+    use super::super::MAX_PENDING_CAPTURE_CONTEXTS;
     use super::super::capture::MAX_CAPTURE_PATHS;
     use super::*;
     use notify::{Event, EventKind, RecursiveMode, WatcherKind};
@@ -2690,6 +2694,151 @@ mod lifecycle_tests {
         dispatch_pending_capture_contexts(&mut state, &mut admission, &mut pending_contexts, now);
         assert_eq!(admission.in_flight(), 0);
         assert!(pending_contexts.is_empty());
+        assert!(
+            state
+                .pending
+                .get(source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        );
+    }
+
+    #[test]
+    fn full_context_capacity_queues_current_lane_audit_without_extra_ticket_or_context() {
+        let directory = tempfile::tempdir().expect("source root");
+        let sources = (0..=MAX_PENDING_CAPTURE_CONTEXTS)
+            .map(|index| {
+                source_with_root(
+                    &format!("full-context-{index}"),
+                    &directory.path().join(format!("source-{index}")),
+                )
+            })
+            .collect::<Vec<_>>();
+        let overflow_source = sources.last().cloned().expect("overflow source");
+        let mut state = source_watcher_state(sources.clone());
+        let mut admission = configured_admission(&sources);
+        let mut pending_contexts = HashMap::new();
+
+        for (index, source) in sources
+            .iter()
+            .take(MAX_PENDING_CAPTURE_CONTEXTS)
+            .enumerate()
+        {
+            let capture = notify_capture(&source.root, 101, &["sample.wav"]);
+            let target = SourceCaptureTarget {
+                source_id: source.id.clone(),
+                source_root: source.root.clone(),
+                paths: vec![source.root.join("sample.wav")],
+                conservative: false,
+            };
+            admit_capture_target(
+                &mut state,
+                &mut admission,
+                &capture,
+                exact_boundary(index as u64 + 1),
+                target,
+                &mut pending_contexts,
+                Instant::now(),
+            );
+        }
+
+        assert_eq!(pending_contexts.len(), MAX_PENDING_CAPTURE_CONTEXTS);
+        assert_eq!(admission.in_flight(), MAX_PENDING_CAPTURE_CONTEXTS);
+        assert_eq!(
+            admission.retained_uncertainties().len(),
+            MAX_PENDING_CAPTURE_CONTEXTS
+        );
+
+        let lane = admission
+            .lane_for_capture(&overflow_source.id)
+            .expect("overflow source lane");
+        state.pending_audit_requests.clear();
+        let capture = notify_capture(&overflow_source.root, 101, &["sample.wav"]);
+        let target = SourceCaptureTarget {
+            source_id: overflow_source.id.clone(),
+            source_root: overflow_source.root.clone(),
+            paths: vec![overflow_source.root.join("sample.wav")],
+            conservative: false,
+        };
+        admit_capture_target(
+            &mut state,
+            &mut admission,
+            &capture,
+            exact_boundary(258),
+            target,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+
+        assert_eq!(pending_contexts.len(), MAX_PENDING_CAPTURE_CONTEXTS);
+        assert_eq!(admission.in_flight(), MAX_PENDING_CAPTURE_CONTEXTS);
+        assert_eq!(
+            admission.retained_uncertainties().len(),
+            MAX_PENDING_CAPTURE_CONTEXTS,
+            "full-context widening must not retain another marker"
+        );
+        let request = state
+            .pending_audit_requests
+            .first()
+            .expect("full-context source audit request");
+        assert_eq!(request.source_id(), &overflow_source.id);
+        assert_eq!(request.root_identity(), lane.root_identity());
+        assert_eq!(request.generation(), lane.generation());
+        assert!(request.boundary().first() > 0);
+        assert_eq!(request.boundary().first(), request.boundary().through());
+        assert!(
+            state
+                .pending
+                .get(overflow_source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        );
+    }
+
+    #[test]
+    fn full_context_stopped_lane_widens_without_typed_request() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = source_with_root("full-context-stopped", directory.path());
+        let mut state = source_watcher_state(vec![source.clone()]);
+        let mut admission = limited_admission(&state.sources, 1);
+        let capture = notify_capture(directory.path(), 102, &["first.wav"]);
+        let target = SourceCaptureTarget {
+            source_id: source.id.clone(),
+            source_root: source.root.clone(),
+            paths: vec![source.root.join("first.wav")],
+            conservative: false,
+        };
+        let mut pending_contexts = HashMap::new();
+        admit_capture_target(
+            &mut state,
+            &mut admission,
+            &capture,
+            exact_boundary(259),
+            target,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        assert_eq!(pending_contexts.len(), 1);
+        admission.fence_all().expect("stop capturing lane");
+        state.pending_audit_requests.clear();
+
+        let capture = notify_capture(directory.path(), 102, &["second.wav"]);
+        let target = SourceCaptureTarget {
+            source_id: source.id.clone(),
+            source_root: source.root.clone(),
+            paths: vec![source.root.join("second.wav")],
+            conservative: false,
+        };
+        admit_capture_target(
+            &mut state,
+            &mut admission,
+            &capture,
+            exact_boundary(260),
+            target,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+
+        assert!(state.pending_audit_requests.is_empty());
+        assert_eq!(pending_contexts.len(), 1);
         assert!(
             state
                 .pending

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -1,6 +1,4 @@
-#[cfg(test)]
-use notify::EventKind;
-use notify::{Config, Event, EventHandler, PollWatcher, Watcher};
+use notify::{Config, Event, EventHandler, EventKind, PollWatcher, Watcher};
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
@@ -13,9 +11,13 @@ use std::{
     time::{Duration, Instant},
 };
 use wavecrate::sample_sources::{SampleSource, SourceId};
+use wavecrate_library::sample_sources::reconciliation::{
+    AdmissionOutcome, BackendStreamIdentity, CaptureBoundary, DispatchTicket, LiveAuditCorrelation,
+    ReconciliationLifecycle, ReconciliationScopeKind, RootIdentity, WatcherGeneration,
+};
 
 use super::admission_lifecycle::AdmissionLifecycle;
-use super::capture::{SourceWatcherCapture, capture_event};
+use super::capture::{SourceWatcherCapture, capture_event, capture_to_observation_batch};
 use super::classification::retain_source_refresh_candidates;
 use super::journal::{self, JournalRecovery};
 use super::roots::{
@@ -43,6 +45,36 @@ static NEXT_STREAM_ID: AtomicU64 = AtomicU64::new(1);
 
 fn next_stream_id() -> u64 {
     NEXT_STREAM_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+static NEXT_CAPTURE_BOUNDARY: AtomicU64 = AtomicU64::new(1);
+
+fn next_capture_boundary() -> CaptureBoundary {
+    let captured_at = NEXT_CAPTURE_BOUNDARY.fetch_add(1, Ordering::Relaxed);
+    // This process-local monotonic value is an opaque callback marker only. It is deliberately
+    // not copied into the optional backend sequence fields, which remain absent unless notify
+    // supplies real sequence or cookie evidence.
+    CaptureBoundary::try_new(captured_at, None, None).expect("capture boundary")
+}
+
+#[derive(Debug)]
+struct CapturedSourceWatcherCapture {
+    capture: SourceWatcherCapture,
+    boundary: CaptureBoundary,
+}
+
+impl CapturedSourceWatcherCapture {
+    fn from_capture(capture: SourceWatcherCapture) -> Self {
+        Self {
+            capture,
+            boundary: next_capture_boundary(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_boundary(capture: SourceWatcherCapture, boundary: CaptureBoundary) -> Self {
+        Self { capture, boundary }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -210,7 +242,7 @@ impl SourceWatcherTeardown {
 }
 
 struct SourceWatcherIngress {
-    event_tx: SyncSender<SourceWatcherCapture>,
+    event_tx: SyncSender<CapturedSourceWatcherCapture>,
     overflowed: Arc<AtomicBool>,
     enabled: Arc<AtomicBool>,
     stream_id: u64,
@@ -233,7 +265,10 @@ impl EventHandler for SourceWatcherIngress {
         if !self.enabled.load(Ordering::Acquire) {
             return;
         }
-        match self.event_tx.try_send(capture) {
+        match self
+            .event_tx
+            .try_send(CapturedSourceWatcherCapture::from_capture(capture))
+        {
             Ok(()) => {}
             Err(TrySendError::Full(_)) => {
                 self.overflowed.store(true, Ordering::Release);
@@ -429,7 +464,8 @@ fn run_source_watcher(
     initial_sources: Vec<SampleSource>,
     lifecycle_tx: Sender<SourceWatcherLifecycle>,
 ) {
-    let (event_tx, event_rx) = std::sync::mpsc::sync_channel(WATCHER_EVENT_QUEUE_CAPACITY);
+    let (event_tx, event_rx) =
+        std::sync::mpsc::sync_channel::<CapturedSourceWatcherCapture>(WATCHER_EVENT_QUEUE_CAPACITY);
     let ingress_overflowed = Arc::new(AtomicBool::new(false));
     let mut watcher = None;
     let mut pending_watcher = None;
@@ -440,6 +476,7 @@ fn run_source_watcher(
     let mut state = GuiSourceWatchState::default();
     state.set_sources(initial_sources);
     let mut admission_lifecycle = AdmissionLifecycle::new();
+    let mut pending_capture_contexts = HashMap::<DispatchTicket, PendingCaptureContext>::new();
     let mut next_restart = Instant::now();
     let mut restart_delay = WATCHER_RESTART_MIN;
     let mut next_root_refresh = Instant::now();
@@ -551,7 +588,7 @@ fn run_source_watcher(
                         SourceWatcherCapture::Overflow { stream_id }
                     }
                 };
-                match event_tx.try_send(capture) {
+                match event_tx.try_send(CapturedSourceWatcherCapture::from_capture(capture)) {
                     Ok(()) => {}
                     Err(TrySendError::Full(_)) => {
                         ingress_overflowed.store(true, Ordering::Release);
@@ -560,13 +597,15 @@ fn run_source_watcher(
                 }
             }
             #[cfg(test)]
-            Ok(GuiSourceWatchCommand::InjectCapture(capture)) => match event_tx.try_send(capture) {
-                Ok(()) => {}
-                Err(TrySendError::Full(_)) => {
-                    ingress_overflowed.store(true, Ordering::Release);
+            Ok(GuiSourceWatchCommand::InjectCapture(capture)) => {
+                match event_tx.try_send(CapturedSourceWatcherCapture::from_capture(capture)) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_)) => {
+                        ingress_overflowed.store(true, Ordering::Release);
+                    }
+                    Err(TrySendError::Disconnected(_)) => {}
                 }
-                Err(TrySendError::Disconnected(_)) => {}
-            },
+            }
             #[cfg(test)]
             Ok(GuiSourceWatchCommand::ReportWatcherLive(status_tx)) => {
                 let is_live = watcher
@@ -917,8 +956,14 @@ fn run_source_watcher(
             state.mark_all_overflowed(now);
         }
 
-        let (watcher_failed, root_invalidated) =
-            drain_watcher_captures(&mut state, watcher.as_ref(), &event_rx, now);
+        let (watcher_failed, root_invalidated) = drain_watcher_captures(
+            &mut state,
+            &mut admission_lifecycle,
+            watcher.as_ref(),
+            &event_rx,
+            &mut pending_capture_contexts,
+            now,
+        );
 
         if watcher_failed || root_invalidated {
             fence_watcher_admission(&mut admission_lifecycle, "watcher capture retirement");
@@ -1005,20 +1050,467 @@ fn reconcile_watcher_admission(
     }
 }
 
+struct SourceCaptureTarget {
+    source_id: SourceId,
+    source_root: PathBuf,
+    paths: Vec<PathBuf>,
+    conservative: bool,
+}
+
+struct PendingCaptureContext {
+    source_id: SourceId,
+    source_root: PathBuf,
+    root_identity: RootIdentity,
+    stream_id: u64,
+    watcher_generation: WatcherGeneration,
+    capture_boundary: CaptureBoundary,
+    original_event: Option<Event>,
+    compatibility_event: Option<Event>,
+    conservative: bool,
+    correlation: Option<LiveAuditCorrelation>,
+}
+
+fn capture_stream_id(capture: &SourceWatcherCapture) -> u64 {
+    match capture {
+        SourceWatcherCapture::Notify { stream_id, .. }
+        | SourceWatcherCapture::Error { stream_id }
+        | SourceWatcherCapture::Overflow { stream_id } => *stream_id,
+    }
+}
+
+fn source_capture_targets(
+    capture: &SourceWatcherCapture,
+    sources: &[SampleSource],
+) -> Vec<SourceCaptureTarget> {
+    let Some(event) = (match capture {
+        SourceWatcherCapture::Notify { event, .. } => Some(event),
+        SourceWatcherCapture::Error { .. } | SourceWatcherCapture::Overflow { .. } => None,
+    }) else {
+        return sources
+            .iter()
+            .map(|source| SourceCaptureTarget {
+                source_id: source.id.clone(),
+                source_root: source.root.clone(),
+                paths: Vec::new(),
+                conservative: true,
+            })
+            .collect();
+    };
+
+    if event.paths.is_empty() {
+        return sources
+            .iter()
+            .map(|source| SourceCaptureTarget {
+                source_id: source.id.clone(),
+                source_root: source.root.clone(),
+                paths: Vec::new(),
+                conservative: true,
+            })
+            .collect();
+    }
+
+    let mut targets = Vec::<SourceCaptureTarget>::new();
+    let mut ambiguous = false;
+    for path in &event.paths {
+        let mut matches = sources
+            .iter()
+            .filter(|source| path.starts_with(&source.root))
+            .collect::<Vec<_>>();
+        let deepest_root = matches
+            .iter()
+            .map(|source| source.root.components().count())
+            .max();
+        matches.retain(|source| Some(source.root.components().count()) == deepest_root);
+        if matches.is_empty() || matches.len() > 1 {
+            ambiguous = true;
+        }
+        for source in matches {
+            if let Some(target) = targets
+                .iter_mut()
+                .find(|target| target.source_id == source.id)
+            {
+                target.paths.push(path.clone());
+            } else {
+                targets.push(SourceCaptureTarget {
+                    source_id: source.id.clone(),
+                    source_root: source.root.clone(),
+                    paths: vec![path.clone()],
+                    conservative: false,
+                });
+            }
+        }
+    }
+
+    if ambiguous {
+        return sources
+            .iter()
+            .map(|source| SourceCaptureTarget {
+                source_id: source.id.clone(),
+                source_root: source.root.clone(),
+                paths: Vec::new(),
+                conservative: true,
+            })
+            .collect();
+    }
+    if targets.len() > 1 {
+        return targets
+            .into_iter()
+            .map(|target| SourceCaptureTarget {
+                source_id: target.source_id,
+                source_root: target.source_root,
+                paths: Vec::new(),
+                conservative: true,
+            })
+            .collect();
+    }
+    targets
+}
+
+fn capture_for_target(
+    capture: &SourceWatcherCapture,
+    target: &SourceCaptureTarget,
+) -> SourceWatcherCapture {
+    match capture {
+        SourceWatcherCapture::Notify { stream_id, event } => {
+            let event = if target.conservative {
+                let mut event = event.clone();
+                // Keep bounded callback attributes (including Rescan/tracker) while replacing
+                // path-bearing evidence with an explicit pathless observation. The normalizer
+                // widens this to SourceAudit, but the non-marker raw kind still receives a ticket
+                // so the exact original Event remains retained through handoff.
+                event.kind = EventKind::Create(notify::event::CreateKind::Any);
+                event.paths.clear();
+                event
+            } else {
+                let mut event = event.clone();
+                event.paths = target.paths.clone();
+                event
+            };
+            SourceWatcherCapture::Notify {
+                stream_id: *stream_id,
+                event,
+            }
+        }
+        SourceWatcherCapture::Error { stream_id } => SourceWatcherCapture::Error {
+            stream_id: *stream_id,
+        },
+        SourceWatcherCapture::Overflow { stream_id } => SourceWatcherCapture::Overflow {
+            stream_id: *stream_id,
+        },
+    }
+}
+
+fn widen_source(state: &mut GuiSourceWatchState, source_root: &PathBuf, now: Instant) {
+    state.mark_roots_overflowed(std::slice::from_ref(source_root), now);
+}
+
+fn admit_capture_target(
+    state: &mut GuiSourceWatchState,
+    admission: &mut AdmissionLifecycle,
+    capture: &SourceWatcherCapture,
+    boundary: CaptureBoundary,
+    target: SourceCaptureTarget,
+    pending_contexts: &mut HashMap<DispatchTicket, PendingCaptureContext>,
+    now: Instant,
+) {
+    let context_limit = admission
+        .max_in_flight()
+        .min(super::MAX_PENDING_CAPTURE_CONTEXTS);
+    if pending_contexts.len() >= context_limit {
+        tracing::warn!(
+            source_id = target.source_id.as_str(),
+            context_limit,
+            "Native watcher admission context pressure widened source"
+        );
+        widen_source(state, &target.source_root, now);
+        return;
+    }
+
+    let Some(lane) = admission.lane_for_capture(&target.source_id) else {
+        tracing::warn!(
+            source_id = target.source_id.as_str(),
+            "Native watcher capture had no identity-qualified admission lane"
+        );
+        widen_source(state, &target.source_root, now);
+        return;
+    };
+    if lane.lifecycle() != ReconciliationLifecycle::Capturing {
+        tracing::warn!(
+            source_id = target.source_id.as_str(),
+            generation = lane.generation().get(),
+            "Native watcher capture arrived outside a capturing admission lane"
+        );
+        widen_source(state, &target.source_root, now);
+        return;
+    }
+
+    let original_event = match capture {
+        SourceWatcherCapture::Notify { event, .. } => Some(event.clone()),
+        _ => None,
+    };
+    let compatibility_event = match capture {
+        SourceWatcherCapture::Notify { event, .. } if !target.conservative => {
+            let mut event = event.clone();
+            event.paths = target.paths.clone();
+            Some(event)
+        }
+        _ => None,
+    };
+    let stream_id = capture_stream_id(capture);
+    let capture = capture_for_target(capture, &target);
+    let batch = match capture_to_observation_batch(
+        capture,
+        &target.source_root,
+        target.source_id.clone(),
+        lane.root_identity().clone(),
+        lane.generation(),
+        boundary,
+    ) {
+        Ok(batch) => batch,
+        Err(error) => {
+            tracing::warn!(
+                source_id = target.source_id.as_str(),
+                ?error,
+                "Native watcher capture could not be mapped to a root-relative observation"
+            );
+            widen_source(state, &target.source_root, now);
+            return;
+        }
+    };
+
+    let live = match admission.admit_live_with_correlation(batch) {
+        Ok(live) => live,
+        Err(error) => {
+            tracing::warn!(
+                source_id = target.source_id.as_str(),
+                ?error,
+                "Native watcher live admission failed closed"
+            );
+            widen_source(state, &target.source_root, now);
+            return;
+        }
+    };
+    let outcome = live.admission().outcome().clone();
+    match outcome {
+        AdmissionOutcome::Accepted(ticket) => {
+            let source_id = target.source_id.clone();
+            let context = PendingCaptureContext {
+                source_id: target.source_id,
+                source_root: target.source_root,
+                root_identity: lane.root_identity().clone(),
+                stream_id,
+                watcher_generation: lane.generation(),
+                capture_boundary: boundary,
+                original_event,
+                compatibility_event,
+                conservative: target.conservative,
+                correlation: live.correlation().cloned(),
+            };
+            if let Some(previous) = pending_contexts.insert(ticket, context) {
+                tracing::error!(
+                    ticket = ticket.id(),
+                    source_id = previous.source_id.as_str(),
+                    "Native watcher admission ticket unexpectedly replaced its handoff context"
+                );
+                state.mark_all_overflowed(now);
+            }
+            if live.correlation().is_none() {
+                tracing::error!(
+                    ticket = ticket.id(),
+                    source_id = source_id.as_str(),
+                    "Accepted live admission did not return its retained audit correlation"
+                );
+            }
+        }
+        AdmissionOutcome::DuplicateSuppressed(_) => {
+            tracing::debug!(
+                source_id = target.source_id.as_str(),
+                "Suppressing duplicate native watcher observation"
+            );
+        }
+        AdmissionOutcome::Rejected(reason) => {
+            tracing::warn!(
+                source_id = target.source_id.as_str(),
+                ?reason,
+                "Native watcher evidence was retained as conservative uncertainty"
+            );
+            widen_source(state, &target.source_root, now);
+        }
+        AdmissionOutcome::UncertaintyCapacityExhausted(_) => {
+            tracing::error!(
+                source_id = target.source_id.as_str(),
+                "Native watcher uncertainty capacity was exhausted"
+            );
+            widen_source(state, &target.source_root, now);
+        }
+    }
+}
+
+fn handoff_dispatched_capture(
+    state: &mut GuiSourceWatchState,
+    context: &PendingCaptureContext,
+    dispatched: &wavecrate_library::sample_sources::reconciliation::DispatchedObservation,
+    now: Instant,
+) -> (bool, bool) {
+    let provenance = dispatched.normalized().envelope().provenance();
+    let expected_stream =
+        BackendStreamIdentity::from_bytes(context.stream_id.to_be_bytes().to_vec());
+    let correlation_matches = context
+        .correlation
+        .as_ref()
+        .is_some_and(|correlation| correlation.ticket() == dispatched.ticket());
+    let provenance_matches = provenance.source_id() == &context.source_id
+        && provenance.root_identity() == Some(&context.root_identity)
+        && provenance.backend_stream_identity() == Some(&expected_stream)
+        && provenance.watcher_generation() == context.watcher_generation
+        && provenance.capture_boundary() == context.capture_boundary;
+    if !correlation_matches || !provenance_matches {
+        tracing::error!(
+            source_id = context.source_id.as_str(),
+            ticket = dispatched.ticket().id(),
+            correlation_matches,
+            provenance_matches,
+            "Native watcher dispatch provenance did not match its retained capture context"
+        );
+        state.mark_all_overflowed(now);
+        return (false, false);
+    }
+    let source_audit = context.conservative
+        || dispatched
+            .normalized()
+            .scopes()
+            .iter()
+            .any(|scope| scope.kind() == ReconciliationScopeKind::SourceAudit);
+    if source_audit {
+        widen_source(state, &context.source_root, now);
+        return (true, false);
+    }
+
+    let Some(compatibility_event) = context.compatibility_event.as_ref() else {
+        tracing::error!(
+            source_id = context.source_id.as_str(),
+            original_event_retained = context.original_event.is_some(),
+            "Native watcher dispatch has no compatible source-refresh event"
+        );
+        state.mark_all_overflowed(now);
+        return (false, false);
+    };
+    let mut event = compatibility_event.clone();
+    if !retain_source_refresh_candidates(&mut event) {
+        return (true, false);
+    }
+    (true, state.collect_event(&event, now))
+}
+
+fn dispatch_pending_capture_contexts(
+    state: &mut GuiSourceWatchState,
+    admission: &mut AdmissionLifecycle,
+    pending_contexts: &mut HashMap<DispatchTicket, PendingCaptureContext>,
+    now: Instant,
+) -> bool {
+    let mut root_invalidated = false;
+    if admission.in_flight() == 0 && !pending_contexts.is_empty() {
+        tracing::error!(
+            context_count = pending_contexts.len(),
+            "Native watcher admission fence retired pending capture contexts before handoff"
+        );
+        for (_, context) in pending_contexts.drain() {
+            widen_source(state, &context.source_root, now);
+        }
+    }
+    while let Some(dispatched) = admission.dispatch_next() {
+        let ticket = dispatched.ticket();
+        let Some(context) = pending_contexts.remove(&ticket) else {
+            tracing::error!(
+                ticket = ticket.id(),
+                "Native watcher dispatch ticket had no retained handoff context"
+            );
+            state.mark_all_overflowed(now);
+            if let Err(error) = admission.mark_dispatched(ticket) {
+                tracing::error!(
+                    ticket = ticket.id(),
+                    ?error,
+                    "Could not mark orphaned watcher dispatch"
+                );
+                break;
+            }
+            if let Err(error) = admission.mark_applied(ticket) {
+                tracing::error!(
+                    ticket = ticket.id(),
+                    ?error,
+                    "Could not mark orphaned watcher application"
+                );
+                break;
+            }
+            if let Err(error) = admission.mark_unproven_audit_handed_off(ticket) {
+                tracing::error!(
+                    ticket = ticket.id(),
+                    ?error,
+                    "Could not retire orphaned watcher dispatch"
+                );
+                break;
+            }
+            continue;
+        };
+
+        if let Err(error) = admission.mark_dispatched(ticket) {
+            tracing::error!(
+                ticket = ticket.id(),
+                ?error,
+                "Could not mark native watcher dispatch"
+            );
+            widen_source(state, &context.source_root, now);
+            pending_contexts.insert(ticket, context);
+            break;
+        }
+        let (handoff_succeeded, invalidated) =
+            handoff_dispatched_capture(state, &context, &dispatched, now);
+        root_invalidated |= invalidated;
+        if !handoff_succeeded {
+            tracing::error!(
+                ticket = ticket.id(),
+                source_id = context.source_id.as_str(),
+                "Native watcher handoff failed closed"
+            );
+        }
+        if let Err(error) = admission.mark_applied(ticket) {
+            tracing::error!(
+                ticket = ticket.id(),
+                ?error,
+                "Could not mark native watcher application"
+            );
+            widen_source(state, &context.source_root, now);
+            pending_contexts.insert(ticket, context);
+            break;
+        }
+        if let Err(error) = admission.mark_unproven_audit_handed_off(ticket) {
+            tracing::error!(
+                ticket = ticket.id(),
+                ?error,
+                "Could not retire native watcher proofless dispatch"
+            );
+            widen_source(state, &context.source_root, now);
+            pending_contexts.insert(ticket, context);
+            break;
+        }
+        let _correlation = context.correlation;
+    }
+    root_invalidated
+}
+
 fn drain_watcher_captures(
     state: &mut GuiSourceWatchState,
+    admission: &mut AdmissionLifecycle,
     watcher: Option<&ActiveSourceWatcher>,
-    event_rx: &Receiver<SourceWatcherCapture>,
+    event_rx: &Receiver<CapturedSourceWatcherCapture>,
+    pending_contexts: &mut HashMap<DispatchTicket, PendingCaptureContext>,
     now: Instant,
 ) -> (bool, bool) {
     let mut watcher_failed = false;
-    let mut root_invalidated = false;
-    while let Ok(event) = event_rx.try_recv() {
-        let stream_id = match &event {
-            SourceWatcherCapture::Notify { stream_id, .. }
-            | SourceWatcherCapture::Error { stream_id }
-            | SourceWatcherCapture::Overflow { stream_id } => *stream_id,
-        };
+    let mut root_invalidated =
+        dispatch_pending_capture_contexts(state, admission, pending_contexts, now);
+    while let Ok(captured) = event_rx.try_recv() {
+        let stream_id = capture_stream_id(&captured.capture);
         let current_stream = watcher.is_some_and(|watcher| {
             watcher.stream_id == stream_id && watcher.ingress_enabled.load(Ordering::Acquire)
         });
@@ -1026,22 +1518,26 @@ fn drain_watcher_captures(
             state.mark_all_overflowed(now);
             continue;
         }
-        match event {
-            SourceWatcherCapture::Notify { mut event, .. } => {
-                if !retain_source_refresh_candidates(&mut event) {
-                    continue;
-                }
-                root_invalidated |= state.collect_event(&event, Instant::now());
-            }
-            SourceWatcherCapture::Error { .. } => {
-                tracing::warn!("GUI source watcher error");
-                watcher_failed = true;
-            }
-            SourceWatcherCapture::Overflow { .. } => {
-                state.mark_all_overflowed(now);
-            }
+        if matches!(&captured.capture, SourceWatcherCapture::Error { .. }) {
+            tracing::warn!("GUI source watcher error");
+            watcher_failed = true;
+        }
+        if matches!(&captured.capture, SourceWatcherCapture::Overflow { .. }) {
+            tracing::warn!("GUI source watcher overflow marker");
+        }
+        for target in source_capture_targets(&captured.capture, &state.sources) {
+            admit_capture_target(
+                state,
+                admission,
+                &captured.capture,
+                captured.boundary,
+                target,
+                pending_contexts,
+                now,
+            );
         }
     }
+    root_invalidated |= dispatch_pending_capture_contexts(state, admission, pending_contexts, now);
     (watcher_failed, root_invalidated)
 }
 
@@ -1201,7 +1697,7 @@ fn run_source_watcher_without_lifecycle(command_rx: Receiver<GuiSourceWatchComma
 
 fn spawn_source_watcher(
     sources: Vec<SampleSource>,
-    event_tx: SyncSender<SourceWatcherCapture>,
+    event_tx: SyncSender<CapturedSourceWatcherCapture>,
     ingress_overflowed: Arc<AtomicBool>,
     backend: SourceWatcherBackend,
 ) -> Result<PendingSourceWatcher, String> {
@@ -1284,7 +1780,7 @@ fn start_pending_source_watcher(
     pending: &mut Option<PendingSourceWatcher>,
     retired_initializers: &[PendingSourceWatcher],
     sources: Vec<SampleSource>,
-    event_tx: SyncSender<SourceWatcherCapture>,
+    event_tx: SyncSender<CapturedSourceWatcherCapture>,
     ingress_overflowed: Arc<AtomicBool>,
     backend: SourceWatcherBackend,
 ) -> bool {
@@ -1454,6 +1950,10 @@ mod lifecycle_tests {
         },
     };
     use wavecrate::sample_sources::{SampleSource, SourceId};
+    use wavecrate_library::sample_sources::reconciliation::{
+        CaptureBoundary, RawObservationLimits, ReconciliationAdmissionLimits,
+        ReconciliationScopeKind, UncertaintyReason,
+    };
 
     static LIFECYCLE_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
@@ -1788,18 +2288,534 @@ mod lifecycle_tests {
             attrs: notify::event::EventAttributes::default(),
         }));
 
+        let notification = event_rx.recv().expect("captured notification");
         assert!(matches!(
-            event_rx.recv().expect("captured notification"),
+            notification.capture,
             SourceWatcherCapture::Notify { stream_id: 41, .. }
         ));
+        assert!(notification.boundary.captured_at() > 0);
+        let error = event_rx.recv().expect("captured error");
         assert!(matches!(
-            event_rx.recv().expect("captured error"),
+            error.capture,
             SourceWatcherCapture::Error { stream_id: 41 }
         ));
+        assert!(error.boundary.captured_at() > 0);
+        let overflow = event_rx.recv().expect("captured overflow");
         assert!(matches!(
-            event_rx.recv().expect("captured overflow"),
+            overflow.capture,
             SourceWatcherCapture::Overflow { stream_id: 41 }
         ));
+        assert!(overflow.boundary.captured_at() > 0);
+    }
+
+    struct ImmediateDropWatcher;
+
+    impl Watcher for ImmediateDropWatcher {
+        fn new<F: EventHandler>(_event_handler: F, _config: Config) -> notify::Result<Self>
+        where
+            Self: Sized,
+        {
+            unreachable!("test watcher is constructed directly")
+        }
+
+        fn watch(&mut self, _path: &Path, _recursive_mode: RecursiveMode) -> notify::Result<()> {
+            Ok(())
+        }
+
+        fn unwatch(&mut self, _path: &Path) -> notify::Result<()> {
+            Ok(())
+        }
+
+        fn kind() -> WatcherKind
+        where
+            Self: Sized,
+        {
+            WatcherKind::NullWatcher
+        }
+    }
+
+    fn source_with_root(id: &str, root: &Path) -> SampleSource {
+        SampleSource::new_with_id(SourceId::from_string(id), root.to_path_buf())
+    }
+
+    fn configured_admission(sources: &[SampleSource]) -> AdmissionLifecycle {
+        configured_admission_with_limits(sources, None)
+    }
+
+    fn configured_admission_with_limits(
+        sources: &[SampleSource],
+        limits: Option<ReconciliationAdmissionLimits>,
+    ) -> AdmissionLifecycle {
+        let watched_roots = sources
+            .iter()
+            .enumerate()
+            .map(|(index, source)| (source.root.clone(), Some(format!("identity-{index}"))))
+            .collect::<WatchedRootIdentities>();
+        let mut admission = limits
+            .map(AdmissionLifecycle::with_limits)
+            .unwrap_or_else(AdmissionLifecycle::new);
+        admission
+            .reconcile(sources, &watched_roots)
+            .expect("configured source admission");
+        admission
+    }
+
+    fn limited_admission(sources: &[SampleSource], max_in_flight: usize) -> AdmissionLifecycle {
+        let per_lane = RawObservationLimits::new(8, usize::MAX, usize::MAX)
+            .expect("native test per-lane limits");
+        let global = RawObservationLimits::new(32, usize::MAX, usize::MAX)
+            .expect("native test global limits");
+        let limits = ReconciliationAdmissionLimits::new_with_per_lane_capacity(
+            sources.len().max(1),
+            per_lane,
+            global,
+            max_in_flight,
+            1,
+            8,
+            64,
+        )
+        .expect("native test admission limits");
+        configured_admission_with_limits(sources, Some(limits))
+    }
+
+    fn source_watcher_state(sources: Vec<SampleSource>) -> GuiSourceWatchState {
+        GuiSourceWatchState {
+            sources,
+            ..Default::default()
+        }
+    }
+
+    fn notify_capture(root: &Path, stream_id: u64, paths: &[&str]) -> SourceWatcherCapture {
+        SourceWatcherCapture::Notify {
+            stream_id,
+            event: Event {
+                kind: EventKind::Create(notify::event::CreateKind::File),
+                paths: paths.iter().map(|path| root.join(path)).collect(),
+                attrs: notify::event::EventAttributes::default(),
+            },
+        }
+    }
+
+    fn exact_boundary(sequence: u64) -> CaptureBoundary {
+        CaptureBoundary::try_new(sequence, Some(sequence), Some(sequence))
+            .expect("native test capture boundary")
+    }
+
+    fn live_test_watcher(stream_id: u64) -> ActiveSourceWatcher {
+        ActiveSourceWatcher {
+            _watcher: Box::new(ImmediateDropWatcher),
+            ingress_enabled: Arc::new(AtomicBool::new(true)),
+            stream_id,
+        }
+    }
+
+    #[test]
+    fn admitted_capture_retains_identity_and_correlation_until_proofless_handoff() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = source_with_root("identity-bound", directory.path());
+        let mut state = source_watcher_state(vec![source.clone()]);
+        let mut admission = configured_admission(&state.sources);
+        let capture = notify_capture(directory.path(), 17, &["sample.wav"]);
+        let boundary = exact_boundary(77);
+        let mut targets = source_capture_targets(&capture, &state.sources);
+        assert_eq!(targets.len(), 1);
+        let target = targets.pop().expect("source target");
+        let mut pending_contexts = HashMap::new();
+
+        admit_capture_target(
+            &mut state,
+            &mut admission,
+            &capture,
+            boundary,
+            target,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+
+        let ticket = *pending_contexts
+            .keys()
+            .next()
+            .expect("accepted capture ticket");
+        let lane = admission
+            .lane_for_capture(&source.id)
+            .expect("identity-qualified lane");
+        let context = pending_contexts
+            .get(&ticket)
+            .expect("pending capture context");
+        assert_eq!(context.source_id, source.id);
+        assert_eq!(context.source_root, source.root);
+        assert_eq!(
+            context.root_identity,
+            RootIdentity::from_bytes(b"identity-0".to_vec())
+        );
+        assert_eq!(context.stream_id, 17);
+        assert_eq!(context.watcher_generation, lane.generation());
+        assert_eq!(context.capture_boundary, boundary);
+        assert_eq!(
+            context.correlation.as_ref().map(|value| value.ticket()),
+            Some(ticket)
+        );
+        let expected_root_identity = context.root_identity.clone();
+        let expected_generation = context.watcher_generation;
+        assert_eq!(admission.in_flight(), 1);
+
+        assert!(!dispatch_pending_capture_contexts(
+            &mut state,
+            &mut admission,
+            &mut pending_contexts,
+            Instant::now(),
+        ));
+
+        assert!(pending_contexts.is_empty());
+        assert_eq!(admission.in_flight(), 0);
+        let marker = admission
+            .retained_uncertainties()
+            .iter()
+            .find(|marker| marker.source_id() == Some(&source.id))
+            .expect("live uncertainty marker");
+        assert_eq!(marker.root_identity(), Some(&expected_root_identity));
+        assert_eq!(marker.generation(), Some(expected_generation));
+        assert_eq!(marker.capture_boundary(), Some(boundary));
+        assert_eq!(marker.scope(), ReconciliationScopeKind::SourceAudit);
+        assert!(marker.reasons().contains(&UncertaintyReason::LiveUnproven));
+        assert_eq!(
+            state
+                .pending
+                .get(source.id.as_str())
+                .expect("compatibility refresh handoff")
+                .paths,
+            [Path::new("sample.wav").to_path_buf()]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn exact_callback_boundary_duplicate_is_suppressed_without_new_handoff() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = source_with_root("duplicate", directory.path());
+        let mut state = source_watcher_state(vec![source.clone()]);
+        let mut admission = configured_admission(&state.sources);
+        let boundary = exact_boundary(88);
+        let mut pending_contexts = HashMap::new();
+
+        for capture in [
+            notify_capture(directory.path(), 21, &["duplicate.wav"]),
+            notify_capture(directory.path(), 21, &["duplicate.wav"]),
+        ] {
+            let target = source_capture_targets(&capture, &state.sources)
+                .pop()
+                .expect("source target");
+            admit_capture_target(
+                &mut state,
+                &mut admission,
+                &capture,
+                boundary,
+                target,
+                &mut pending_contexts,
+                Instant::now(),
+            );
+            if admission.in_flight() != 0 {
+                dispatch_pending_capture_contexts(
+                    &mut state,
+                    &mut admission,
+                    &mut pending_contexts,
+                    Instant::now(),
+                );
+            }
+        }
+
+        assert!(pending_contexts.is_empty());
+        assert_eq!(admission.in_flight(), 0);
+        assert_eq!(
+            admission
+                .retained_uncertainties()
+                .iter()
+                .filter(|marker| marker.source_id() == Some(&source.id))
+                .count(),
+            1,
+            "duplicate suppression must not retain a second marker"
+        );
+    }
+
+    #[test]
+    fn stale_stream_is_fenced_before_native_admission() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = source_with_root("stale-stream", directory.path());
+        let mut state = source_watcher_state(vec![source]);
+        let mut admission = configured_admission(&state.sources);
+        let watcher = live_test_watcher(41);
+        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+        event_tx
+            .send(CapturedSourceWatcherCapture::with_boundary(
+                notify_capture(directory.path(), 40, &["stale.wav"]),
+                exact_boundary(91),
+            ))
+            .expect("stale capture");
+        let mut pending_contexts = HashMap::new();
+
+        let (watcher_failed, root_invalidated) = drain_watcher_captures(
+            &mut state,
+            &mut admission,
+            Some(&watcher),
+            &event_rx,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+
+        assert!(!watcher_failed);
+        assert!(!root_invalidated);
+        assert_eq!(admission.in_flight(), 0);
+        assert!(pending_contexts.is_empty());
+        assert!(
+            state
+                .pending
+                .values()
+                .next()
+                .expect("stale stream widening")
+                .overflowed
+        );
+    }
+
+    #[test]
+    fn queue_pressure_and_handoff_failure_widen_without_dropping_ticket_state() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = source_with_root("pressure", directory.path());
+        let mut state = source_watcher_state(vec![source.clone()]);
+        let mut admission = limited_admission(&state.sources, 1);
+        let mut pending_contexts = HashMap::new();
+        let now = Instant::now();
+
+        for path in ["first.wav", "second.wav"] {
+            let capture = notify_capture(directory.path(), 31, &[path]);
+            let target = source_capture_targets(&capture, &state.sources)
+                .pop()
+                .expect("source target");
+            admit_capture_target(
+                &mut state,
+                &mut admission,
+                &capture,
+                exact_boundary(if path == "first.wav" { 101 } else { 102 }),
+                target,
+                &mut pending_contexts,
+                now,
+            );
+        }
+        assert_eq!(admission.in_flight(), 1);
+        assert_eq!(pending_contexts.len(), 1);
+        assert!(
+            state
+                .pending
+                .get(source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        );
+
+        dispatch_pending_capture_contexts(&mut state, &mut admission, &mut pending_contexts, now);
+        assert_eq!(admission.in_flight(), 0);
+        assert!(pending_contexts.is_empty());
+
+        let capture = notify_capture(directory.path(), 31, &["handoff.wav"]);
+        let target = source_capture_targets(&capture, &state.sources)
+            .pop()
+            .expect("source target");
+        admit_capture_target(
+            &mut state,
+            &mut admission,
+            &capture,
+            exact_boundary(103),
+            target,
+            &mut pending_contexts,
+            now,
+        );
+        pending_contexts
+            .values_mut()
+            .next()
+            .expect("handoff context")
+            .correlation = None;
+        dispatch_pending_capture_contexts(&mut state, &mut admission, &mut pending_contexts, now);
+        assert_eq!(admission.in_flight(), 0);
+        assert!(pending_contexts.is_empty());
+        assert!(
+            state
+                .pending
+                .get(source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        );
+    }
+
+    #[test]
+    fn multi_source_and_ambiguous_paths_widen_all_configured_sources() {
+        let first_directory = tempfile::tempdir().expect("first source root");
+        let second_directory = tempfile::tempdir().expect("second source root");
+        let first = source_with_root("multi-first", first_directory.path());
+        let second = source_with_root("multi-second", second_directory.path());
+        let sources = vec![first.clone(), second.clone()];
+        let mut state = source_watcher_state(sources.clone());
+        let mut admission = configured_admission(&sources);
+        let capture = SourceWatcherCapture::Notify {
+            stream_id: 51,
+            event: Event {
+                kind: EventKind::Create(notify::event::CreateKind::File),
+                paths: vec![
+                    first_directory.path().join("first.wav"),
+                    second_directory.path().join("second.wav"),
+                ],
+                attrs: notify::event::EventAttributes::default(),
+            },
+        };
+        let targets = source_capture_targets(&capture, &sources);
+        assert_eq!(targets.len(), 2);
+        assert!(targets.iter().all(|target| target.conservative));
+        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+        event_tx
+            .send(CapturedSourceWatcherCapture::with_boundary(
+                capture,
+                exact_boundary(111),
+            ))
+            .expect("multi-source capture");
+        let watcher = live_test_watcher(51);
+        let mut pending_contexts = HashMap::new();
+        drain_watcher_captures(
+            &mut state,
+            &mut admission,
+            Some(&watcher),
+            &event_rx,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        assert!(sources.iter().all(|source| {
+            state
+                .pending
+                .get(source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        }));
+        assert!(pending_contexts.is_empty());
+
+        let shared_directory = tempfile::tempdir().expect("ambiguous root");
+        let ambiguous_sources = vec![
+            source_with_root("ambiguous-first", shared_directory.path()),
+            source_with_root("ambiguous-second", shared_directory.path()),
+        ];
+        let mut ambiguous_state = source_watcher_state(ambiguous_sources.clone());
+        let mut ambiguous_admission = configured_admission(&ambiguous_sources);
+        let ambiguous_capture = notify_capture(shared_directory.path(), 61, &["ambiguous.wav"]);
+        let ambiguous_targets = source_capture_targets(&ambiguous_capture, &ambiguous_sources);
+        assert_eq!(ambiguous_targets.len(), 2);
+        assert!(ambiguous_targets.iter().all(|target| target.conservative));
+        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+        event_tx
+            .send(CapturedSourceWatcherCapture::with_boundary(
+                ambiguous_capture,
+                exact_boundary(112),
+            ))
+            .expect("ambiguous capture");
+        let watcher = live_test_watcher(61);
+        let mut pending_contexts = HashMap::new();
+        drain_watcher_captures(
+            &mut ambiguous_state,
+            &mut ambiguous_admission,
+            Some(&watcher),
+            &event_rx,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        assert!(ambiguous_sources.iter().all(|source| {
+            ambiguous_state
+                .pending
+                .get(source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        }));
+    }
+
+    #[test]
+    fn lifecycle_fence_cleans_pending_contexts_and_widens_retired_work() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = source_with_root("fenced-context", directory.path());
+        let mut state = source_watcher_state(vec![source.clone()]);
+        let mut admission = configured_admission(&state.sources);
+        let capture = notify_capture(directory.path(), 71, &["retired.wav"]);
+        let target = source_capture_targets(&capture, &state.sources)
+            .pop()
+            .expect("source target");
+        let mut pending_contexts = HashMap::new();
+        admit_capture_target(
+            &mut state,
+            &mut admission,
+            &capture,
+            exact_boundary(121),
+            target,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        assert_eq!(admission.in_flight(), 1);
+        admission.fence_all().expect("fence captured work");
+        assert_eq!(admission.in_flight(), 0);
+
+        dispatch_pending_capture_contexts(
+            &mut state,
+            &mut admission,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        assert!(pending_contexts.is_empty());
+        assert!(
+            state
+                .pending
+                .get(source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        );
+    }
+
+    #[test]
+    fn missing_identity_and_invalid_root_mapping_widen_conservatively() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = source_with_root("missing-identity", directory.path());
+        let mut state = source_watcher_state(vec![source.clone()]);
+        let mut admission = AdmissionLifecycle::new();
+        let capture = notify_capture(directory.path(), 81, &["missing.wav"]);
+        let target = source_capture_targets(&capture, &state.sources)
+            .pop()
+            .expect("source target");
+        let mut pending_contexts = HashMap::new();
+        admit_capture_target(
+            &mut state,
+            &mut admission,
+            &capture,
+            exact_boundary(131),
+            target,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        assert!(
+            state
+                .pending
+                .get(source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        );
+
+        let mut configured = configured_admission(&state.sources);
+        let invalid_target = SourceCaptureTarget {
+            source_id: source.id.clone(),
+            source_root: source.root.clone(),
+            paths: vec![source.root.join("../escape.wav")],
+            conservative: false,
+        };
+        let mut invalid_state = source_watcher_state(vec![source.clone()]);
+        admit_capture_target(
+            &mut invalid_state,
+            &mut configured,
+            &notify_capture(directory.path(), 82, &["ignored.wav"]),
+            exact_boundary(132),
+            invalid_target,
+            &mut pending_contexts,
+            Instant::now(),
+        );
+        assert!(
+            invalid_state
+                .pending
+                .get(source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        );
     }
 
     struct BlockingDropWatcher {
@@ -1884,11 +2900,21 @@ mod lifecycle_tests {
         };
         let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
         event_tx
-            .send(SourceWatcherCapture::Error { stream_id })
+            .send(CapturedSourceWatcherCapture::from_capture(
+                SourceWatcherCapture::Error { stream_id },
+            ))
             .expect("inject same-stream fenced capture");
+        let mut admission = AdmissionLifecycle::new();
+        let mut pending_contexts = HashMap::new();
 
-        let (watcher_failed, root_invalidated) =
-            drain_watcher_captures(&mut state, watcher.as_ref(), &event_rx, Instant::now());
+        let (watcher_failed, root_invalidated) = drain_watcher_captures(
+            &mut state,
+            &mut admission,
+            watcher.as_ref(),
+            &event_rx,
+            &mut pending_contexts,
+            Instant::now(),
+        );
 
         assert!(
             !watcher_failed,

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -1314,6 +1314,13 @@ fn admit_capture_target(
         }
     };
     let outcome = live.admission().outcome().clone();
+    let audit_request_to_queue = match &outcome {
+        AdmissionOutcome::Accepted(_) if live.correlation().is_some() => None,
+        _ => live.audit_request().cloned(),
+    };
+    if let Some(request) = audit_request_to_queue {
+        state.pending_audit_requests.push(request);
+    }
     match outcome {
         AdmissionOutcome::Accepted(ticket) => {
             let source_id = target.source_id.clone();
@@ -2525,10 +2532,7 @@ mod lifecycle_tests {
         assert_eq!(request.root_identity(), &expected_root_identity);
         assert_eq!(request.generation(), expected_generation);
         assert_eq!(request.boundary(), marker.boundary());
-        let receipt = request.complete(42, expected_root_identity);
-        let acknowledgement = admission.acknowledge_source_audit_receipt(&receipt);
-        assert_eq!(acknowledgement.cleared_markers(), 1);
-        assert_eq!(admission.retained_uncertainties().len(), 0);
+        assert_eq!(admission.retained_uncertainties().len(), 1);
         assert_eq!(
             state
                 .pending

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -510,9 +510,8 @@ fn run_source_watcher(
                     desired_watched_roots(&sources) != desired_watched_roots(&state.sources);
                 state.set_sources(sources);
                 if !reconcile_watcher_admission(
+                    &mut state,
                     &mut admission_lifecycle,
-                    &state.sources,
-                    &state.watched_roots,
                     "source-list replacement",
                 ) {
                     retire_source_watcher(&mut watcher, &mut teardown);
@@ -525,7 +524,12 @@ fn run_source_watcher(
                     next_restart = now + restart_delay;
                     restart_delay = doubled_backoff(restart_delay);
                 } else if roots_changed {
-                    fence_watcher_admission(&mut admission_lifecycle, "source-list watcher reset");
+                    fence_watcher_admission(
+                        &mut state,
+                        &mut admission_lifecycle,
+                        "source-list watcher reset",
+                        now,
+                    );
                     retire_source_watcher(&mut watcher, &mut teardown);
                     cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
                     state.reset_watches(now);
@@ -578,11 +582,17 @@ fn run_source_watcher(
             }
             #[cfg(test)]
             Ok(GuiSourceWatchCommand::ForceRestart) => {
-                fence_watcher_admission(&mut admission_lifecycle, "forced watcher restart");
+                let now = Instant::now();
+                fence_watcher_admission(
+                    &mut state,
+                    &mut admission_lifecycle,
+                    "forced watcher restart",
+                    now,
+                );
                 retire_source_watcher(&mut watcher, &mut teardown);
                 cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
-                state.reset_watches(Instant::now());
-                next_restart = Instant::now();
+                state.reset_watches(now);
+                next_restart = now;
                 restart_delay = WATCHER_RESTART_MIN;
             }
             #[cfg(test)]
@@ -637,14 +647,26 @@ fn run_source_watcher(
                 let _ = status_tx.send(is_live);
             }
             Ok(GuiSourceWatchCommand::Shutdown) => {
-                fence_watcher_admission(&mut admission_lifecycle, "watcher shutdown");
+                let now = Instant::now();
+                fence_watcher_admission(
+                    &mut state,
+                    &mut admission_lifecycle,
+                    "watcher shutdown",
+                    now,
+                );
                 cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
                 retire_source_watcher_on_shutdown(&mut watcher, &mut teardown);
                 break;
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                fence_watcher_admission(&mut admission_lifecycle, "watcher command disconnect");
+                let now = Instant::now();
+                fence_watcher_admission(
+                    &mut state,
+                    &mut admission_lifecycle,
+                    "watcher command disconnect",
+                    now,
+                );
                 cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
                 retire_source_watcher_on_shutdown(&mut watcher, &mut teardown);
                 break;
@@ -709,8 +731,10 @@ fn run_source_watcher(
                         state.apply_root_watch_update(update, now, false);
                     if watch_failed {
                         fence_watcher_admission(
+                            &mut state,
                             &mut admission_lifecycle,
                             "partial watcher installation",
+                            now,
                         );
                         if let Err(restarted) =
                             retire_source_watcher_value(restarted, &mut teardown)
@@ -742,9 +766,8 @@ fn run_source_watcher(
                         }
                     } else {
                         let lifecycle_ready = reconcile_watcher_admission(
+                            &mut state,
                             &mut admission_lifecycle,
-                            &state.sources,
-                            &state.watched_roots,
                             "successful watcher installation",
                         );
                         if !lifecycle_ready {
@@ -807,8 +830,10 @@ fn run_source_watcher(
                 Ok(Err(error)) => {
                     let _ = pending.join_handle.join();
                     fence_watcher_admission(
+                        &mut state,
                         &mut admission_lifecycle,
                         "watcher initialization failure",
+                        now,
                     );
                     tracing::warn!(
                         ?backend,
@@ -850,8 +875,10 @@ fn run_source_watcher(
                 }
                 Err(TryRecvError::Empty) => {
                     fence_watcher_admission(
+                        &mut state,
                         &mut admission_lifecycle,
                         "watcher initialization timeout",
+                        now,
                     );
                     pending.ingress_enabled.store(false, Ordering::Release);
                     debug_assert!(
@@ -902,8 +929,10 @@ fn run_source_watcher(
                 Err(TryRecvError::Disconnected) => {
                     let _ = pending.join_handle.join();
                     fence_watcher_admission(
+                        &mut state,
                         &mut admission_lifecycle,
                         "watcher initializer disconnect",
+                        now,
                     );
                     tracing::warn!(
                         ?backend,
@@ -959,7 +988,12 @@ fn run_source_watcher(
                     "Source root availability or filesystem identity changed; restarting watcher"
                 );
                 state.mark_roots_overflowed(&invalidated_roots, now);
-                fence_watcher_admission(&mut admission_lifecycle, "root identity refresh");
+                fence_watcher_admission(
+                    &mut state,
+                    &mut admission_lifecycle,
+                    "root identity refresh",
+                    now,
+                );
                 retire_source_watcher(&mut watcher, &mut teardown);
                 cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
                 state.clear_watches();
@@ -987,10 +1021,14 @@ fn run_source_watcher(
             &mut pending_capture_contexts,
             now,
         );
-        flush_pending_audit_requests(&mut state, &message_tx, now);
 
         if watcher_failed || root_invalidated {
-            fence_watcher_admission(&mut admission_lifecycle, "watcher capture retirement");
+            fence_watcher_admission(
+                &mut state,
+                &mut admission_lifecycle,
+                "watcher capture retirement",
+                now,
+            );
             retire_source_watcher(&mut watcher, &mut teardown);
             cancel_pending_source_watcher(&mut pending_watcher, &mut retired_initializers);
             if watcher_failed {
@@ -1003,6 +1041,8 @@ fn run_source_watcher(
                 restart_delay = WATCHER_RESTART_MIN;
             }
         }
+
+        flush_pending_audit_requests(&mut state, &admission_lifecycle, &message_tx, now);
 
         for event in state.drain_ready_sources(now, SOURCE_CHANGE_DEBOUNCE) {
             tracing::debug!(
@@ -1044,7 +1084,12 @@ fn run_source_watcher(
     }
 }
 
-fn fence_watcher_admission(admission: &mut AdmissionLifecycle, boundary: &'static str) {
+fn fence_watcher_admission(
+    state: &mut GuiSourceWatchState,
+    admission: &mut AdmissionLifecycle,
+    boundary: &'static str,
+    now: Instant,
+) {
     if let Err(error) = admission.fence_all() {
         tracing::error!(
             boundary,
@@ -1052,15 +1097,17 @@ fn fence_watcher_admission(admission: &mut AdmissionLifecycle, boundary: &'stati
             "Could not fully fence native watcher admission; keeping backend ingress closed"
         );
     }
+    purge_stale_audit_requests(state, admission, now);
 }
 
 fn reconcile_watcher_admission(
+    state: &mut GuiSourceWatchState,
     admission: &mut AdmissionLifecycle,
-    sources: &[SampleSource],
-    watched_roots: &WatchedRootIdentities,
     boundary: &'static str,
 ) -> bool {
-    match admission.reconcile(sources, watched_roots) {
+    let result = admission.reconcile(&state.sources, &state.watched_roots);
+    purge_stale_audit_requests(state, admission, Instant::now());
+    match result {
         Ok(()) => true,
         Err(error) => {
             tracing::error!(
@@ -1068,9 +1115,26 @@ fn reconcile_watcher_admission(
                 ?error,
                 "Native watcher admission lifecycle failed closed"
             );
-            fence_watcher_admission(admission, boundary);
+            fence_watcher_admission(state, admission, boundary, Instant::now());
             false
         }
+    }
+}
+
+fn purge_stale_audit_requests(
+    state: &mut GuiSourceWatchState,
+    admission: &AdmissionLifecycle,
+    now: Instant,
+) {
+    let displaced = state.purge_non_matching_audit_requests(|request| {
+        admission.request_matches_current_capturing_lane(request)
+    });
+    if !displaced.is_empty() {
+        tracing::warn!(
+            request_count = displaced.len(),
+            "Purged watcher audit requests from a stopped or replaced admission lane"
+        );
+        state.recover_displaced_audit_requests(&displaced, now);
     }
 }
 
@@ -1541,16 +1605,28 @@ fn dispatch_pending_capture_contexts(
 
 fn flush_pending_audit_requests(
     state: &mut GuiSourceWatchState,
+    admission: &AdmissionLifecycle,
     message_tx: &Sender<GuiMessage>,
     now: Instant,
 ) {
+    purge_stale_audit_requests(state, admission, now);
     if state.pending_audit_requests.conservative_recovery_latched() {
         state.mark_all_overflowed(now);
         state
             .pending_audit_requests
             .clear_conservative_recovery_latch();
     }
-    while let Some(request) = state.pending_audit_requests.front().cloned() {
+    while state.pending_audit_requests.front().is_some() {
+        // Revalidate immediately before each send. A lifecycle boundary can leave a retained
+        // request in the queue until this exact transport point; stale identities must never be
+        // emitted, while a failed send below deliberately leaves the request at the front.
+        purge_stale_audit_requests(state, admission, now);
+        let Some(request) = state.pending_audit_requests.front().cloned() else {
+            break;
+        };
+        if !admission.request_matches_current_capturing_lane(&request) {
+            continue;
+        }
         if message_tx
             .send(GuiMessage::SourceWatcherManifestAuditRequested { request })
             .is_err()
@@ -2657,6 +2733,123 @@ mod lifecycle_tests {
                 .identity(),
             first_request.identity()
         );
+    }
+
+    #[test]
+    fn root_rebind_drops_old_typed_requests_and_widens_the_replacement_source() {
+        let old_directory = tempfile::tempdir().expect("old source root");
+        let new_directory = tempfile::tempdir().expect("replacement source root");
+        let old_source = source_with_root("root-rebind-request", old_directory.path());
+        let replacement = source_with_root("root-rebind-request", new_directory.path());
+        let mut state = source_watcher_state(vec![old_source.clone()]);
+        let mut admission = configured_admission(&state.sources);
+        state.set_audit_request_capacity(admission.max_source_audit_request_entries());
+
+        let old_request = admission
+            .source_audit_request_for_current_lane(&old_source.id)
+            .expect("old typed request")
+            .0;
+        state.enqueue_audit_request(old_request.clone(), true);
+
+        state.set_sources(vec![replacement.clone()]);
+        state.watched_roots = HashMap::from([(
+            replacement.root.clone(),
+            Some(String::from("replacement-identity")),
+        )]);
+        admission
+            .reconcile(&state.sources, &state.watched_roots)
+            .expect("replacement admission lane");
+
+        let (message_tx, message_rx) = std::sync::mpsc::channel();
+        purge_stale_audit_requests(&mut state, &admission, Instant::now());
+        flush_pending_audit_requests(&mut state, &admission, &message_tx, Instant::now());
+
+        assert!(matches!(
+            message_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+        assert!(
+            state
+                .pending
+                .get(replacement.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        );
+        assert!(
+            !state
+                .pending_audit_requests
+                .front()
+                .is_some_and(|request| request == &old_request)
+        );
+    }
+
+    #[test]
+    fn stop_restart_drops_old_typed_requests_then_emits_only_restarted_identity() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = source_with_root("stop-restart-request", directory.path());
+        let mut state = source_watcher_state(vec![source.clone()]);
+        let mut admission = configured_admission(&state.sources);
+        state.watched_roots =
+            HashMap::from([(source.root.clone(), Some(String::from("identity-0")))]);
+        state.set_audit_request_capacity(admission.max_source_audit_request_entries());
+
+        let old_request = admission
+            .source_audit_request_for_current_lane(&source.id)
+            .expect("old typed request")
+            .0;
+        state.enqueue_audit_request(old_request.clone(), true);
+        admission.fence_all().expect("stop watcher lane");
+
+        let (message_tx, message_rx) = std::sync::mpsc::channel();
+        purge_stale_audit_requests(&mut state, &admission, Instant::now());
+        flush_pending_audit_requests(&mut state, &admission, &message_tx, Instant::now());
+        assert!(matches!(
+            message_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+        assert!(
+            state
+                .pending
+                .get(source.id.as_str())
+                .is_some_and(|pending| pending.overflowed)
+        );
+
+        admission
+            .reconcile(&state.sources, &state.watched_roots)
+            .expect("restart watcher lane");
+        let restarted_request = admission
+            .source_audit_request_for_current_lane(&source.id)
+            .expect("restarted typed request")
+            .0;
+        assert!(restarted_request.generation() > old_request.generation());
+        state.enqueue_audit_request(restarted_request.clone(), true);
+        flush_pending_audit_requests(&mut state, &admission, &message_tx, Instant::now());
+
+        let emitted = match message_rx.recv().expect("restarted audit request") {
+            GuiMessage::SourceWatcherManifestAuditRequested { request } => request,
+            message => panic!("expected restarted audit request, got {message:?}"),
+        };
+        assert_eq!(emitted, restarted_request);
+        assert_ne!(emitted, old_request);
+    }
+
+    #[test]
+    fn failed_audit_handoff_retains_the_current_request_for_retry() {
+        let directory = tempfile::tempdir().expect("source root");
+        let source = source_with_root("failed-audit-handoff", directory.path());
+        let mut state = source_watcher_state(vec![source.clone()]);
+        let admission = configured_admission(&state.sources);
+        state.set_audit_request_capacity(admission.max_source_audit_request_entries());
+        let request = admission
+            .source_audit_request_for_current_lane(&source.id)
+            .expect("current typed request")
+            .0;
+        state.enqueue_audit_request(request.clone(), true);
+
+        let (message_tx, message_rx) = std::sync::mpsc::channel();
+        drop(message_rx);
+        flush_pending_audit_requests(&mut state, &admission, &message_tx, Instant::now());
+
+        assert_eq!(state.pending_audit_requests.front(), Some(&request));
     }
 
     #[test]

--- a/src/native_app/sample_library/source_watcher/state.rs
+++ b/src/native_app/sample_library/source_watcher/state.rs
@@ -106,9 +106,19 @@ impl PendingSourceAuditRequests {
         AuditRequestQueueOutcome::FallbackCouldNotFit
     }
 
-    pub(super) fn retain_source_ids(&mut self, allowed: &HashSet<String>) {
-        self.entries
-            .retain(|entry| allowed.contains(entry.request.source_id().as_str()));
+    pub(super) fn purge_non_matching<F>(&mut self, mut matches: F) -> Vec<SourceAuditRequest>
+    where
+        F: FnMut(&SourceAuditRequest) -> bool,
+    {
+        let mut displaced = Vec::new();
+        self.entries.retain(|entry| {
+            let keep = matches(&entry.request);
+            if !keep {
+                displaced.push(entry.request.clone());
+            }
+            keep
+        });
+        displaced
     }
 
     #[cfg(test)]
@@ -165,7 +175,6 @@ impl GuiSourceWatchState {
             .retain(|source_id, _| allowed.contains(source_id));
         self.acknowledged_paths
             .retain(|(source_id, _), _| allowed.contains(source_id));
-        self.pending_audit_requests.retain_source_ids(&allowed);
     }
 
     pub(super) fn set_audit_request_capacity(&mut self, capacity: usize) {
@@ -178,6 +187,43 @@ impl GuiSourceWatchState {
         marker_backed: bool,
     ) -> AuditRequestQueueOutcome {
         self.pending_audit_requests.insert(request, marker_backed)
+    }
+
+    pub(super) fn purge_non_matching_audit_requests<F>(
+        &mut self,
+        matches: F,
+    ) -> Vec<SourceAuditRequest>
+    where
+        F: FnMut(&SourceAuditRequest) -> bool,
+    {
+        self.pending_audit_requests.purge_non_matching(matches)
+    }
+
+    /// Replace displaced typed work with the existing bounded conservative source recovery.
+    ///
+    /// A request whose source is still configured widens only that source. If its source was
+    /// removed, the old identity cannot be emitted or acknowledged, so the remaining configured
+    /// sources receive the existing all-source conservative recovery instead.
+    pub(super) fn recover_displaced_audit_requests(
+        &mut self,
+        requests: &[SourceAuditRequest],
+        now: Instant,
+    ) {
+        let mut recover_all = false;
+        for request in requests {
+            if self
+                .sources
+                .iter()
+                .any(|source| source.id == *request.source_id())
+            {
+                self.mark_source_overflowed(request.source_id().as_str(), now);
+            } else {
+                recover_all = true;
+            }
+        }
+        if recover_all {
+            self.mark_all_overflowed(now);
+        }
     }
 
     pub(super) fn apply_root_watch_update(

--- a/src/native_app/sample_library/source_watcher/state.rs
+++ b/src/native_app/sample_library/source_watcher/state.rs
@@ -18,13 +18,139 @@ use crate::native_app::sample_library::committed_file_mutations::{
     CommittedWatcherEcho, CommittedWatcherPathState, RevisionFirstCursor,
 };
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum AuditRequestQueueOutcome {
+    Queued,
+    Coalesced,
+    QueuedAfterDroppingFallback,
+    FallbackCouldNotFit,
+    MarkerCouldNotFit,
+}
+
+struct PendingSourceAuditRequest {
+    request: SourceAuditRequest,
+    marker_backed: bool,
+}
+
+/// Watcher-owned FIFO transport for exact source-audit requests.
+///
+/// Requests with one source/root/generation identity are covered into their original queue entry.
+/// The capacity is supplied by the admission owner and includes ordinary plus emergency retained
+/// uncertainty capacity; it is intentionally independent from the raw capture-context limit.
+pub(super) struct PendingSourceAuditRequests {
+    entries: Vec<PendingSourceAuditRequest>,
+    capacity: usize,
+    conservative_recovery_latched: bool,
+}
+
+impl Default for PendingSourceAuditRequests {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            capacity: 0,
+            conservative_recovery_latched: false,
+        }
+    }
+}
+
+impl PendingSourceAuditRequests {
+    pub(super) fn set_capacity(&mut self, capacity: usize) {
+        debug_assert!(
+            capacity >= self.entries.len(),
+            "audit request capacity cannot displace retained queue entries"
+        );
+        self.capacity = capacity;
+    }
+
+    pub(super) fn insert(
+        &mut self,
+        request: SourceAuditRequest,
+        marker_backed: bool,
+    ) -> AuditRequestQueueOutcome {
+        if let Some(entry) = self
+            .entries
+            .iter_mut()
+            .find(|entry| entry.request.identity() == request.identity())
+        {
+            entry.request = entry
+                .request
+                .covering(&request)
+                .expect("queue identity was checked before covering requests");
+            entry.marker_backed |= marker_backed;
+            return AuditRequestQueueOutcome::Coalesced;
+        }
+
+        if self.entries.len() < self.capacity {
+            self.entries.push(PendingSourceAuditRequest {
+                request,
+                marker_backed,
+            });
+            return AuditRequestQueueOutcome::Queued;
+        }
+
+        if marker_backed {
+            if let Some(index) = self.entries.iter().position(|entry| !entry.marker_backed) {
+                self.entries.remove(index);
+                self.conservative_recovery_latched = true;
+                self.entries.push(PendingSourceAuditRequest {
+                    request,
+                    marker_backed,
+                });
+                return AuditRequestQueueOutcome::QueuedAfterDroppingFallback;
+            }
+            self.conservative_recovery_latched = true;
+            return AuditRequestQueueOutcome::MarkerCouldNotFit;
+        }
+
+        self.conservative_recovery_latched = true;
+        AuditRequestQueueOutcome::FallbackCouldNotFit
+    }
+
+    pub(super) fn retain_source_ids(&mut self, allowed: &HashSet<String>) {
+        self.entries
+            .retain(|entry| allowed.contains(entry.request.source_id().as_str()));
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(super) fn clear(&mut self) {
+        self.entries.clear();
+        self.conservative_recovery_latched = false;
+    }
+
+    pub(super) fn conservative_recovery_latched(&self) -> bool {
+        self.conservative_recovery_latched
+    }
+
+    pub(super) fn clear_conservative_recovery_latch(&mut self) {
+        self.conservative_recovery_latched = false;
+    }
+
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(super) fn front(&self) -> Option<&SourceAuditRequest> {
+        self.entries.first().map(|entry| &entry.request)
+    }
+
+    pub(super) fn pop_front(&mut self) -> Option<SourceAuditRequest> {
+        (!self.entries.is_empty()).then(|| self.entries.remove(0).request)
+    }
+}
+
 #[derive(Default)]
 pub(super) struct GuiSourceWatchState {
     pub(super) watched_roots: WatchedRootIdentities,
     pub(super) sources: Vec<SampleSource>,
     pub(super) pending: HashMap<String, PendingGuiSourceWatch>,
     pub(super) acknowledged_paths: HashMap<(String, PathBuf), (CommittedWatcherPathState, Instant)>,
-    pub(super) pending_audit_requests: Vec<SourceAuditRequest>,
+    pub(super) pending_audit_requests: PendingSourceAuditRequests,
 }
 
 impl GuiSourceWatchState {
@@ -39,8 +165,19 @@ impl GuiSourceWatchState {
             .retain(|source_id, _| allowed.contains(source_id));
         self.acknowledged_paths
             .retain(|(source_id, _), _| allowed.contains(source_id));
-        self.pending_audit_requests
-            .retain(|request| allowed.contains(request.source_id().as_str()));
+        self.pending_audit_requests.retain_source_ids(&allowed);
+    }
+
+    pub(super) fn set_audit_request_capacity(&mut self, capacity: usize) {
+        self.pending_audit_requests.set_capacity(capacity);
+    }
+
+    pub(super) fn enqueue_audit_request(
+        &mut self,
+        request: SourceAuditRequest,
+        marker_backed: bool,
+    ) -> AuditRequestQueueOutcome {
+        self.pending_audit_requests.insert(request, marker_backed)
     }
 
     pub(super) fn apply_root_watch_update(

--- a/src/native_app/sample_library/source_watcher/state.rs
+++ b/src/native_app/sample_library/source_watcher/state.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 use wavecrate::sample_sources::SampleSource;
+use wavecrate_library::sample_sources::reconciliation::SourceAuditRequest;
 
 use super::classification::path_is_source_refresh_candidate;
 use super::debounce::{GuiSourceWatchEvent, PendingGuiSourceWatch};
@@ -23,6 +24,7 @@ pub(super) struct GuiSourceWatchState {
     pub(super) sources: Vec<SampleSource>,
     pub(super) pending: HashMap<String, PendingGuiSourceWatch>,
     pub(super) acknowledged_paths: HashMap<(String, PathBuf), (CommittedWatcherPathState, Instant)>,
+    pub(super) pending_audit_requests: Vec<SourceAuditRequest>,
 }
 
 impl GuiSourceWatchState {
@@ -37,6 +39,8 @@ impl GuiSourceWatchState {
             .retain(|source_id, _| allowed.contains(source_id));
         self.acknowledged_paths
             .retain(|(source_id, _), _| allowed.contains(source_id));
+        self.pending_audit_requests
+            .retain(|request| allowed.contains(request.source_id().as_str()));
     }
 
     pub(super) fn apply_root_watch_update(

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -93,6 +93,7 @@ impl NativeAppState {
             | GuiMessage::SourceFilesystemChanged { .. }
             | GuiMessage::SourceWatcherReady { .. }
             | GuiMessage::SourceWatcherJournalGap { .. }
+            | GuiMessage::SourceWatcherManifestAuditRequested { .. }
             | GuiMessage::SourceWatcherCheckpointReady(_)
             | GuiMessage::SourceFilesystemSyncFinished(_)
             | GuiMessage::SourceManifestAuditCommitted { .. }

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -165,6 +165,14 @@ impl NativeAppState {
                     .source_processing
                     .request_source_manifest_audit(&source_id, reason);
             }
+            GuiMessage::SourceWatcherManifestAuditRequested { request } => {
+                self.background
+                    .source_processing
+                    .request_source_manifest_audit_for_request(
+                        request,
+                        "live_unproven_audit_request",
+                    );
+            }
             GuiMessage::SourceWatcherCheckpointReady(request) => {
                 if self
                     .library
@@ -204,7 +212,13 @@ impl NativeAppState {
                 lifecycle_generation,
                 source_revision,
                 complete,
+                receipt,
             } => {
+                if let Some(watcher) = self.library.source_watcher.as_ref()
+                    && let Some(receipt) = receipt
+                {
+                    watcher.acknowledge_source_audit_receipt(receipt);
+                }
                 let source_is_current = self.library.folder_browser.source_exists(&source_id)
                     && self.background.source_lifecycle_generations.get(&source_id)
                         == Some(&lifecycle_generation);

--- a/src/native_app/source_processing/events.rs
+++ b/src/native_app/source_processing/events.rs
@@ -119,6 +119,7 @@ pub(in crate::native_app) enum SourceProcessingEvent {
         lifecycle: SourceProcessingLifecycle,
         source_revision: Option<u64>,
         complete: bool,
+        receipt: Option<wavecrate_library::sample_sources::reconciliation::SourceAuditReceipt>,
     },
     Completed,
 }

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -37,6 +37,7 @@ use wavecrate::sample_sources::{
         complete_pending_deep_hash_for_path, sync_paths_with_progress,
     },
 };
+use wavecrate_library::sample_sources::reconciliation::SourceAuditRequest;
 
 use super::worker::{SourceProcessingFailure, source_database_failure};
 use super::{

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -33,7 +33,8 @@ use wavecrate::sample_sources::{
     },
     scanner::{
         CommittedSourceDelta, ContentAuditActivity, ContentAuditBudget, ContentAuditStorage,
-        ManifestAuditOutcome, audit_source_and_record_with_budget_and_progress_and_writer_outcome,
+        ManifestAuditOutcome,
+        audit_source_and_record_with_budget_and_progress_and_writer_with_request,
         complete_pending_deep_hash_for_path, sync_paths_with_progress,
     },
 };

--- a/src/native_app/source_processing/supervisor/commands.rs
+++ b/src/native_app/source_processing/supervisor/commands.rs
@@ -3,6 +3,7 @@ use super::{
     SourceDeltaQueueResult, SourceProcessingBudgetHandle, SourceProcessingSupervisor,
     register_source_for_scan_locked,
 };
+use wavecrate_library::sample_sources::reconciliation::SourceAuditRequest;
 
 /// Lifecycle hints that may require source-audit admission, but are not proof that a complete
 /// traversal is required. The durable readiness and watcher coverage gates decide that per source.
@@ -39,6 +40,19 @@ pub(super) fn request_source_manifest_audit(
     control.mark_source_dirty(source_id, reason);
     drop(control);
     shared.wake.notify_one();
+}
+
+pub(super) fn request_source_manifest_audit_for_request(
+    shared: &super::Shared,
+    request: SourceAuditRequest,
+    reason: &'static str,
+) {
+    let mut control = shared.control();
+    if control.queue_source_audit_request(request) {
+        control.notify(reason);
+        drop(control);
+        shared.wake.notify_one();
+    }
 }
 
 impl SourceProcessingSupervisor {
@@ -107,6 +121,15 @@ impl SourceProcessingSupervisor {
         reason: &'static str,
     ) {
         request_source_manifest_audit(self.shared.as_ref(), source_id, reason);
+    }
+
+    /// Queue one opaque live-capture audit request without widening its covered boundary.
+    pub(in crate::native_app) fn request_source_manifest_audit_for_request(
+        &self,
+        request: SourceAuditRequest,
+        reason: &'static str,
+    ) {
+        request_source_manifest_audit_for_request(self.shared.as_ref(), request, reason);
     }
 
     pub(in crate::native_app) fn wake_source(&self, source_id: &str, reason: &'static str) {

--- a/src/native_app/source_processing/supervisor/control.rs
+++ b/src/native_app/source_processing/supervisor/control.rs
@@ -78,9 +78,25 @@ impl ControlState {
         }
     }
 
-    fn request_is_newer(existing: &SourceAuditRequest, request: &SourceAuditRequest) -> bool {
-        existing.identity() != request.identity()
-            || existing.boundary().through() < request.boundary().through()
+    fn merge_deferred_source_audit_request(
+        &mut self,
+        source_id: &str,
+        request: SourceAuditRequest,
+    ) {
+        let Some(existing) = self.pending_source_audit_requests.get_mut(source_id) else {
+            self.pending_source_audit_requests
+                .insert(source_id.to_string(), request);
+            return;
+        };
+
+        // A deferred request is never allowed to lose an earlier boundary. Different
+        // identities cannot be covered; the lifecycle fence owns that stale identity boundary,
+        // so retain the request from the latest current lane in the single deferred slot.
+        if let Some(covering) = existing.covering(&request) {
+            *existing = covering;
+        } else {
+            *existing = request;
+        }
     }
 
     pub(super) fn queue_source_audit_request(&mut self, request: SourceAuditRequest) -> bool {
@@ -88,19 +104,21 @@ impl ControlState {
         if !self.source_is_active(&source_id) {
             return false;
         }
-        let request_is_after_active = self
-            .active_source_audit_requests
-            .get(&source_id)
-            .is_none_or(|active| Self::request_is_newer(active, &request));
-        if request_is_after_active {
-            let pending_new = self
-                .pending_source_audit_requests
-                .get(&source_id)
-                .is_none_or(|existing| Self::request_is_newer(existing, &request));
-            if pending_new {
-                self.pending_source_audit_requests
-                    .insert(source_id.clone(), request);
-            }
+        let deferred_request = match self.active_source_audit_requests.get(&source_id) {
+            None => Some(request),
+            Some(active) => match active.covering(&request) {
+                // The active request already covers the incoming evidence. There is no
+                // deferred work to retain for this arrival.
+                Some(covering) if covering == *active => None,
+                // Preserve the union in the deferred slot without mutating the active request.
+                Some(covering) => Some(covering),
+                // A root or generation change is not coverable by the active request. Keep the
+                // identity separate and let lifecycle fencing reject stale work at its boundary.
+                None => Some(request),
+            },
+        };
+        if let Some(deferred_request) = deferred_request {
+            self.merge_deferred_source_audit_request(&source_id, deferred_request);
         }
         self.force_manifest_audit_sources.insert(source_id.clone());
         self.deferred_lifecycle_audit_sources.remove(&source_id);
@@ -122,14 +140,29 @@ impl ControlState {
         let Some(active) = self.active_source_audit_requests.remove(source_id) else {
             return;
         };
-        if !complete
-            && self
-                .pending_source_audit_requests
-                .get(source_id)
-                .is_none_or(|pending| !Self::request_is_newer(&active, pending))
+
+        if !complete && self.source_is_active(source_id) {
+            if let Some(pending) = self.pending_source_audit_requests.get_mut(source_id) {
+                // Do not overwrite deferred work with an incomplete active request. Same-
+                // identity work retains the complete union; a different identity remains
+                // separate and is treated as the current deferred fence.
+                if let Some(covering) = active.covering(pending) {
+                    *pending = covering;
+                }
+            } else {
+                self.pending_source_audit_requests
+                    .insert(source_id.to_string(), active);
+            }
+        }
+
+        // The coordinator may have consumed dirty/force state while this request was active.
+        // Keep deferred work actionable and wake the owner whenever it remains.
+        if self.pending_source_audit_requests.contains_key(source_id)
+            && self.source_is_active(source_id)
         {
-            self.pending_source_audit_requests
-                .insert(source_id.to_string(), active);
+            self.force_manifest_audit_sources
+                .insert(source_id.to_string());
+            self.mark_source_dirty(source_id, "source_audit_deferred");
         }
     }
 

--- a/src/native_app/source_processing/supervisor/control.rs
+++ b/src/native_app/source_processing/supervisor/control.rs
@@ -5,6 +5,7 @@ use super::{
 };
 use crate::native_app::sample_library::source_watcher::RevisionBoundCheckpoint;
 use std::collections::VecDeque;
+use wavecrate_library::sample_sources::reconciliation::SourceAuditRequest;
 
 pub(super) struct ControlState {
     pub(super) sources: BTreeMap<String, SampleSource>,
@@ -24,6 +25,8 @@ pub(super) struct ControlState {
     pub(super) accepted_manifest_revisions: BTreeMap<String, AcceptedManifestRevision>,
     pub(super) awaiting_foreground_refresh_sources: BTreeSet<String>,
     pub(super) force_manifest_audit_sources: BTreeSet<String>,
+    pub(super) pending_source_audit_requests: BTreeMap<String, SourceAuditRequest>,
+    pub(super) active_source_audit_requests: BTreeMap<String, SourceAuditRequest>,
     pub(super) force_reanalysis_sources: BTreeSet<String>,
     pub(super) quarantined_sources: BTreeSet<String>,
     pub(super) pending_retirements: BTreeMap<u64, PendingSourceRetirement>,
@@ -72,6 +75,61 @@ impl ControlState {
             self.safety_probe_sources.remove(source_id);
             self.dirty_sources.insert(source_id.to_string());
             self.notify(reason);
+        }
+    }
+
+    fn request_is_newer(existing: &SourceAuditRequest, request: &SourceAuditRequest) -> bool {
+        existing.identity() != request.identity()
+            || existing.boundary().through() < request.boundary().through()
+    }
+
+    pub(super) fn queue_source_audit_request(&mut self, request: SourceAuditRequest) -> bool {
+        let source_id = request.source_id().as_str().to_string();
+        if !self.source_is_active(&source_id) {
+            return false;
+        }
+        let request_is_after_active = self
+            .active_source_audit_requests
+            .get(&source_id)
+            .is_none_or(|active| Self::request_is_newer(active, &request));
+        if request_is_after_active {
+            let pending_new = self
+                .pending_source_audit_requests
+                .get(&source_id)
+                .is_none_or(|existing| Self::request_is_newer(existing, &request));
+            if pending_new {
+                self.pending_source_audit_requests
+                    .insert(source_id.clone(), request);
+            }
+        }
+        self.force_manifest_audit_sources.insert(source_id.clone());
+        self.deferred_lifecycle_audit_sources.remove(&source_id);
+        self.mark_source_dirty(&source_id, "live_unproven_audit_request");
+        true
+    }
+
+    pub(super) fn begin_source_audit_request(
+        &mut self,
+        source_id: &str,
+    ) -> Option<SourceAuditRequest> {
+        let request = self.pending_source_audit_requests.remove(source_id)?;
+        self.active_source_audit_requests
+            .insert(source_id.to_string(), request.clone());
+        Some(request)
+    }
+
+    pub(super) fn finish_source_audit_request(&mut self, source_id: &str, complete: bool) {
+        let Some(active) = self.active_source_audit_requests.remove(source_id) else {
+            return;
+        };
+        if !complete
+            && self
+                .pending_source_audit_requests
+                .get(source_id)
+                .is_none_or(|pending| !Self::request_is_newer(&active, pending))
+        {
+            self.pending_source_audit_requests
+                .insert(source_id.to_string(), active);
         }
     }
 

--- a/src/native_app/source_processing/supervisor/coordinator_completion.rs
+++ b/src/native_app/source_processing/supervisor/coordinator_completion.rs
@@ -75,6 +75,15 @@ pub(super) fn handle_completion(
         );
         return;
     }
+    if matches!(&candidate.task, RuntimeTask::ManifestAudit { .. }) {
+        let complete = matches!(
+            &result,
+            Ok(ExecutionOutcome::Completed | ExecutionOutcome::CompletedAwaitingForegroundRefresh)
+        );
+        shared
+            .control()
+            .finish_source_audit_request(candidate.source.id.as_str(), complete);
+    }
     if matches!(
         &result,
         Ok(ExecutionOutcome::Completed | ExecutionOutcome::CompletedAwaitingForegroundRefresh)

--- a/src/native_app/source_processing/supervisor/execution.rs
+++ b/src/native_app/source_processing/supervisor/execution.rs
@@ -9,8 +9,8 @@ use super::{
     RuntimeTask, SourceAuditRequest, SourceDatabase, SourceProcessingActivity,
     SourceProcessingEvent, SourceProcessingLifecycle, SourceProcessingPresentation,
     SourceProcessingProgressEvent,
-    audit_source_and_record_with_budget_and_progress_and_writer_outcome, execute_readiness_target,
-    manifest_audit_source_row_active, now_epoch_seconds,
+    audit_source_and_record_with_budget_and_progress_and_writer_with_request,
+    execute_readiness_target, manifest_audit_source_row_active, now_epoch_seconds,
 };
 
 #[cfg(test)]
@@ -109,25 +109,24 @@ pub(super) fn execute_candidate_with_presentation(
                 ));
                 last_progress_publish_at = Some(Instant::now());
             };
-            let (outcome, manifest_complete, content_incomplete_error, root_identity) =
-                match audit_source_and_record_with_budget_and_progress_and_writer_outcome(
+            let (outcome, manifest_complete, content_incomplete_error, audit_commit) =
+                match audit_source_and_record_with_budget_and_progress_and_writer_with_request(
                     &database,
                     Some(cancel),
                     content_budget,
                     completed_at,
                     &mut publish_progress,
                     database_writer,
+                    audit_request.as_ref(),
                 ) {
                     Ok(ManifestAuditOutcome::Complete {
                         stats,
                         content_incomplete,
-                        root_identity,
-                    }) => (stats, true, content_incomplete, Some(root_identity)),
+                        audit_commit,
+                    }) => (stats, true, content_incomplete, Some(audit_commit)),
                     Ok(ManifestAuditOutcome::Incomplete {
-                        committed,
-                        error,
-                        root_identity,
-                    }) => (committed, false, Some(error), Some(root_identity)),
+                        committed, error, ..
+                    }) => (committed, false, Some(error), None),
                     Err(error) => {
                         publish_event(SourceProcessingEvent::ManifestAuditFinished {
                             lifecycle: SourceProcessingLifecycle::new(
@@ -201,7 +200,7 @@ pub(super) fn execute_candidate_with_presentation(
             let foreground_refresh_owns_reconciliation =
                 browser_refresh_required && audit_published;
             let cancelled = cancel.load(Ordering::Acquire);
-            let execution_outcome = manifest_audit_execution_outcome(
+            let mut execution_outcome = manifest_audit_execution_outcome(
                 foreground_refresh_owns_reconciliation,
                 !manifest_complete,
                 cancelled,
@@ -209,18 +208,27 @@ pub(super) fn execute_candidate_with_presentation(
             let receipt = if matches!(
                 execution_outcome,
                 ExecutionOutcome::Completed | ExecutionOutcome::CompletedAwaitingForegroundRefresh
-            ) && let (Some(request), Some(root_identity)) =
-                (audit_request.as_ref(), root_identity.as_ref())
-            {
-                Some(request.complete(
-                    committed_source_revision,
-                    wavecrate_library::sample_sources::reconciliation::RootIdentity::from_bytes(
-                        root_identity.as_bytes().to_vec(),
-                    ),
-                ))
+            ) {
+                audit_request
+                    .as_ref()
+                    .zip(audit_commit)
+                    .and_then(|(request, audit_commit)| {
+                        request.complete_from_committed_audit(audit_commit)
+                    })
+                    .or_else(|| audit_request.as_ref().map(SourceAuditRequest::incomplete))
             } else {
                 audit_request.as_ref().map(SourceAuditRequest::incomplete)
             };
+            if matches!(
+                execution_outcome,
+                ExecutionOutcome::Completed | ExecutionOutcome::CompletedAwaitingForegroundRefresh
+            ) && audit_request.is_some()
+                && !receipt
+                    .as_ref()
+                    .is_some_and(|receipt| receipt.is_complete())
+            {
+                execution_outcome = ExecutionOutcome::Failed;
+            }
             publish_event(SourceProcessingEvent::ManifestAuditFinished {
                 lifecycle: SourceProcessingLifecycle::new(
                     candidate.source.id.as_str(),

--- a/src/native_app/source_processing/supervisor/execution.rs
+++ b/src/native_app/source_processing/supervisor/execution.rs
@@ -6,8 +6,9 @@ use super::{
 use super::{
     AtomicBool, ContentAuditActivity, ContentAuditBudget, ContentAuditStorage, DatabaseWriterGate,
     Duration, ExecutionOutcome, Instant, ManifestAuditOutcome, Ordering, RuntimeCandidate,
-    RuntimeTask, SourceDatabase, SourceProcessingActivity, SourceProcessingEvent,
-    SourceProcessingLifecycle, SourceProcessingPresentation, SourceProcessingProgressEvent,
+    RuntimeTask, SourceAuditRequest, SourceDatabase, SourceProcessingActivity,
+    SourceProcessingEvent, SourceProcessingLifecycle, SourceProcessingPresentation,
+    SourceProcessingProgressEvent,
     audit_source_and_record_with_budget_and_progress_and_writer_outcome, execute_readiness_target,
     manifest_audit_source_row_active, now_epoch_seconds,
 };
@@ -28,6 +29,7 @@ pub(super) fn execute_candidate(
         database_writer,
         content_audit_activity,
         SourceProcessingPresentation::UserRelevant,
+        None,
         publish_event,
     )
 }
@@ -39,6 +41,7 @@ pub(super) fn execute_candidate_with_presentation(
     database_writer: &DatabaseWriterGate,
     content_audit_activity: ContentAuditActivity,
     presentation: SourceProcessingPresentation,
+    audit_request: Option<SourceAuditRequest>,
     publish_event: &mut dyn FnMut(SourceProcessingEvent) -> bool,
 ) -> Result<ExecutionOutcome, String> {
     let result = match &candidate.task {
@@ -106,7 +109,7 @@ pub(super) fn execute_candidate_with_presentation(
                 ));
                 last_progress_publish_at = Some(Instant::now());
             };
-            let (outcome, manifest_complete, content_incomplete_error) =
+            let (outcome, manifest_complete, content_incomplete_error, root_identity) =
                 match audit_source_and_record_with_budget_and_progress_and_writer_outcome(
                     &database,
                     Some(cancel),
@@ -118,10 +121,13 @@ pub(super) fn execute_candidate_with_presentation(
                     Ok(ManifestAuditOutcome::Complete {
                         stats,
                         content_incomplete,
-                    }) => (stats, true, content_incomplete),
-                    Ok(ManifestAuditOutcome::Incomplete { committed, error }) => {
-                        (committed, false, Some(error))
-                    }
+                        root_identity,
+                    }) => (stats, true, content_incomplete, Some(root_identity)),
+                    Ok(ManifestAuditOutcome::Incomplete {
+                        committed,
+                        error,
+                        root_identity,
+                    }) => (committed, false, Some(error), Some(root_identity)),
                     Err(error) => {
                         publish_event(SourceProcessingEvent::ManifestAuditFinished {
                             lifecycle: SourceProcessingLifecycle::new(
@@ -130,6 +136,7 @@ pub(super) fn execute_candidate_with_presentation(
                             ),
                             source_revision: None,
                             complete: false,
+                            receipt: audit_request.as_ref().map(SourceAuditRequest::incomplete),
                         });
                         return Err(error.to_string());
                     }
@@ -193,6 +200,27 @@ pub(super) fn execute_candidate_with_presentation(
             });
             let foreground_refresh_owns_reconciliation =
                 browser_refresh_required && audit_published;
+            let cancelled = cancel.load(Ordering::Acquire);
+            let execution_outcome = manifest_audit_execution_outcome(
+                foreground_refresh_owns_reconciliation,
+                !manifest_complete,
+                cancelled,
+            );
+            let receipt = if matches!(
+                execution_outcome,
+                ExecutionOutcome::Completed | ExecutionOutcome::CompletedAwaitingForegroundRefresh
+            ) && let (Some(request), Some(root_identity)) =
+                (audit_request.as_ref(), root_identity.as_ref())
+            {
+                Some(request.complete(
+                    committed_source_revision,
+                    wavecrate_library::sample_sources::reconciliation::RootIdentity::from_bytes(
+                        root_identity.as_bytes().to_vec(),
+                    ),
+                ))
+            } else {
+                audit_request.as_ref().map(SourceAuditRequest::incomplete)
+            };
             publish_event(SourceProcessingEvent::ManifestAuditFinished {
                 lifecycle: SourceProcessingLifecycle::new(
                     candidate.source.id.as_str(),
@@ -200,6 +228,7 @@ pub(super) fn execute_candidate_with_presentation(
                 ),
                 source_revision: Some(committed_source_revision),
                 complete: manifest_complete,
+                receipt,
             });
             if let Some(error) = content_incomplete_error {
                 tracing::warn!(
@@ -210,11 +239,7 @@ pub(super) fn execute_candidate_with_presentation(
                     "Manifest audit did not complete all work"
                 );
             }
-            Ok(manifest_audit_execution_outcome(
-                foreground_refresh_owns_reconciliation,
-                !manifest_complete,
-                cancel.load(Ordering::Acquire),
-            ))
+            Ok(execution_outcome)
         }
         RuntimeTask::Readiness(target) => {
             execute_readiness_target(&candidate.source, target, cancel, database_writer)

--- a/src/native_app/source_processing/supervisor/execution_pool.rs
+++ b/src/native_app/source_processing/supervisor/execution_pool.rs
@@ -171,6 +171,16 @@ fn run_worker(
             }
         };
         let started = Instant::now();
+        let audit_request = if matches!(
+            &request.candidate.task,
+            super::RuntimeTask::ManifestAudit { .. }
+        ) {
+            shared
+                .control()
+                .begin_source_audit_request(request.candidate.source.id.as_str())
+        } else {
+            None
+        };
         let result = execute_candidate_with_presentation(
             &request.candidate,
             lifecycle_generation,
@@ -178,6 +188,7 @@ fn run_worker(
             &shared.database_writer,
             content_audit_activity,
             request.presentation,
+            audit_request,
             &mut |event| shared.publish_event(event),
         );
         let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;

--- a/src/native_app/source_processing/supervisor/lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/lifecycle.rs
@@ -133,6 +133,14 @@ impl SourceProcessingSupervisor {
             .force_manifest_audit_sources
             .retain(|source_id| retained_source_ids.contains(source_id));
         control
+            .pending_source_audit_requests
+            .retain(|source_id, _| {
+                retained_source_ids.contains(source_id) && !changed_source_ids.contains(source_id)
+            });
+        control.active_source_audit_requests.retain(|source_id, _| {
+            retained_source_ids.contains(source_id) && !changed_source_ids.contains(source_id)
+        });
+        control
             .force_reanalysis_sources
             .retain(|source_id| retained_source_ids.contains(source_id));
         control.force_manifest_audit_sources.extend(

--- a/src/native_app/source_processing/supervisor/state.rs
+++ b/src/native_app/source_processing/supervisor/state.rs
@@ -153,6 +153,8 @@ impl Shared {
                 accepted_manifest_revisions: BTreeMap::new(),
                 awaiting_foreground_refresh_sources: BTreeSet::new(),
                 force_manifest_audit_sources: BTreeSet::new(),
+                pending_source_audit_requests: BTreeMap::new(),
+                active_source_audit_requests: BTreeMap::new(),
                 force_reanalysis_sources: BTreeSet::new(),
                 quarantined_sources: BTreeSet::new(),
                 pending_retirements,

--- a/src/native_app/source_processing/supervisor/tests/admission_and_audits.rs
+++ b/src/native_app/source_processing/supervisor/tests/admission_and_audits.rs
@@ -300,7 +300,11 @@ fn live_audit_requests_started_and_arriving_during_audit_keep_deferred_boundarie
             control
                 .pending_source_audit_requests
                 .get(source.id.as_str()),
-            Some(&second_request)
+            Some(
+                &first_request
+                    .covering(&second_request)
+                    .expect("same-identity deferred union"),
+            )
         );
         control.finish_source_audit_request(source.id.as_str(), true);
         assert!(
@@ -310,10 +314,270 @@ fn live_audit_requests_started_and_arriving_during_audit_keep_deferred_boundarie
         );
         assert_eq!(
             control.begin_source_audit_request(source.id.as_str()),
-            Some(second_request),
+            Some(
+                first_request
+                    .covering(&second_request)
+                    .expect("same-identity deferred union"),
+            ),
             "a request arriving after audit start must remain deferred"
         );
     }
+}
+
+fn test_live_audit_requests(
+    source_id: &SourceId,
+    root: &wavecrate_library::sample_sources::reconciliation::RootIdentity,
+) -> Vec<SourceAuditRequest> {
+    use wavecrate_library::sample_sources::reconciliation::{
+        BackendStreamIdentity, CaptureBoundary, RawEventKind, RawObservation, RawObservationLimits,
+        RawObservationProvenance, RawObservedPath, RawPathRole, ReconciliationAdmissionLimits,
+        ReconciliationAdmissionOwner, ReconciliationAdmissionSupervisor, SyntheticObservationBatch,
+    };
+
+    let mut admission = ReconciliationAdmissionOwner::new(ReconciliationAdmissionSupervisor::new(
+        ReconciliationAdmissionLimits::new(
+            1,
+            RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("lane limits"),
+            RawObservationLimits::new(16, usize::MAX, usize::MAX).expect("global limits"),
+            4,
+            8,
+            8,
+        )
+        .expect("admission limits"),
+    ));
+    let lane = admission
+        .begin_source(source_id.clone(), root.clone())
+        .expect("test source lane");
+    let batch = |captured_at| {
+        SyntheticObservationBatch::new(
+            RawObservationProvenance::new(
+                source_id.clone(),
+                Some(root.clone()),
+                Some(BackendStreamIdentity::from_bytes(b"test-stream".to_vec())),
+                lane.generation(),
+                CaptureBoundary::try_new(captured_at, None, None).expect("capture boundary"),
+            ),
+            vec![RawObservation::new(
+                RawEventKind::Create,
+                vec![RawObservedPath::new(
+                    "sample.wav".into(),
+                    RawPathRole::Subject,
+                )],
+            )],
+            RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("batch limits"),
+        )
+    };
+
+    (1..=3)
+        .map(|captured_at| {
+            admission
+                .admit_live_with_correlation(batch(captured_at))
+                .expect("test live admission")
+                .correlation()
+                .expect("test live correlation")
+                .audit_request()
+                .clone()
+        })
+        .collect()
+}
+
+#[test]
+fn audit_request_union_preserves_active_range_and_deferred_completion() {
+    let (_directory, source) = unhashed_source("exact-range-union");
+    let shared = Arc::new(Shared::new(vec![source.clone()], None));
+    let requests = test_live_audit_requests(
+        &source.id,
+        &wavecrate_library::sample_sources::reconciliation::RootIdentity::from_bytes(
+            b"root-a".to_vec(),
+        ),
+    );
+    let earliest = &requests[0];
+    let active = requests[1].clone();
+    let earlier = earliest
+        .covering(&active)
+        .expect("same-identity earlier request");
+    let extending = active
+        .covering(&requests[2])
+        .expect("same-identity extending request");
+
+    let mut control = shared.control();
+    control.dirty_sources.clear();
+    control.force_manifest_audit_sources.clear();
+    assert!(control.queue_source_audit_request(active.clone()));
+    assert_eq!(
+        control.begin_source_audit_request(source.id.as_str()),
+        Some(active.clone())
+    );
+
+    assert!(control.queue_source_audit_request(earlier.clone()));
+    assert_eq!(
+        control.active_source_audit_requests.get(source.id.as_str()),
+        Some(&active),
+        "active audit identity and boundary must remain immutable"
+    );
+    assert_eq!(
+        control
+            .pending_source_audit_requests
+            .get(source.id.as_str()),
+        Some(&earlier),
+        "an earlier equal-through boundary must remain deferred"
+    );
+
+    assert!(control.queue_source_audit_request(extending.clone()));
+    assert_eq!(
+        control
+            .pending_source_audit_requests
+            .get(source.id.as_str())
+            .expect("deferred union"),
+        &earlier
+            .covering(&extending)
+            .expect("deferred covering union")
+    );
+
+    control.finish_source_audit_request(source.id.as_str(), true);
+    assert_eq!(
+        control.begin_source_audit_request(source.id.as_str()),
+        Some(
+            earlier
+                .covering(&extending)
+                .expect("deferred covering union"),
+        ),
+        "completed active work must leave the deferred union available"
+    );
+    control.finish_source_audit_request(source.id.as_str(), true);
+    assert!(
+        !control
+            .pending_source_audit_requests
+            .contains_key(source.id.as_str())
+    );
+    assert!(
+        !control
+            .active_source_audit_requests
+            .contains_key(source.id.as_str())
+    );
+}
+
+#[test]
+fn incomplete_audit_requeues_without_overwriting_an_earlier_deferred_request() {
+    let (_directory, source) = unhashed_source("incomplete-exact-range");
+    let shared = Arc::new(Shared::new(vec![source.clone()], None));
+    let requests = test_live_audit_requests(
+        &source.id,
+        &wavecrate_library::sample_sources::reconciliation::RootIdentity::from_bytes(
+            b"root-a".to_vec(),
+        ),
+    );
+    let active = requests[1].clone();
+    let earlier = requests[0]
+        .covering(&active)
+        .expect("same-identity earlier request");
+
+    let mut control = shared.control();
+    control.dirty_sources.clear();
+    control.force_manifest_audit_sources.clear();
+    assert!(control.queue_source_audit_request(active.clone()));
+    assert_eq!(
+        control.begin_source_audit_request(source.id.as_str()),
+        Some(active)
+    );
+    assert!(control.queue_source_audit_request(earlier.clone()));
+    let wake_before_finish = control.wake_generation;
+
+    control.finish_source_audit_request(source.id.as_str(), false);
+
+    assert!(
+        !control
+            .active_source_audit_requests
+            .contains_key(source.id.as_str())
+    );
+    assert_eq!(
+        control
+            .pending_source_audit_requests
+            .get(source.id.as_str()),
+        Some(&earlier),
+        "incomplete active work must not overwrite the earlier deferred boundary"
+    );
+    assert!(
+        control
+            .force_manifest_audit_sources
+            .contains(source.id.as_str())
+    );
+    assert!(control.dirty_sources.contains(source.id.as_str()));
+    assert!(
+        control.wake_generation > wake_before_finish,
+        "deferred incomplete work must wake source processing"
+    );
+}
+
+#[test]
+fn audit_requests_with_different_root_or_generation_stay_separate_and_fenced() {
+    use wavecrate_library::sample_sources::reconciliation::{
+        RawObservationLimits, ReconciliationAdmissionLimits, ReconciliationAdmissionOwner,
+        ReconciliationAdmissionSupervisor,
+    };
+
+    let (_directory, source) = unhashed_source("identity-separated-audit");
+    let shared = Arc::new(Shared::new(vec![source.clone()], None));
+    let mut old_requests = test_live_audit_requests(
+        &source.id,
+        &wavecrate_library::sample_sources::reconciliation::RootIdentity::from_bytes(
+            b"root-a".to_vec(),
+        ),
+    );
+    let old = old_requests.remove(0);
+    let mut replacement_owner =
+        ReconciliationAdmissionOwner::new(ReconciliationAdmissionSupervisor::new(
+            ReconciliationAdmissionLimits::new(
+                1,
+                RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("lane limits"),
+                RawObservationLimits::new(16, usize::MAX, usize::MAX).expect("global limits"),
+                1,
+                8,
+                8,
+            )
+            .expect("admission limits"),
+        ));
+    let replacement_source_id = source.id.clone();
+    replacement_owner
+        .begin_source(
+            replacement_source_id.clone(),
+            wavecrate_library::sample_sources::reconciliation::RootIdentity::from_bytes(
+                b"root-b".to_vec(),
+            ),
+        )
+        .expect("replacement lane");
+    let replacement = replacement_owner
+        .source_audit_request_for_current_lane(&replacement_source_id)
+        .expect("replacement request");
+
+    let mut control = shared.control();
+    assert!(control.queue_source_audit_request(old.clone()));
+    assert_eq!(
+        control.begin_source_audit_request(source.id.as_str()),
+        Some(old.clone())
+    );
+    assert!(control.queue_source_audit_request(replacement.clone()));
+
+    assert_eq!(
+        control.active_source_audit_requests.get(source.id.as_str()),
+        Some(&old),
+        "a replacement identity must not mutate the active request"
+    );
+    assert_eq!(
+        control
+            .pending_source_audit_requests
+            .get(source.id.as_str()),
+        Some(&replacement),
+        "different root/generation requests must not be unioned"
+    );
+    control.finish_source_audit_request(source.id.as_str(), false);
+    assert_eq!(
+        control
+            .pending_source_audit_requests
+            .get(source.id.as_str()),
+        Some(&replacement),
+        "an incomplete stale identity must not overwrite the replacement request"
+    );
 }
 
 #[test]

--- a/src/native_app/source_processing/supervisor/tests/admission_and_audits.rs
+++ b/src/native_app/source_processing/supervisor/tests/admission_and_audits.rs
@@ -186,13 +186,10 @@ fn manifest_audit_is_scheduled_only_when_the_active_source_is_due() {
     else {
         panic!("manifest audit discovery unexpectedly cancelled");
     };
-    assert!(
-        due.iter()
-            .any(|candidate| matches!(
-                candidate.task,
-                RuntimeTask::ManifestAudit { accelerated: false }
-            ))
-    );
+    assert!(due.iter().any(|candidate| matches!(
+        candidate.task,
+        RuntimeTask::ManifestAudit { accelerated: false }
+    )));
 
     db.set_metadata(
         META_LAST_MANIFEST_AUDIT_AT,
@@ -223,14 +220,100 @@ fn manifest_audit_is_scheduled_only_when_the_active_source_is_due() {
     .expect("discover forced startup manifest audit") else {
         panic!("forced manifest audit discovery unexpectedly cancelled");
     };
-    assert!(
-        forced
-            .iter()
-            .any(|candidate| matches!(
-                candidate.task,
-                RuntimeTask::ManifestAudit { accelerated: true }
-            ))
-    );
+    assert!(forced.iter().any(|candidate| matches!(
+        candidate.task,
+        RuntimeTask::ManifestAudit { accelerated: true }
+    )));
+}
+
+#[test]
+fn live_audit_requests_started_and_arriving_during_audit_keep_deferred_boundaries() {
+    use wavecrate_library::sample_sources::reconciliation::{
+        BackendStreamIdentity, CaptureBoundary, RawEventKind, RawObservation, RawObservationLimits,
+        RawObservationProvenance, RawObservedPath, RawPathRole, ReconciliationAdmissionLimits,
+        ReconciliationAdmissionOwner, ReconciliationAdmissionSupervisor, RootIdentity,
+        SyntheticObservationBatch,
+    };
+
+    let (_directory, source) = unhashed_source("live-audit-boundaries");
+    let mut source_admission =
+        ReconciliationAdmissionOwner::new(ReconciliationAdmissionSupervisor::new(
+            ReconciliationAdmissionLimits::new(
+                1,
+                RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("lane limits"),
+                RawObservationLimits::new(16, usize::MAX, usize::MAX).expect("global limits"),
+                2,
+                8,
+                8,
+            )
+            .expect("admission limits"),
+        ));
+    let root = RootIdentity::from_bytes(b"live-audit-root".to_vec());
+    let lane = source_admission
+        .begin_source(source.id.clone(), root.clone())
+        .expect("capturing watcher lane");
+    let batch = |captured_at| {
+        SyntheticObservationBatch::new(
+            RawObservationProvenance::new(
+                source.id.clone(),
+                Some(root.clone()),
+                Some(BackendStreamIdentity::from_bytes(b"stream".to_vec())),
+                lane.generation(),
+                CaptureBoundary::try_new(captured_at, None, None).expect("capture boundary"),
+            ),
+            vec![RawObservation::new(
+                RawEventKind::Create,
+                vec![RawObservedPath::new(
+                    "sample.wav".into(),
+                    RawPathRole::Subject,
+                )],
+            )],
+            RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("batch limits"),
+        )
+    };
+    let first = source_admission
+        .admit_live_with_correlation(batch(1))
+        .expect("first live capture");
+    let first_request = first
+        .correlation()
+        .expect("first live correlation")
+        .audit_request();
+    let second = source_admission
+        .admit_live_with_correlation(batch(2))
+        .expect("second live capture");
+    let second_request = second
+        .correlation()
+        .expect("second live correlation")
+        .audit_request();
+    assert!(second_request.boundary().through() > first_request.boundary().through());
+
+    let shared = Arc::new(Shared::new(vec![source.clone()], None));
+    {
+        let mut control = shared.control();
+        assert!(control.queue_source_audit_request(first_request.clone()));
+        assert_eq!(
+            control.begin_source_audit_request(source.id.as_str()),
+            Some(first_request.clone())
+        );
+        assert!(control.queue_source_audit_request(second_request.clone()));
+        assert_eq!(
+            control
+                .pending_source_audit_requests
+                .get(source.id.as_str()),
+            Some(&second_request)
+        );
+        control.finish_source_audit_request(source.id.as_str(), true);
+        assert!(
+            !control
+                .active_source_audit_requests
+                .contains_key(source.id.as_str())
+        );
+        assert_eq!(
+            control.begin_source_audit_request(source.id.as_str()),
+            Some(second_request),
+            "a request arriving after audit start must remain deferred"
+        );
+    }
 }
 
 #[test]
@@ -374,7 +457,7 @@ fn scheduled_manifest_audit_does_not_recreate_source_removed_after_discovery() {
             ContentAuditActivity::default(),
             &mut |_| false,
         )
-            .expect("unavailable audit is parked"),
+        .expect("unavailable audit is parked"),
         ExecutionOutcome::Parked
     );
     assert!(

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -29,6 +29,7 @@ pub mod scanner {
         audit_source_and_record, audit_source_and_record_with_budget_and_progress,
         audit_source_and_record_with_budget_and_progress_and_writer,
         audit_source_and_record_with_budget_and_progress_and_writer_outcome,
+        audit_source_and_record_with_budget_and_progress_and_writer_with_request,
         audit_source_and_record_with_progress, audit_source_with_budget, complete_deferred_hashes,
         complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
         complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,


### PR DESCRIPTION
## Goal

Align native watcher ingress with the target I/O architecture by admitting bounded raw captures through the owner-controlled reconciliation lifecycle and releasing retained live uncertainty only after the matching committed source audit.

## Scope and non-goals

- Preserve bounded, no-I/O native capture of notify paths, kinds, roles, uncertainty, and retained metadata.
- Bind source/root/stream/generation/capture-boundary identity from the owner-controlled lifecycle.
- Route live captures through bounded owner admission and the exact dispatch, handoff, apply, and proofless audit-retirement sequence.
- Carry each proofless handoff into a source-scoped audit request with a bounded monotonic request boundary.
- Return a typed receipt only from a complete audit whose held SourceRootCapability identity and committed revision are available; the opaque commit witness is bound to the exact request identity and boundary, so public unbound scanner completions cannot clear live uncertainty.
- Keep later captures deferred for a subsequent audit, and fence stale, incomplete, cancelled, partial, or replaced-lifecycle receipts.
- Preserve bounded retention with same-lane monotonic coalescing, bounded emergency markers, a current-lane audit-request fallback when raw admission capacity is exhausted, and the same fallback before generic widening when the 256-context handoff cap is full.
- Bound watcher-side audit-request transport by exact source/root/generation identity with covering-range coalescing, admission-derived capacity, transactional flush, marker-backed protection, conservative recovery when a lifecycle displaces typed work, and send-failure retention.
- Non-goals: WatcherContinuityProof or targeted checkpoint authority for live notify, filesystem or SQLite I/O in the callback/UI/admission path, durable raw-event retention, directory-truth schema/projection redesign, native runtime/DAW acceptance, PR #980, or unrelated test-fixture cleanup.

## Definition of Done

- Native callback work is bounded and non-blocking.
- Raw notify evidence and metadata remain conservative evidence without invented sequence or continuity authority.
- Admission, dispatch, handoff, audit request, receipt, and acknowledgement are owner-authoritative, bounded, correlated, and lifecycle/root fenced.
- A complete matching capability-bound audit receipt clears only the retained uncertainty it covers; invalid or incomplete receipts clear nothing and duplicate delivery is idempotent.
- Capacity exhaustion and full-context widening still yield source/root/generation/boundary-bound audit work, while same-lane evidence coalesces monotonically and emergency retention remains bounded.
- Active audit requests remain immutable; deferred same-identity requests union without losing an earlier boundary; requests from replaced roots/generations are purged before transport and recover conservatively; failed channel handoff retains queued work.
- Focused reconciliation/native coverage passes apart from documented unrelated baseline failures, and changed files are formatted and whitespace-clean.

## Validation

Validated on head `6e75f92f71103989990ac2718ce85662b0053632`:

- `rustfmt --edition 2024 --check` on all changed Rust files — passed.
- `git diff --check` — passed.
- `cargo check -p wavecrate --all-targets` against pinned Radiant revision `13ae1f524313a5257fee6691679799a1aca99d32` — passed.
- `cargo test -p wavecrate-library --lib sample_sources::reconciliation` — 76 passed.
- `cargo test -p wavecrate-library --lib sample_sources::db` — 185 passed.
- `cargo test -p wavecrate --lib source_processing` — 168 passed, 1 resource/timing-sensitive failure, 7 ignored; the exact failing test passed when rerun alone.
- `cargo test -p wavecrate --lib source_watcher` — 123 passed and 3 documented pre-existing native baseline failures; all new exact-range, lifecycle-fence, queue, failed-handoff, and compatibility-handoff tests passed.
- `cargo test -p wavecrate-scan --lib sample_sources::scanner::scan` — the current full run reached 188 passed with one descriptor-peak/resource-sensitive failure; rerunning that exact test alone passed. This PR changes scanner audit plumbing, but not the descriptor-peak test path; the full-suite result remains a validation limitation rather than a baseline exemption.
- Focused exact-range, root-rebind, stop/restart, queue-overflow, failed-handoff, and compatibility-handoff regressions — passed.

## Known limitations

Three existing native source-watcher tests remain red independently of this correction: retained-uncertainty fencing, post-startup filesystem notification, and idempotent startup synchronization. The scanner audit plumbing is part of this PR; the descriptor-peak test path is unchanged. One full-suite descriptor-peak failure is resource-sensitive and passes in isolation, so reproduction against the base branch remains a follow-up validation item. One source-processing readiness heartbeat test is timing/resource-sensitive in the full suite but passes in isolation. Real macOS/FSEvents acceptance and DAW-style runtime acceptance remain user-owned. The live path remains deliberately proofless and may widen to authoritative audits until replayable FSEvents continuity is implemented.

## Next architecture task

Admit closed-application/native FSEvents replay through the same reconciliation owner, attach `WatcherContinuityProof` only for valid contiguous replay, route proven scopes to targeted source reconciliation, and advance the watcher checkpoint only after the matching committed targeted result.

User approval is required before merge.