### PR TITLE
Admit native FSEvents replay through the owner lane

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/replay_authority.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/replay_authority.rs
@@ -32,7 +32,6 @@ const CONTINUITY_PROOF_FIELDS: [&str; 7] = [
     "replay_coverage_end_event_id",
     "acknowledged_end_event_id",
 ];
-const FSEVENTS_STREAM_PREFIX: &[u8] = b"fsevents:";
 
 /// A construction capability that can only be created after this module validates DB metadata.
 pub(crate) struct ValidatedReplayAuthority {
@@ -86,11 +85,15 @@ impl SourceDatabase {
     /// The checkpoint parser is intentionally strict and fail-closed. In particular, legacy,
     /// proofless, malformed, unknown, duplicated, or identity-mismatched metadata returns
     /// `Ok(None)`, while database access failures retain their original `SourceDbError`.
+    /// `expected_source_lifecycle_generation` belongs to the persisted source lifecycle; the
+    /// separate `owner_watcher_generation` is the current in-memory reconciliation-owner lane
+    /// generation that the returned opaque authority must bind to.
     pub fn read_durable_replay_prior(
         &self,
         expected_source_id: &SourceId,
         expected_root_identity: &RootIdentity,
-        expected_watcher_generation: WatcherGeneration,
+        expected_source_lifecycle_generation: WatcherGeneration,
+        owner_watcher_generation: WatcherGeneration,
     ) -> Result<Option<ReplayPriorToken>, SourceDbError> {
         let Some(value) = self.get_metadata(META_SOURCE_WATCHER_CHECKPOINT)? else {
             return Ok(None);
@@ -99,7 +102,8 @@ impl SourceDatabase {
             &value,
             expected_source_id,
             expected_root_identity,
-            expected_watcher_generation,
+            expected_source_lifecycle_generation,
+            owner_watcher_generation,
         ))
     }
 }
@@ -108,7 +112,8 @@ fn parse_durable_replay_prior(
     value: &str,
     expected_source_id: &SourceId,
     expected_root_identity: &RootIdentity,
-    expected_watcher_generation: WatcherGeneration,
+    expected_source_lifecycle_generation: WatcherGeneration,
+    owner_watcher_generation: WatcherGeneration,
 ) -> Option<ReplayPriorToken> {
     let object = parse_object(value).ok()?;
     if !has_exact_fields(&object, &CHECKPOINT_FIELDS) {
@@ -120,7 +125,7 @@ fn parse_durable_replay_prior(
     if u64_field(&object, "format_version")? != CHECKPOINT_FORMAT_VERSION
         || string_field(&object, "source_id")? != expected_source_id.as_str()
         || root_identity.as_bytes() != expected_root_identity.as_bytes()
-        || u64_field(&object, "lifecycle_generation")? != expected_watcher_generation.get()
+        || u64_field(&object, "lifecycle_generation")? != expected_source_lifecycle_generation.get()
         || u64_field(&object, "source_revision").is_none()
         || string_field(&object, "cause")? != "targeted_replay"
     {
@@ -150,16 +155,13 @@ fn parse_durable_replay_prior(
 
     // Keep the backend discriminator in the opaque identity so a future native replay adapter
     // cannot accidentally treat a notify/process-local stream id as FSEvents authority.
-    let mut stream_identity =
-        Vec::with_capacity(FSEVENTS_STREAM_PREFIX.len() + std::mem::size_of::<u64>());
-    stream_identity.extend_from_slice(FSEVENTS_STREAM_PREFIX);
-    stream_identity.extend_from_slice(&backend_device.to_be_bytes());
+    let stream_identity = BackendStreamIdentity::from_fsevents_device(backend_device)?;
     Some(ReplayPriorToken::from_validated_durable_authority(
         ValidatedReplayAuthority::new(
             expected_source_id.clone(),
             expected_root_identity.clone(),
-            BackendStreamIdentity::from_bytes(stream_identity),
-            expected_watcher_generation,
+            stream_identity,
+            owner_watcher_generation,
             event_id,
         ),
     ))
@@ -332,7 +334,11 @@ mod tests {
         .to_string()
     }
 
-    fn read(value: &str) -> Option<ReplayPriorToken> {
+    fn read_with_generations(
+        value: &str,
+        source_lifecycle_generation: u64,
+        owner_watcher_generation: u64,
+    ) -> Option<ReplayPriorToken> {
         let directory = tempdir().expect("source root");
         let database = SourceDatabase::open_for_test_fixture_source_write(directory.path())
             .expect("source database");
@@ -340,16 +346,25 @@ mod tests {
             .set_metadata(META_SOURCE_WATCHER_CHECKPOINT, value)
             .expect("checkpoint metadata");
         database
-            .read_durable_replay_prior(&source_id(), &root(), WatcherGeneration::new(4))
+            .read_durable_replay_prior(
+                &source_id(),
+                &root(),
+                WatcherGeneration::new(source_lifecycle_generation),
+                WatcherGeneration::new(owner_watcher_generation),
+            )
             .expect("authority read")
+    }
+
+    fn read(value: &str) -> Option<ReplayPriorToken> {
+        read_with_generations(value, 4, 4)
     }
 
     #[test]
     fn valid_checkpoint_produces_durable_opaque_authority() {
-        let token = read(&checkpoint()).expect("valid token");
+        let token = read_with_generations(&checkpoint(), 4, 9).expect("valid token");
         assert_eq!(token.source_id(), &source_id());
         assert_eq!(token.root_identity(), &root());
-        assert_eq!(token.watcher_generation(), WatcherGeneration::new(4));
+        assert_eq!(token.watcher_generation(), WatcherGeneration::new(9));
         assert_eq!(token.acknowledged_sequence(), 17);
         assert_eq!(
             token.backend_stream_identity().as_bytes(),
@@ -370,7 +385,12 @@ mod tests {
         let database = SourceDatabase::open_for_test_fixture_source_write(directory.path())
             .expect("reopened source database");
         let token = database
-            .read_durable_replay_prior(&source_id(), &root(), WatcherGeneration::new(4))
+            .read_durable_replay_prior(
+                &source_id(),
+                &root(),
+                WatcherGeneration::new(4),
+                WatcherGeneration::new(4),
+            )
             .expect("authority read")
             .expect("valid token");
         assert_eq!(token.acknowledged_sequence(), 17);

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/model.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/model.rs
@@ -204,6 +204,20 @@ impl BackendStreamIdentity {
         Self(bytes)
     }
 
+    /// Construct the canonical opaque identity for one durable FSEvents device stream.
+    ///
+    /// The discriminator prevents a process-local notify stream id from being treated as
+    /// durable FSEvents authority. A zero device is unavailable and cannot identify a stream.
+    pub fn from_fsevents_device(device: u64) -> Option<Self> {
+        if device == 0 {
+            return None;
+        }
+        let mut bytes = Vec::with_capacity(9 + std::mem::size_of::<u64>());
+        bytes.extend_from_slice(b"fsevents:");
+        bytes.extend_from_slice(&device.to_be_bytes());
+        Some(Self::from_bytes(bytes))
+    }
+
     /// Borrow the backend-supplied stream identity bytes without decoding them.
     pub fn as_bytes(&self) -> &[u8] {
         &self.0

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -4,12 +4,15 @@ use std::collections::HashSet;
 
 use wavecrate::sample_sources::{SampleSource, SourceId};
 use wavecrate_library::sample_sources::reconciliation::{
-    AdapterError, AdmissionOwnerError, DispatchTicket, DispatchedObservation, LiveAuditAdmission,
-    OwnedAdmissionLane, RawObservationLimits, ReconciliationAcknowledgementOutcome,
-    ReconciliationAdmissionLimits, ReconciliationAdmissionOwner, ReconciliationAdmissionSupervisor,
-    ReconciliationLifecycle, RootIdentity, SourceAuditReceipt, SourceAuditRequest,
-    SyntheticObservationBatch,
+    AdapterError, AdmissionOwnerError, BackendStreamIdentity, CaptureBoundary, DispatchTicket,
+    DispatchedObservation, LiveAuditAdmission, OwnedAdmissionLane, OwnerReplayAdmission,
+    RawObservation, RawObservationLimits, RawObservationProvenance,
+    ReconciliationAcknowledgementOutcome, ReconciliationAdmissionLimits,
+    ReconciliationAdmissionOwner, ReconciliationAdmissionSupervisor, ReconciliationLifecycle,
+    RootIdentity, SourceAuditReceipt, SourceAuditRequest, SyntheticObservationBatch,
+    WatcherGeneration,
 };
+use wavecrate_library::sample_sources::{SourceDatabase, SourceDbError};
 
 use super::roots::{WatchedRootIdentities, registered_root_identity};
 
@@ -23,6 +26,36 @@ const NATIVE_ADMISSION_MAX_IN_FLIGHT_PER_LANE: usize = 1;
 const NATIVE_ADMISSION_MAX_RECENT_SEQUENCES_PER_LANE: usize = 64;
 const NATIVE_ADMISSION_MAX_RETAINED_UNCERTAINTIES: usize = 4096;
 const NATIVE_ADMISSION_MAX_EVENTS_PER_LANE: usize = 512;
+
+/// Bounded FSEvents history evidence awaiting owner admission.
+///
+/// The source lifecycle generation, history worker generation, and owner lane generation are
+/// intentionally separate. Only the owner lane generation is allowed into reconciliation
+/// provenance; the history worker generation is validated as replay-stream evidence and is not
+/// promoted into owner authority.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(super) struct FseventsReplayEvidence {
+    pub(super) source_lifecycle_generation: WatcherGeneration,
+    pub(super) replay_stream_generation: u64,
+    pub(super) backend_device: u64,
+    pub(super) replay_start_event_id: u64,
+    pub(super) replay_end_event_id: u64,
+    pub(super) observations: Vec<RawObservation>,
+    pub(super) limits: RawObservationLimits,
+}
+
+/// Fail-closed result for the dormant native replay admission seam.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(super) enum FseventsReplayAdmissionError {
+    Database(SourceDbError),
+    InvalidBackendDevice,
+    InvalidReplayRange,
+    InvalidReplayStreamGeneration,
+    NoCapturingLane,
+    Adapter(AdapterError),
+}
 
 /// Owns the one admission owner used by a native source-watcher coordinator.
 pub(super) struct AdmissionLifecycle {
@@ -212,6 +245,61 @@ impl AdmissionLifecycle {
         self.owner.admit_live_with_correlation(batch)
     }
 
+    /// Admit one bounded FSEvents history replay through the current owner lane.
+    ///
+    /// The database supplies only an opaque prior after validating the persisted source
+    /// lifecycle. The owner independently binds that prior to the current root, FSEvents device
+    /// stream, and reconciliation-lane generation. Any stale, missing, gapped, or mismatched
+    /// evidence therefore remains an unproven replay and retains the existing bounded audit path.
+    #[allow(dead_code)]
+    pub(super) fn admit_fsevents_replay(
+        &mut self,
+        source: &SampleSource,
+        database: &SourceDatabase,
+        evidence: FseventsReplayEvidence,
+    ) -> Result<OwnerReplayAdmission, FseventsReplayAdmissionError> {
+        let lane = self
+            .lane_for_capture(&source.id)
+            .ok_or(FseventsReplayAdmissionError::NoCapturingLane)?;
+        if evidence.replay_stream_generation == 0 {
+            return Err(FseventsReplayAdmissionError::InvalidReplayStreamGeneration);
+        }
+        let stream_identity = BackendStreamIdentity::from_fsevents_device(evidence.backend_device)
+            .ok_or(FseventsReplayAdmissionError::InvalidBackendDevice)?;
+        let first_sequence = evidence
+            .replay_start_event_id
+            .checked_add(1)
+            .ok_or(FseventsReplayAdmissionError::InvalidReplayRange)?;
+        let capture_boundary = CaptureBoundary::try_new(
+            evidence.replay_end_event_id,
+            Some(first_sequence),
+            Some(evidence.replay_end_event_id),
+        )
+        .map_err(|_| FseventsReplayAdmissionError::InvalidReplayRange)?;
+        let batch = SyntheticObservationBatch::new(
+            RawObservationProvenance::new(
+                source.id.clone(),
+                Some(lane.root_identity().clone()),
+                Some(stream_identity),
+                lane.generation(),
+                capture_boundary,
+            ),
+            evidence.observations,
+            evidence.limits,
+        );
+        let prior = database
+            .read_durable_replay_prior(
+                &source.id,
+                lane.root_identity(),
+                evidence.source_lifecycle_generation,
+                lane.generation(),
+            )
+            .map_err(FseventsReplayAdmissionError::Database)?;
+        self.owner
+            .admit_replay_with_durable_prior(batch, prior.as_ref(), true)
+            .map_err(FseventsReplayAdmissionError::Adapter)
+    }
+
     /// Select the next owner-scheduled live envelope.
     pub(super) fn dispatch_next(&mut self) -> Option<DispatchedObservation> {
         if self.admission_closed {
@@ -274,7 +362,7 @@ impl AdmissionLifecycle {
 
     #[cfg(test)]
     fn lane(&self, source_id: &SourceId) -> Option<OwnedAdmissionLane> {
-        self.lane_for_capture(source_id)
+        self.owner.lane(source_id)
     }
 }
 
@@ -303,6 +391,11 @@ fn native_admission_limits() -> ReconciliationAdmissionLimits {
 mod tests {
     use super::*;
     use std::{collections::HashMap, path::PathBuf};
+    use tempfile::tempdir;
+    use wavecrate_library::sample_sources::db::META_SOURCE_WATCHER_CHECKPOINT;
+    use wavecrate_library::sample_sources::reconciliation::{
+        AdapterDisposition, AdmissionOutcome, Proof, RawEventKind, RawObservedPath, RawPathRole,
+    };
 
     fn source(id: &str, root: &str) -> SampleSource {
         SampleSource::new_with_id(SourceId::from_string(id), PathBuf::from(root))
@@ -340,6 +433,225 @@ mod tests {
             max_retained_uncertainties,
         )
         .expect("admission limits")
+    }
+
+    fn checkpoint(
+        source_id: &SourceId,
+        root_identity: &str,
+        source_lifecycle_generation: u64,
+        backend_device: u64,
+        replay_start_event_id: u64,
+        replay_end_event_id: u64,
+    ) -> String {
+        serde_json::json!({
+            "root_identity": root_identity,
+            "event_id": replay_end_event_id,
+            "format_version": 3,
+            "source_id": source_id.as_str(),
+            "lifecycle_generation": source_lifecycle_generation,
+            "source_revision": 12,
+            "cause": "targeted_replay",
+            "continuity_proof": {
+                "root_identity": root_identity,
+                "backend": "fsevents",
+                "backend_device": backend_device,
+                "watcher_generation": 41,
+                "replay_coverage_start_event_id": replay_start_event_id,
+                "replay_coverage_end_event_id": replay_end_event_id,
+                "acknowledged_end_event_id": replay_end_event_id
+            }
+        })
+        .to_string()
+    }
+
+    fn replay_observation() -> RawObservation {
+        RawObservation::new(
+            RawEventKind::Create,
+            vec![RawObservedPath::new(
+                PathBuf::from("replayed.wav"),
+                RawPathRole::Subject,
+            )],
+        )
+    }
+
+    fn admit_unproven_replay(
+        checkpoint_value: &str,
+        source_lifecycle_generation: u64,
+        backend_device: u64,
+        replay_start_event_id: u64,
+        replay_end_event_id: u64,
+    ) -> (AdapterDisposition, bool, bool) {
+        let directory = tempdir().expect("source root");
+        let source = source(
+            "replay-source",
+            directory.path().to_str().expect("source path"),
+        );
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        database
+            .set_metadata(META_SOURCE_WATCHER_CHECKPOINT, checkpoint_value)
+            .expect("checkpoint metadata");
+
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(1, 1, 8));
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&source),
+                &HashMap::from([(source.root.clone(), Some("identity-a".to_string()))]),
+            )
+            .expect("lifecycle binding");
+        let admission = lifecycle
+            .admit_fsevents_replay(
+                &source,
+                &database,
+                FseventsReplayEvidence {
+                    source_lifecycle_generation: WatcherGeneration::new(
+                        source_lifecycle_generation,
+                    ),
+                    replay_stream_generation: 42,
+                    backend_device,
+                    replay_start_event_id,
+                    replay_end_event_id,
+                    observations: vec![replay_observation()],
+                    limits: RawObservationLimits::new(8, usize::MAX, usize::MAX)
+                        .expect("replay limits"),
+                },
+            )
+            .expect("replay admission");
+        let disposition = admission.admission().disposition();
+        let has_audit_request = admission.audit_request().is_some();
+        let ticket = match admission.admission().outcome() {
+            AdmissionOutcome::Accepted(ticket) => *ticket,
+            outcome => panic!("expected accepted unproven replay, got {outcome:?}"),
+        };
+        let dispatched = lifecycle.dispatch_next().expect("unproven replay dispatch");
+        assert_eq!(dispatched.ticket(), ticket);
+        assert_eq!(dispatched.normalized().proof(), &Proof::Unproven);
+        lifecycle
+            .mark_dispatched(ticket)
+            .expect("unproven replay dispatched");
+        lifecycle
+            .mark_applied(ticket)
+            .expect("unproven replay applied");
+        lifecycle
+            .mark_unproven_audit_handed_off(ticket)
+            .expect("unproven replay audit handed off");
+        (
+            disposition,
+            has_audit_request,
+            !lifecycle.retained_uncertainties().is_empty(),
+        )
+    }
+
+    #[test]
+    fn fsevents_replay_admission_binds_distinct_lifecycle_generations() {
+        let directory = tempdir().expect("source root");
+        let source = source(
+            "replay-source",
+            directory.path().to_str().expect("source path"),
+        );
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        database
+            .set_metadata(
+                META_SOURCE_WATCHER_CHECKPOINT,
+                &checkpoint(&source.id, "identity-a", 7, 99, 7, 17),
+            )
+            .expect("checkpoint metadata");
+
+        let mut lifecycle = AdmissionLifecycle::with_limits(limits(1, 1, 8));
+        lifecycle
+            .reconcile(
+                std::slice::from_ref(&source),
+                &HashMap::from([(source.root.clone(), Some("identity-a".to_string()))]),
+            )
+            .expect("lifecycle binding");
+        let owner_lane = lifecycle.lane(&source.id).expect("owner lane");
+        assert_ne!(owner_lane.generation(), WatcherGeneration::new(7));
+        assert_ne!(owner_lane.generation().get(), 42);
+
+        let admission = lifecycle
+            .admit_fsevents_replay(
+                &source,
+                &database,
+                FseventsReplayEvidence {
+                    source_lifecycle_generation: WatcherGeneration::new(7),
+                    replay_stream_generation: 42,
+                    backend_device: 99,
+                    replay_start_event_id: 17,
+                    replay_end_event_id: 18,
+                    observations: vec![replay_observation()],
+                    limits: RawObservationLimits::new(8, usize::MAX, usize::MAX)
+                        .expect("replay limits"),
+                },
+            )
+            .expect("valid replay admission");
+
+        assert_eq!(
+            admission.admission().disposition(),
+            AdapterDisposition::AdmittedWithContinuity
+        );
+        assert!(admission.audit_request().is_none());
+        let ticket = match admission.admission().outcome() {
+            AdmissionOutcome::Accepted(ticket) => *ticket,
+            outcome => panic!("expected accepted replay, got {outcome:?}"),
+        };
+        let dispatched = lifecycle.dispatch_next().expect("replay dispatch");
+        assert_eq!(dispatched.ticket(), ticket);
+        assert_eq!(dispatched.generation(), owner_lane.generation());
+        assert_eq!(
+            dispatched
+                .normalized()
+                .envelope()
+                .provenance()
+                .watcher_generation(),
+            owner_lane.generation()
+        );
+        let proof = dispatched
+            .normalized()
+            .proof()
+            .watcher_continuity()
+            .expect("continuity proof");
+        assert_eq!(
+            proof.backend_stream_identity(),
+            &BackendStreamIdentity::from_fsevents_device(99).expect("FSEvents stream")
+        );
+    }
+
+    #[test]
+    fn stale_malformed_root_device_and_gapped_checkpoints_remain_bounded_audits() {
+        let source_id = SourceId::from_string("replay-source");
+        let cases = [
+            checkpoint(&source_id, "identity-a", 6, 99, 7, 17),
+            checkpoint(&source_id, "identity-b", 7, 99, 7, 17),
+            checkpoint(&source_id, "identity-a", 7, 99, 7, 17),
+            checkpoint(&source_id, "identity-a", 7, 99, 7, 17),
+            String::from("not-json"),
+        ];
+        let evidence = [
+            (7, 99, 17, 18),
+            (7, 99, 17, 18),
+            (7, 100, 17, 18),
+            (7, 99, 18, 19),
+            (7, 99, 17, 18),
+        ];
+
+        for (checkpoint_value, (source_lifecycle_generation, backend_device, start, end)) in
+            cases.iter().zip(evidence)
+        {
+            let (disposition, has_audit_request, retained_uncertainty) = admit_unproven_replay(
+                checkpoint_value,
+                source_lifecycle_generation,
+                backend_device,
+                start,
+                end,
+            );
+            assert!(matches!(
+                disposition,
+                AdapterDisposition::AdmittedUnproven | AdapterDisposition::SourceAuditRequired
+            ));
+            assert!(has_audit_request);
+            assert!(retained_uncertainty);
+        }
     }
 
     #[test]

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -31,8 +31,8 @@ const NATIVE_ADMISSION_MAX_EVENTS_PER_LANE: usize = 512;
 ///
 /// The source lifecycle generation, history worker generation, and owner lane generation are
 /// intentionally separate. Only the owner lane generation is allowed into reconciliation
-/// provenance; the history worker generation is validated as replay-stream evidence and is not
-/// promoted into owner authority.
+/// provenance; the history worker generation must match the coordinator's active stream
+/// generation before any durable prior can be used, and is never promoted into owner authority.
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(super) struct FseventsReplayEvidence {
@@ -249,19 +249,21 @@ impl AdmissionLifecycle {
     ///
     /// The database supplies only an opaque prior after validating the persisted source
     /// lifecycle. The owner independently binds that prior to the current root, FSEvents device
-    /// stream, and reconciliation-lane generation. Any stale, missing, gapped, or mismatched
-    /// evidence therefore remains an unproven replay and retains the existing bounded audit path.
+    /// stream, and reconciliation-lane generation. The coordinator's active replay-stream
+    /// generation fences stale asynchronous history completions before the database is read;
+    /// mismatches therefore receive no durable prior and retain the existing bounded audit path.
     #[allow(dead_code)]
     pub(super) fn admit_fsevents_replay(
         &mut self,
         source: &SampleSource,
         database: &SourceDatabase,
+        active_replay_stream_generation: u64,
         evidence: FseventsReplayEvidence,
     ) -> Result<OwnerReplayAdmission, FseventsReplayAdmissionError> {
         let lane = self
             .lane_for_capture(&source.id)
             .ok_or(FseventsReplayAdmissionError::NoCapturingLane)?;
-        if evidence.replay_stream_generation == 0 {
+        if active_replay_stream_generation == 0 || evidence.replay_stream_generation == 0 {
             return Err(FseventsReplayAdmissionError::InvalidReplayStreamGeneration);
         }
         let stream_identity = BackendStreamIdentity::from_fsevents_device(evidence.backend_device)
@@ -287,14 +289,18 @@ impl AdmissionLifecycle {
             evidence.observations,
             evidence.limits,
         );
-        let prior = database
-            .read_durable_replay_prior(
-                &source.id,
-                lane.root_identity(),
-                evidence.source_lifecycle_generation,
-                lane.generation(),
-            )
-            .map_err(FseventsReplayAdmissionError::Database)?;
+        let prior = if evidence.replay_stream_generation == active_replay_stream_generation {
+            database
+                .read_durable_replay_prior(
+                    &source.id,
+                    lane.root_identity(),
+                    evidence.source_lifecycle_generation,
+                    lane.generation(),
+                )
+                .map_err(FseventsReplayAdmissionError::Database)?
+        } else {
+            None
+        };
         self.owner
             .admit_replay_with_durable_prior(batch, prior.as_ref(), true)
             .map_err(FseventsReplayAdmissionError::Adapter)
@@ -477,6 +483,8 @@ mod tests {
     fn admit_unproven_replay(
         checkpoint_value: &str,
         source_lifecycle_generation: u64,
+        replay_stream_generation: u64,
+        active_replay_stream_generation: u64,
         backend_device: u64,
         replay_start_event_id: u64,
         replay_end_event_id: u64,
@@ -503,11 +511,12 @@ mod tests {
             .admit_fsevents_replay(
                 &source,
                 &database,
+                active_replay_stream_generation,
                 FseventsReplayEvidence {
                     source_lifecycle_generation: WatcherGeneration::new(
                         source_lifecycle_generation,
                     ),
-                    replay_stream_generation: 42,
+                    replay_stream_generation,
                     backend_device,
                     replay_start_event_id,
                     replay_end_event_id,
@@ -573,6 +582,7 @@ mod tests {
             .admit_fsevents_replay(
                 &source,
                 &database,
+                42,
                 FseventsReplayEvidence {
                     source_lifecycle_generation: WatcherGeneration::new(7),
                     replay_stream_generation: 42,
@@ -618,6 +628,21 @@ mod tests {
     }
 
     #[test]
+    fn stale_nonzero_replay_worker_generation_remains_a_bounded_audit() {
+        let source_id = SourceId::from_string("replay-source");
+        let checkpoint_value = checkpoint(&source_id, "identity-a", 7, 99, 7, 17);
+        let (disposition, has_audit_request, retained_uncertainty) =
+            admit_unproven_replay(&checkpoint_value, 7, 41, 42, 99, 17, 18);
+
+        assert!(matches!(
+            disposition,
+            AdapterDisposition::AdmittedUnproven | AdapterDisposition::SourceAuditRequired
+        ));
+        assert!(has_audit_request);
+        assert!(retained_uncertainty);
+    }
+
+    #[test]
     fn stale_malformed_root_device_and_gapped_checkpoints_remain_bounded_audits() {
         let source_id = SourceId::from_string("replay-source");
         let cases = [
@@ -641,6 +666,8 @@ mod tests {
             let (disposition, has_audit_request, retained_uncertainty) = admit_unproven_replay(
                 checkpoint_value,
                 source_lifecycle_generation,
+                42,
+                42,
                 backend_device,
                 start,
                 end,

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -50,9 +50,6 @@ pub(super) struct FseventsReplayEvidence {
 #[derive(Debug)]
 pub(super) enum FseventsReplayAdmissionError {
     Database(SourceDbError),
-    InvalidBackendDevice,
-    InvalidReplayRange,
-    InvalidReplayStreamGeneration,
     NoCapturingLane,
     Adapter(AdapterError),
 }
@@ -263,33 +260,34 @@ impl AdmissionLifecycle {
         let lane = self
             .lane_for_capture(&source.id)
             .ok_or(FseventsReplayAdmissionError::NoCapturingLane)?;
-        if active_replay_stream_generation == 0 || evidence.replay_stream_generation == 0 {
-            return Err(FseventsReplayAdmissionError::InvalidReplayStreamGeneration);
-        }
-        let stream_identity = BackendStreamIdentity::from_fsevents_device(evidence.backend_device)
-            .ok_or(FseventsReplayAdmissionError::InvalidBackendDevice)?;
+        let stream_identity = BackendStreamIdentity::from_fsevents_device(evidence.backend_device);
         let first_sequence = evidence
             .replay_start_event_id
             .checked_add(1)
-            .ok_or(FseventsReplayAdmissionError::InvalidReplayRange)?;
+            .filter(|first| *first <= evidence.replay_end_event_id);
         let capture_boundary = CaptureBoundary::try_new(
             evidence.replay_end_event_id,
-            Some(first_sequence),
-            Some(evidence.replay_end_event_id),
+            first_sequence,
+            first_sequence.map(|_| evidence.replay_end_event_id),
         )
-        .map_err(|_| FseventsReplayAdmissionError::InvalidReplayRange)?;
+        .expect("replay boundary fallback remains structurally valid");
+        let authority_eligible = active_replay_stream_generation != 0
+            && evidence.replay_stream_generation != 0
+            && evidence.replay_stream_generation == active_replay_stream_generation
+            && stream_identity.is_some()
+            && first_sequence.is_some();
         let batch = SyntheticObservationBatch::new(
             RawObservationProvenance::new(
                 source.id.clone(),
                 Some(lane.root_identity().clone()),
-                Some(stream_identity),
+                stream_identity,
                 lane.generation(),
                 capture_boundary,
             ),
             evidence.observations,
             evidence.limits,
         );
-        let prior = if evidence.replay_stream_generation == active_replay_stream_generation {
+        let prior = if authority_eligible {
             database
                 .read_durable_replay_prior(
                     &source.id,
@@ -640,6 +638,34 @@ mod tests {
         ));
         assert!(has_audit_request);
         assert!(retained_uncertainty);
+    }
+
+    #[test]
+    fn malformed_native_replay_fields_remain_bounded_audits() {
+        let source_id = SourceId::from_string("replay-source");
+        let checkpoint_value = checkpoint(&source_id, "identity-a", 7, 99, 7, 17);
+        for (replay_stream_generation, active_generation, backend_device, start, end) in [
+            (42, 42, 0, 17, 18),
+            (42, 42, 99, 18, 18),
+            (0, 42, 99, 17, 18),
+            (42, 0, 99, 17, 18),
+        ] {
+            let (disposition, has_audit_request, retained_uncertainty) = admit_unproven_replay(
+                &checkpoint_value,
+                7,
+                replay_stream_generation,
+                active_generation,
+                backend_device,
+                start,
+                end,
+            );
+            assert!(matches!(
+                disposition,
+                AdapterDisposition::AdmittedUnproven | AdapterDisposition::SourceAuditRequired
+            ));
+            assert!(has_audit_request);
+            assert!(retained_uncertainty);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Goal

Advance the I/O target by adding the dormant native FSEvents history-replay admission seam without confusing persisted source lifecycle, replay-worker, and current reconciliation-owner generations.

Scope and non-goals

Scope:
- Centralize canonical durable FSEvents stream identity as fsevents:<device>.
- Make durable checkpoint authority bind persisted source lifecycle validation to the current owner-lane generation.
- Fence stale asynchronous history completions by comparing their replay-worker generation with the coordinator's active replay-stream generation before reading durable authority.
- Convert malformed native replay fields into owner-routed unproven evidence with bounded audit handling instead of dropping the evidence at the seam.
- Build bounded native replay provenance and capture boundaries, obtain opaque DB authority only for the active replay stream, and route the batch through ReconciliationAdmissionOwner.
- Add regression coverage for valid continuity and stale-worker, stale-lifecycle, malformed-checkpoint, malformed-native, wrong-root, wrong-device, and gapped fallback.

Non-goals:
- Do not replace the production GuiMessage::SourceFilesystemChanged route yet.
- Do not add checkpoint writing/schema changes, committed reconciliation projection, or durable terminal-token wiring.
- Do not touch unrelated PR #980 work.

Definition of Done

- A valid test intentionally uses distinct source-lifecycle, replay-stream, and owner-lane generations and produces AdmittedWithContinuity.
- A nonzero stale replay-worker generation cannot produce continuity admission.
- Stale, malformed durable or native evidence, wrong-root, wrong-device, and gapped evidence remains unproven and retains bounded SourceAudit handling.
- The DB reader and native handoff use the same typed FSEvents stream identity.
- No implementation path mints authority outside the source-database validation capability or bypasses the reconciliation owner.

Validation

- cargo test -p wavecrate-library --lib sample_sources::db::replay_authority — 4 passed.
- cargo test -p wavecrate-library --lib sample_sources::reconciliation — 85 passed.
- cargo test -p wavecrate --lib source_watcher::admission_lifecycle — 17 passed.
- cargo check -p wavecrate-library — passed.
- cargo check -p wavecrate --bin wavecrate — passed.
- rustfmt --edition 2024 --check on all touched Rust files — passed.
- git diff --check — passed.
- bash scripts/ci.sh smoke — passed after the review correction.

Known limitations

The seam is intentionally dormant; the following production route and durable terminal handoff belong to the next dependency-correct slice. The broader source_watcher filter also has two unrelated existing runtime-harness failures in this checkout: filesystem_event_after_initial_watcher_ready_is_not_suppressed and idempotent_startup_source_sync_does_not_refresh_every_source. The canonical main checkout cannot compile that test target because its Radiant sibling is on an incompatible test API.

User approval is required before merge.