### PR TITLE
Carry committed source-index changes into browser projection

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
@@ -130,7 +130,11 @@ impl SourceWriteBatch<'_> {
                 ],
             )
             .map_err(map_sql_error)?;
-        self.index_revision_dirty |= changed > 0;
+        if changed > 0 {
+            self.index_revision_dirty = true;
+            self.source_index_changes
+                .insert(entry.relative_path.clone(), Some(entry.clone()));
+        }
         Ok(())
     }
 
@@ -141,8 +145,73 @@ impl SourceWriteBatch<'_> {
             .tx
             .execute("DELETE FROM source_index_entries WHERE path = ?1", [path])
             .map_err(map_sql_error)?;
-        self.index_revision_dirty |= changed > 0;
+        if changed > 0 {
+            self.index_revision_dirty = true;
+            self.source_index_changes
+                .insert(relative_path.to_path_buf(), None);
+        }
         Ok(())
+    }
+}
+
+impl SourceDatabase {
+    /// Read a bounded set of index-only entries at one exact committed index revision.
+    ///
+    /// The revision and rows are read from one transaction. This is intended for targeted
+    /// projection hydration and never materializes the source-wide index.
+    pub fn source_index_entries_for_paths_at_revision(
+        &self,
+        expected_revision: u64,
+        paths: &[std::path::PathBuf],
+    ) -> Result<SourceIndexSnapshot, SourceDbError> {
+        if !source_index_schema_available(&self.connection)? {
+            if expected_revision != 0 {
+                return Err(SourceDbError::Unexpected);
+            }
+            return Ok(SourceIndexSnapshot {
+                revision: 0,
+                entries: Vec::new(),
+            });
+        }
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(map_sql_error)?;
+        let revision = read_index_revision(&transaction)?;
+        if revision != expected_revision {
+            return Err(SourceDbError::Unexpected);
+        }
+        let path_encoding_available = source_index_path_encoding_available(&transaction)?;
+        let mut entries = Vec::new();
+        for relative_path in paths {
+            let (normalized, path_encoding) = normalize_source_index_path(relative_path)?;
+            if !path_encoding_available && path_encoding != 0 {
+                return Err(SourceDbError::NonUnicodeRelativePath(relative_path.clone()));
+            }
+            let (sql, params) = if path_encoding_available {
+                (
+                    source_index_select_sql_for_exact_path(true),
+                    ExactIndexPathParams::Encoded(normalized, path_encoding),
+                )
+            } else {
+                (
+                    source_index_select_sql_for_exact_path(false),
+                    ExactIndexPathParams::Plain(normalized),
+                )
+            };
+            entries.extend(match params {
+                ExactIndexPathParams::Encoded(path, encoding) => {
+                    collect_entries(&transaction, &sql, rusqlite::params![path, encoding])?
+                }
+                ExactIndexPathParams::Plain(path) => {
+                    collect_entries(&transaction, &sql, rusqlite::params![path])?
+                }
+            });
+        }
+        entries.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        entries.dedup_by(|left, right| left.relative_path == right.relative_path);
+        transaction.rollback().map_err(map_sql_error)?;
+        Ok(SourceIndexSnapshot { revision, entries })
     }
 }
 
@@ -175,6 +244,31 @@ fn source_index_select_sql(path_encoding: bool, under_path: bool) -> String {
          {predicate}
          ORDER BY path ASC"
     )
+}
+
+fn source_index_select_sql_for_exact_path(path_encoding: bool) -> String {
+    let encoding = if path_encoding {
+        "path_encoding"
+    } else {
+        "0 AS path_encoding"
+    };
+    let predicate = if path_encoding {
+        "WHERE path = ?1 COLLATE BINARY AND path_encoding = ?2"
+    } else {
+        "WHERE path = ?1 COLLATE BINARY"
+    };
+    format!(
+        "SELECT path, {encoding}, classification, file_size, modified_ns, file_identity,
+                diagnostic, format_policy_version
+         FROM source_index_entries
+         {predicate}
+         ORDER BY path ASC"
+    )
+}
+
+enum ExactIndexPathParams {
+    Encoded(String, i64),
+    Plain(String),
 }
 
 fn read_index_revision(connection: &Connection) -> Result<u64, SourceDbError> {
@@ -303,6 +397,39 @@ mod tests {
             database.get_revision().expect("manifest revision"),
             manifest_revision
         );
+    }
+
+    #[test]
+    fn bounded_source_commit_reports_index_facts_at_its_source_revision() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        let expected_revision = database.get_revision().expect("source revision");
+        let entry = SourceIndexEntry {
+            relative_path: PathBuf::from("notes.txt"),
+            classification: SourceIndexClassification::UnsupportedNonAudio,
+            file_size: Some(5),
+            modified_ns: Some(10),
+            file_identity: None,
+            diagnostic: None,
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+        };
+        let mut batch = database.write_batch().expect("index batch");
+        batch
+            .upsert_source_index_entry(&entry)
+            .expect("upsert index entry");
+        let result = batch
+            .commit_with_bounded_manifest_changes(expected_revision)
+            .expect("bounded source commit");
+        let index_commit = result
+            .source_index_commit
+            .expect("same-transaction index evidence");
+
+        assert_eq!(index_commit.source_revision, result.revision);
+        assert_eq!(index_commit.index_revision, 1);
+        assert_eq!(index_commit.upserted_entries, vec![entry]);
+        assert!(index_commit.removed_paths.is_empty());
+        assert_eq!(result.revision, database.get_revision().unwrap());
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 use std::{
     collections::BTreeSet,
@@ -65,7 +66,7 @@ pub use types::{
 pub use util::normalize_relative_path;
 pub use write::{
     ManifestCommitResult, SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite,
-    SourceTagWrite, SourceWriteCommand,
+    SourceIndexCommitResult, SourceTagWrite, SourceWriteCommand,
 };
 
 /// Hidden filename used for per-source databases.
@@ -142,6 +143,7 @@ pub struct SourceWriteBatch<'conn> {
     identities_revision_dirty: bool,
     index_revision_dirty: bool,
     manifest_touched_paths: BTreeSet<PathBuf>,
+    source_index_changes: BTreeMap<PathBuf, Option<SourceIndexEntry>>,
     manifest_audit_completed: bool,
     telemetry_label: &'static str,
 }

--- a/crates/wavecrate-library/src/sample_sources/db/write.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write.rs
@@ -14,7 +14,7 @@ pub use command::{
     SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite, SourceTagWrite,
     SourceWriteCommand,
 };
-pub use transaction::ManifestCommitResult;
+pub use transaction::{ManifestCommitResult, SourceIndexCommitResult};
 
 #[cfg(test)]
 mod tests;

--- a/crates/wavecrate-library/src/sample_sources/db/write/database.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/database.rs
@@ -178,6 +178,7 @@ impl SourceDatabase {
             identities_revision_dirty: false,
             index_revision_dirty: false,
             manifest_touched_paths: std::collections::BTreeSet::new(),
+            source_index_changes: std::collections::BTreeMap::new(),
             manifest_audit_completed: false,
             telemetry_label: self.telemetry_label,
         })

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -4,8 +4,8 @@ use rusqlite::OptionalExtension;
 
 use super::super::util::{map_sql_error, normalize_relative_path};
 use super::super::{
-    META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError, SourceManifestEntry,
-    SourceTraversalPolicy, SourceWriteBatch,
+    META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError, SourceIndexEntry,
+    SourceManifestEntry, SourceTraversalPolicy, SourceWriteBatch,
 };
 use crate::sample_sources::reconciliation::{RootIdentity, SourceAuditCommit, SourceAuditRequest};
 
@@ -17,6 +17,20 @@ pub struct ManifestCommitResult {
     pub touched_path_changes: Vec<(PathBuf, Option<SourceManifestEntry>)>,
     /// Complete manifest captured in the committing transaction when the cached revision was stale.
     pub authoritative_snapshot: Option<Vec<SourceManifestEntry>>,
+    /// Index-only facts committed by this same transaction, when any changed.
+    pub source_index_commit: Option<SourceIndexCommitResult>,
+}
+
+/// Typed index-only facts proven by one committed source-database write.
+pub struct SourceIndexCommitResult {
+    /// Generic source revision assigned by the committing transaction.
+    pub source_revision: u64,
+    /// Index-only revision assigned by the committing transaction.
+    pub index_revision: u64,
+    /// Final typed index rows upserted by the transaction.
+    pub upserted_entries: Vec<SourceIndexEntry>,
+    /// Index rows removed by the transaction.
+    pub removed_paths: Vec<PathBuf>,
 }
 
 impl SourceWriteBatch<'_> {
@@ -165,6 +179,7 @@ impl SourceWriteBatch<'_> {
     ) -> Result<ManifestCommitResult, SourceDbError> {
         self.prepare_commit()?;
         let revision = manifest_revision(&self.tx)?;
+        let source_index_commit = self.source_index_commit(revision)?;
         let (changes, snapshot) = if revision == expected_previous_revision.saturating_add(1) {
             let changes = self
                 .manifest_touched_paths
@@ -190,6 +205,7 @@ impl SourceWriteBatch<'_> {
             revision,
             touched_path_changes: changes,
             authoritative_snapshot: snapshot,
+            source_index_commit,
         })
     }
 
@@ -207,6 +223,7 @@ impl SourceWriteBatch<'_> {
         }
         self.prepare_commit()?;
         let revision = manifest_revision(&self.tx)?;
+        let source_index_commit = self.source_index_commit(revision)?;
         let changes = self
             .manifest_touched_paths
             .iter()
@@ -226,7 +243,43 @@ impl SourceWriteBatch<'_> {
             revision,
             touched_path_changes: changes,
             authoritative_snapshot: None,
+            source_index_commit,
         })
+    }
+
+    fn source_index_commit(
+        &self,
+        source_revision: u64,
+    ) -> Result<Option<SourceIndexCommitResult>, SourceDbError> {
+        if self.source_index_changes.is_empty() {
+            return Ok(None);
+        }
+        let index_revision = self
+            .tx
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'source_index_revision_v1'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+            .transpose()?
+            .unwrap_or_default();
+        let mut upserted_entries = Vec::new();
+        let mut removed_paths = Vec::new();
+        for (path, entry) in &self.source_index_changes {
+            match entry {
+                Some(entry) => upserted_entries.push(entry.clone()),
+                None => removed_paths.push(path.clone()),
+            }
+        }
+        Ok(Some(SourceIndexCommitResult {
+            source_revision,
+            index_revision,
+            upserted_entries,
+            removed_paths,
+        }))
     }
 
     fn prepare_commit(&self) -> Result<(), SourceDbError> {

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -22,9 +22,9 @@ pub use db::{
     BrowserFileMetadata, BrowserMetadataCursor, BrowserMetadataPage, BrowserMetadataSnapshot,
     DB_FILE_NAME, ExistingFileMetadataUpdate, ManifestCommitResult, Rating, SampleCollection,
     SourceCollectionWrite, SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
-    SourceDbError, SourceFileWrite, SourceIndexClassification, SourceIndexDiagnostic,
-    SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage,
-    SourceTagWrite, SourceWriteCommand, WavEntry,
+    SourceDbError, SourceFileWrite, SourceIndexClassification, SourceIndexCommitResult,
+    SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag,
+    SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
 };
 pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -8,12 +8,12 @@ pub mod sample_sources;
 
 pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
-    ChangedSample, CommittedScanBatch, CommittedSourceDelta, DirectoryRepeatKind,
-    ManifestIdentityDelta, MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats,
-    SourceTreeDiagnostic, SourceTreeFile, SourceTreeSnapshot, UpdatedSample, audit_source,
-    audit_source_and_record, audit_source_and_record_with_progress, complete_deferred_hashes,
-    complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
-    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress,
+    ChangedSample, CommittedScanBatch, CommittedSourceDelta, CommittedSourceIndexDelta,
+    DirectoryRepeatKind, ManifestIdentityDelta, MovedManifestIdentity, RenamedSample, ScanError,
+    ScanMode, ScanStats, SourceTreeDiagnostic, SourceTreeFile, SourceTreeSnapshot, UpdatedSample,
+    audit_source, audit_source_and_record, audit_source_and_record_with_progress,
+    complete_deferred_hashes, complete_deferred_rename_candidates,
+    complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
+    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
     scan_with_progress_and_writer_and_committed_batch, sync_paths, sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/sample_sources/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/mod.rs
@@ -17,10 +17,10 @@ pub mod library {
 
 pub use scan_state::ScanTracker;
 pub use scanner::{
-    ChangedSample, CommittedSourceDelta, ContentAuditActivity, ContentAuditBudget,
-    ContentAuditStorage, DirectoryRepeatKind, ManifestIdentityDelta, MovedManifestIdentity,
-    RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeDiagnostic, SourceTreeFile,
-    SourceTreeSnapshot, UpdatedSample,
+    ChangedSample, CommittedSourceDelta, CommittedSourceIndexDelta, ContentAuditActivity,
+    ContentAuditBudget, ContentAuditStorage, DirectoryRepeatKind, ManifestIdentityDelta,
+    MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeDiagnostic,
+    SourceTreeFile, SourceTreeSnapshot, UpdatedSample,
 };
 pub use wavecrate_library::sample_sources::normalize_relative_path;
 pub use wavecrate_library::sample_sources::{

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -12,11 +12,11 @@ mod scan_walk;
 mod scan_writer;
 
 pub use scan::{
-    ChangedSample, CommittedScanBatch, CommittedSourceDelta, ContentAuditActivity,
-    ContentAuditBudget, ContentAuditStorage, DirectoryRepeatKind, ManifestAuditOutcome,
-    ManifestIdentityDelta, MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats,
-    SourceTreeDiagnostic, SourceTreeFile, SourceTreeSnapshot, UpdatedSample, audit_source,
-    audit_source_and_record, audit_source_and_record_with_budget_and_progress,
+    ChangedSample, CommittedScanBatch, CommittedSourceDelta, CommittedSourceIndexDelta,
+    ContentAuditActivity, ContentAuditBudget, ContentAuditStorage, DirectoryRepeatKind,
+    ManifestAuditOutcome, ManifestIdentityDelta, MovedManifestIdentity, RenamedSample, ScanError,
+    ScanMode, ScanStats, SourceTreeDiagnostic, SourceTreeFile, SourceTreeSnapshot, UpdatedSample,
+    audit_source, audit_source_and_record, audit_source_and_record_with_budget_and_progress,
     audit_source_and_record_with_budget_and_progress_and_writer,
     audit_source_and_record_with_budget_and_progress_and_writer_outcome,
     audit_source_and_record_with_budget_and_progress_and_writer_with_request,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -416,6 +416,14 @@ impl ScanContext {
             batch.commit_with_manifest_changes(expected_revision)?
         };
         post_commit_hook();
+        if let Some(index_commit) = result.source_index_commit.as_ref() {
+            self.stats.committed_source_index_delta.record_commit(
+                index_commit.source_revision,
+                index_commit.index_revision,
+                index_commit.upserted_entries.clone(),
+                index_commit.removed_paths.clone(),
+            );
+        }
         if let Some(snapshot) = result.authoritative_snapshot {
             self.committed_manifest = snapshot
                 .into_iter()

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -28,9 +28,9 @@ pub(crate) use runner::{
 };
 pub(crate) use runner::{finish_scan_result, reconcile_scan_renames};
 pub use stats::{
-    ChangedSample, CommittedScanBatch, CommittedSourceDelta, DirectoryRepeatKind,
-    ManifestIdentityDelta, MovedManifestIdentity, RenamedSample, ScanStats, SourceTreeDiagnostic,
-    SourceTreeFile, SourceTreeSnapshot, UpdatedSample,
+    ChangedSample, CommittedScanBatch, CommittedSourceDelta, CommittedSourceIndexDelta,
+    DirectoryRepeatKind, ManifestIdentityDelta, MovedManifestIdentity, RenamedSample, ScanStats,
+    SourceTreeDiagnostic, SourceTreeFile, SourceTreeSnapshot, UpdatedSample,
 };
 
 #[cfg(test)]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -161,6 +161,8 @@ impl SourceTreeSnapshot {
 pub struct ScanStats {
     /// Authoritative identity delta observed at the final committed source revision.
     pub committed_delta: CommittedSourceDelta,
+    /// Typed index-only changes proven by one bounded committed source write.
+    pub committed_source_index_delta: CommittedSourceIndexDelta,
     /// Number of newly discovered files.
     pub added: usize,
     /// Number of files updated in-place.
@@ -241,6 +243,8 @@ impl ScanStats {
         self.updated_samples.append(&mut deferred.updated_samples);
         self.renamed_samples.append(&mut deferred.renamed_samples);
         self.changed_samples.append(&mut deferred.changed_samples);
+        self.committed_source_index_delta
+            .merge(deferred.committed_source_index_delta);
         let has_manifest_snapshot =
             !self.manifest_before.is_empty() || !self.manifest_after.is_empty();
         if !has_manifest_snapshot {
@@ -300,6 +304,59 @@ impl ScanStats {
 
     pub(crate) fn record_rename_candidate(&mut self, path: PathBuf) {
         self.rename_candidate_paths.push(path);
+    }
+}
+
+/// Typed source-index changes published only after their owning source write commits.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CommittedSourceIndexDelta {
+    /// Generic source revision assigned by the bounded write that changed the index.
+    pub revision: u64,
+    /// Source-index revision assigned by that same bounded write.
+    pub index_revision: u64,
+    /// Visible typed rows upserted by the committed write.
+    pub upserted_entries: Vec<SourceIndexEntry>,
+    /// Visible typed rows removed by the committed write.
+    pub removed_paths: Vec<PathBuf>,
+}
+
+impl CommittedSourceIndexDelta {
+    /// Return true when no source-index projection change was committed.
+    pub fn is_empty(&self) -> bool {
+        self.upserted_entries.is_empty() && self.removed_paths.is_empty()
+    }
+
+    pub(crate) fn record_commit(
+        &mut self,
+        revision: u64,
+        index_revision: u64,
+        upserted_entries: Vec<SourceIndexEntry>,
+        removed_paths: Vec<PathBuf>,
+    ) {
+        if self.is_empty() {
+            self.revision = revision;
+            self.index_revision = index_revision;
+        } else if self.revision != revision || self.index_revision != index_revision {
+            // A single scan must not publish facts from multiple source revisions as one
+            // targeted projection. Preserve the facts for diagnostics, but poison the
+            // authority so the browser worker falls back to full recovery.
+            self.revision = 0;
+            self.index_revision = 0;
+        }
+        self.upserted_entries.extend(upserted_entries);
+        self.removed_paths.extend(removed_paths);
+    }
+
+    fn merge(&mut self, deferred: Self) {
+        if deferred.is_empty() {
+            return;
+        }
+        self.record_commit(
+            deferred.revision,
+            deferred.index_revision,
+            deferred.upserted_entries,
+            deferred.removed_paths,
+        );
     }
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
@@ -272,6 +272,71 @@ fn targeted_sync_uses_the_same_index_only_classification_and_reconciliation() {
 }
 
 #[test]
+fn targeted_index_delta_is_bound_to_the_next_source_revision() {
+    let directory = tempdir().unwrap();
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+    let initial_revision = database.get_revision().unwrap();
+
+    let path = directory.path().join("visible.flac");
+    std::fs::write(&path, b"one").unwrap();
+    let created = sync_paths(&database, &[PathBuf::from("visible.flac")]).unwrap();
+    assert!(created.committed_delta.is_empty());
+    assert_eq!(
+        created.committed_source_index_delta.revision,
+        initial_revision + 1
+    );
+    assert_eq!(
+        created.committed_source_index_delta.revision,
+        created.committed_delta.revision
+    );
+    assert_eq!(
+        created.committed_delta.revision,
+        database.get_revision().unwrap()
+    );
+    assert_eq!(
+        created.committed_source_index_delta.upserted_entries.len(),
+        1
+    );
+    assert!(
+        created
+            .committed_source_index_delta
+            .removed_paths
+            .is_empty()
+    );
+
+    std::fs::write(&path, b"updated").unwrap();
+    let updated = sync_paths(&database, &[PathBuf::from("visible.flac")]).unwrap();
+    assert!(updated.committed_delta.is_empty());
+    assert_eq!(
+        updated.committed_source_index_delta.revision,
+        updated.committed_delta.revision
+    );
+    assert_eq!(
+        updated.committed_source_index_delta.upserted_entries[0].file_size,
+        Some(7)
+    );
+
+    std::fs::remove_file(path).unwrap();
+    let deleted = sync_paths(&database, &[PathBuf::from("visible.flac")]).unwrap();
+    assert!(deleted.committed_delta.is_empty());
+    assert_eq!(
+        deleted.committed_source_index_delta.revision,
+        deleted.committed_delta.revision
+    );
+    assert_eq!(
+        deleted.committed_source_index_delta.removed_paths,
+        vec![PathBuf::from("visible.flac")]
+    );
+    assert!(
+        deleted
+            .committed_source_index_delta
+            .upserted_entries
+            .is_empty()
+    );
+}
+
+#[test]
 fn uncertain_subtree_does_not_false_delete_index_only_rows() {
     use crate::sample_sources::scanner::scan_fs::force_directory_read_failure;
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -98,7 +98,17 @@ pub(super) fn complete_scan_generation(
     }
     source_root.ensure_current_generation()?;
     if context.mode == super::scan::ScanMode::Targeted {
-        context.commit_batch(db, batch)?;
+        let index_projection_is_current = !context.stats.committed_source_index_delta.is_empty()
+            && context.stats.committed_source_index_delta.revision
+                == context.latest_committed_snapshot().0;
+        if index_projection_is_current {
+            // Keep the index-bearing source revision contiguous. The index facts were already
+            // committed through the bounded source write above; completion metadata is auxiliary
+            // and must not create an unrepresentable intermediate browser revision.
+            batch.commit_auxiliary_state()?;
+        } else {
+            context.commit_batch(db, batch)?;
+        }
         Ok(context.latest_committed_snapshot())
     } else {
         Ok(batch.commit_with_manifest_snapshot()?)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
@@ -124,11 +124,10 @@ pub(super) fn reconcile_index_entries(
         batch.upsert_source_index_entry(&entry)?;
     }
     source_root.ensure_current_generation()?;
-    if unavailable_manifest_paths.is_empty() {
-        batch.commit_auxiliary_state()?;
-    } else {
-        source_root.ensure_current_generation()?;
-        context.commit_batch(database, batch)?;
-    }
+    source_root.ensure_current_generation()?;
+    // Index-only facts are source projection facts, not auxiliary metadata. Route every
+    // mutation through the bounded source commit so the scanner can publish the exact
+    // revision only after this transaction commits.
+    context.commit_batch(database, batch)?;
     Ok(())
 }

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -489,6 +489,8 @@ pub(in crate::native_app) struct SourceFilesystemSyncSuccess {
     pub(in crate::native_app) incomplete_error: Option<String>,
     pub(in crate::native_app) committed_delta:
         wavecrate::sample_sources::scanner::CommittedSourceDelta,
+    pub(in crate::native_app) committed_source_index_delta:
+        wavecrate::sample_sources::scanner::CommittedSourceIndexDelta,
     pub(in crate::native_app) browser_projection_delta: Option<BrowserProjectionDelta>,
     pub(in crate::native_app) projection_handoff_ticket:
         Option<crate::native_app::source_processing::ProjectionHandoffTicket>,

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -256,6 +256,16 @@ fn committed_projection_delta_applies_only_at_the_next_revision() {
         .expect("projection revision");
     let new_file =
         file_entry_with_snapshot_metadata(&new, 12, Rating::KEEP_1, false, Vec::new(), None, None);
+    let unsupported = root.join("nested/new.flac");
+    let unsupported_file = file_entry_with_snapshot_metadata(
+        &unsupported,
+        7,
+        Rating::NEUTRAL,
+        false,
+        Vec::new(),
+        None,
+        None,
+    );
 
     assert!(browser.apply_committed_projection_delta(
         &source_id,
@@ -264,7 +274,7 @@ fn committed_projection_delta_applies_only_at_the_next_revision() {
             snapshot_revision: revision + 1,
             folders: vec![root.join("nested")],
             removed_file_ids: vec![path_id(&old)],
-            upserted_files: vec![new_file],
+            upserted_files: vec![new_file, unsupported_file],
         },
     ));
     assert!(browser.tree.folders[0].find_file(&path_id(&old)).is_none());
@@ -274,6 +284,13 @@ fn committed_projection_delta_applies_only_at_the_next_revision() {
             .expect("incremental file")
             .rating,
         Rating::KEEP_1
+    );
+    assert_eq!(
+        browser.tree.folders[0]
+            .find_file(&path_id(&unsupported))
+            .expect("unsupported incremental file")
+            .kind,
+        "Unsupported audio"
     );
 
     assert!(browser.apply_committed_projection_delta(

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -944,6 +944,7 @@ mod tests {
                     }],
                     ..CommittedSourceDelta::default()
                 },
+                committed_source_index_delta: Default::default(),
                 browser_projection_delta: projection,
                 projection_handoff_ticket: None,
             }),
@@ -988,6 +989,7 @@ mod tests {
                 renames_reconciled: 0,
                 incomplete_error: None,
                 committed_delta,
+                committed_source_index_delta: Default::default(),
                 browser_projection_delta: Some(BrowserProjectionDelta {
                     manifest_revision: projection_revision,
                     snapshot_revision: projection_revision,

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -1,13 +1,13 @@
 use std::{
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
     thread,
     time::Duration,
 };
 
-use wavecrate::sample_sources::SourceDatabase;
+use wavecrate::sample_sources::{Rating, SourceDatabase, SourceIndexClassification};
 use wavecrate_library::filesystem_identity::stable_filesystem_identity;
-use wavecrate_library::sample_sources::is_supported_audio;
 use wavecrate_scan::sample_sources::scanner::{
     self, ScanWritePhase, ScanWriter, UncoordinatedScanWriter,
 };
@@ -209,7 +209,9 @@ fn sync_source_database_paths_once(
     watcher_continuity_proof: Option<&WatcherContinuityProof>,
     writer: &impl ScanWriter,
 ) -> SourceDatabaseSyncAttempt {
-    let browser_delta_eligible = paths.iter().all(|path| is_supported_audio(path));
+    // Browser IDs are UTF-8 paths. A raw path is still reconciled in the database, but it must
+    // take the existing full-recovery path rather than enter a lossy incremental projection.
+    let browser_delta_eligible = paths.iter().all(|path| path.to_str().is_some());
     let _writer = writer.lock(ScanWritePhase::Open);
     let root_identity = capture_source_root_identity(root);
     if cancel.load(Ordering::Acquire) {
@@ -273,7 +275,12 @@ fn sync_source_database_paths_once(
                 }
             };
             let browser_projection_delta = if browser_delta_eligible && incomplete_error.is_none() {
-                match build_browser_projection_delta(root, &db, &completed.committed_delta) {
+                match build_browser_projection_delta(
+                    root,
+                    &db,
+                    &completed.committed_delta,
+                    &completed.committed_source_index_delta,
+                ) {
                     Ok(Some(projection)) => Some(projection),
                     Ok(None) => {
                         incomplete_error = Some(format!(
@@ -306,6 +313,7 @@ fn sync_source_database_paths_once(
                 renames_reconciled: completed.renames_reconciled,
                 incomplete_error,
                 committed_delta: completed.committed_delta,
+                committed_source_index_delta: completed.committed_source_index_delta,
                 browser_projection_delta,
                 projection_handoff_ticket: None,
             })
@@ -321,7 +329,19 @@ fn build_browser_projection_delta(
     root: &std::path::Path,
     db: &SourceDatabase,
     delta: &scanner::CommittedSourceDelta,
+    index_delta: &scanner::CommittedSourceIndexDelta,
 ) -> Result<Option<BrowserProjectionDelta>, String> {
+    if !index_delta.is_empty()
+        && (index_delta.revision != delta.revision || index_delta.index_revision == 0)
+    {
+        tracing::info!(
+            source_revision = delta.revision,
+            index_source_revision = index_delta.revision,
+            index_revision = index_delta.index_revision,
+            "Source-index projection facts are not bound to the final committed source revision"
+        );
+        return Ok(None);
+    }
     let projection_paths = delta
         .created
         .iter()
@@ -339,6 +359,35 @@ fn build_browser_projection_delta(
                 .map(|entry| entry.new_relative_path.clone()),
         )
         .collect::<Vec<_>>();
+    let mut manifest_upsert_paths = BTreeSet::new();
+    for path in &projection_paths {
+        if !manifest_upsert_paths.insert(path.clone()) {
+            return Err(format!(
+                "duplicate supported browser upsert path {}",
+                path.display()
+            ));
+        }
+        ensure_unicode_projection_path(root, path)?;
+    }
+    let index_paths = index_delta
+        .upserted_entries
+        .iter()
+        .map(|entry| entry.relative_path.clone())
+        .chain(index_delta.removed_paths.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    let index_paths = index_paths.into_iter().collect::<Vec<_>>();
+    for path in &index_paths {
+        ensure_unicode_projection_path(root, path)?;
+    }
+    for entry in &index_delta.upserted_entries {
+        if !manifest_upsert_paths.insert(entry.relative_path.clone()) {
+            return Err(format!(
+                "supported and source-index browser upserts overlap at {}",
+                entry.relative_path.display()
+            ));
+        }
+    }
+
     let snapshot = db
         .browser_metadata_for_paths_at_revision(delta.revision, &projection_paths)
         .map_err(|error| format!("read committed browser projection delta: {error}"))?;
@@ -352,20 +401,17 @@ fn build_browser_projection_delta(
         );
         return Ok(None);
     }
-    let upsert_paths = projection_paths
-        .iter()
-        .cloned()
-        .collect::<std::collections::HashSet<_>>();
     let mut folders = std::collections::BTreeSet::new();
-    let upserted_files = files
-        .into_iter()
-        .filter(|entry| !entry.missing && upsert_paths.contains(&entry.relative_path))
-        .map(|entry| {
+    let mut upserted_files = Vec::new();
+    let mut hydrated_manifest_paths = BTreeSet::new();
+    for entry in files {
+        if !entry.missing && manifest_upsert_paths.contains(&entry.relative_path) {
             let absolute = root.join(&entry.relative_path);
             if let Some(parent) = absolute.parent() {
                 folders.insert(parent.to_path_buf());
             }
-            file_entry_with_snapshot_metadata(
+            hydrated_manifest_paths.insert(entry.relative_path.clone());
+            upserted_files.push(file_entry_with_snapshot_metadata(
                 &absolute,
                 entry.file_size,
                 entry.rating,
@@ -373,30 +419,113 @@ fn build_browser_projection_delta(
                 entry.collections,
                 entry.last_played_at,
                 entry.last_curated_at,
-            )
-        })
-        .collect();
-    let removed_file_ids = delta
+            ));
+        }
+    }
+    if hydrated_manifest_paths.len() != projection_paths.len() {
+        return Err(String::from(
+            "committed supported browser metadata did not hydrate every upsert",
+        ));
+    }
+
+    if !index_delta.is_empty() {
+        let index_snapshot = db
+            .source_index_entries_for_paths_at_revision(index_delta.index_revision, &index_paths)
+            .map_err(|error| format!("read committed source-index projection delta: {error}"))?;
+        let actual = index_snapshot
+            .entries
+            .into_iter()
+            .map(|entry| (entry.relative_path.clone(), entry))
+            .collect::<BTreeMap<_, _>>();
+        let expected = index_delta
+            .upserted_entries
+            .iter()
+            .map(|entry| (entry.relative_path.clone(), entry))
+            .collect::<BTreeMap<_, _>>();
+        if actual.len() != expected.len()
+            || expected
+                .iter()
+                .any(|(path, expected)| actual.get(path) != Some(expected))
+            || index_delta
+                .removed_paths
+                .iter()
+                .any(|path| actual.contains_key(path))
+        {
+            return Err(String::from(
+                "committed source-index projection hydration did not match its write evidence",
+            ));
+        }
+        for entry in &index_delta.upserted_entries {
+            let Some(file_size) = entry.file_size else {
+                return Err(format!(
+                    "source-index upsert has no file size: {}",
+                    entry.relative_path.display()
+                ));
+            };
+            if matches!(
+                entry.classification,
+                SourceIndexClassification::Inaccessible
+            ) {
+                return Err(format!(
+                    "inaccessible source-index row cannot be projected: {}",
+                    entry.relative_path.display()
+                ));
+            }
+            let absolute = root.join(&entry.relative_path);
+            if let Some(parent) = absolute.parent() {
+                folders.insert(parent.to_path_buf());
+            }
+            upserted_files.push(file_entry_with_snapshot_metadata(
+                &absolute,
+                file_size,
+                Rating::NEUTRAL,
+                false,
+                Vec::new(),
+                None,
+                None,
+            ));
+        }
+    }
+    upserted_files.sort_by(|left, right| left.id.cmp(&right.id));
+
+    let mut removed_file_ids = BTreeSet::new();
+    for path in delta
         .deleted
         .iter()
-        .map(|entry| {
-            root.join(&entry.relative_path)
-                .to_string_lossy()
-                .to_string()
-        })
-        .chain(delta.moved.iter().map(|entry| {
-            root.join(&entry.old_relative_path)
-                .to_string_lossy()
-                .to_string()
-        }))
-        .collect();
+        .map(|entry| &entry.relative_path)
+        .chain(delta.moved.iter().map(|entry| &entry.old_relative_path))
+        .chain(index_delta.removed_paths.iter())
+    {
+        removed_file_ids.insert(projected_path_id(root, path)?);
+    }
     Ok(Some(BrowserProjectionDelta {
         manifest_revision: delta.revision,
         snapshot_revision: revision,
         folders: folders.into_iter().collect(),
-        removed_file_ids,
+        removed_file_ids: removed_file_ids.into_iter().collect(),
         upserted_files,
     }))
+}
+
+fn ensure_unicode_projection_path(root: &Path, relative_path: &Path) -> Result<(), String> {
+    let absolute = root.join(relative_path);
+    if absolute.to_str().is_none() {
+        return Err(format!(
+            "non-Unicode source path cannot enter browser projection: {}",
+            relative_path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn projected_path_id(root: &Path, relative_path: &Path) -> Result<String, String> {
+    let absolute = root.join(relative_path);
+    absolute.to_str().map(str::to_owned).ok_or_else(|| {
+        format!(
+            "non-Unicode source path cannot enter browser removal projection: {}",
+            relative_path.display()
+        )
+    })
 }
 
 fn wait_for_retry(cancel: &AtomicBool, delay: Duration) -> bool {
@@ -713,6 +842,168 @@ mod tests {
         );
         assert!(projection.upserted_files.is_empty());
         assert!(projection.removed_file_ids.is_empty());
+    }
+
+    #[test]
+    fn filesystem_sync_projects_visible_unsupported_create_update_and_delete() {
+        let root = tempfile::tempdir().expect("source root");
+        let relative = PathBuf::from("visible.flac");
+        let absolute = root.path().join(&relative);
+        std::fs::write(&absolute, b"one").expect("unsupported file");
+
+        let created = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![relative.clone()],
+            1,
+            &AtomicBool::new(false),
+        )
+        .result
+        .expect("unsupported create sync");
+        assert!(created.committed_delta.is_empty());
+        assert_eq!(
+            created.committed_source_index_delta.upserted_entries.len(),
+            1
+        );
+        let created_projection = created
+            .browser_projection_delta
+            .expect("unsupported create projection");
+        assert_eq!(created_projection.upserted_files.len(), 1);
+        assert_eq!(
+            created_projection.upserted_files[0].id,
+            absolute.display().to_string()
+        );
+        assert_eq!(
+            created_projection.upserted_files[0].kind,
+            "Unsupported audio"
+        );
+        assert_eq!(created_projection.upserted_files[0].size_bytes, 3);
+
+        std::fs::write(&absolute, b"updated").expect("unsupported update");
+        let updated = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![relative.clone()],
+            1,
+            &AtomicBool::new(false),
+        )
+        .result
+        .expect("unsupported update sync");
+        assert!(updated.committed_delta.is_empty());
+        assert_eq!(
+            updated.committed_source_index_delta.upserted_entries.len(),
+            1
+        );
+        assert_eq!(
+            updated
+                .browser_projection_delta
+                .as_ref()
+                .expect("unsupported update projection")
+                .upserted_files[0]
+                .size_bytes,
+            7
+        );
+
+        std::fs::remove_file(&absolute).expect("unsupported delete");
+        let deleted = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![relative.clone()],
+            1,
+            &AtomicBool::new(false),
+        )
+        .result
+        .expect("unsupported delete sync");
+        assert!(deleted.committed_delta.is_empty());
+        assert_eq!(
+            deleted.committed_source_index_delta.removed_paths,
+            vec![relative]
+        );
+        let deleted_projection = deleted
+            .browser_projection_delta
+            .expect("unsupported delete projection");
+        assert_eq!(
+            deleted_projection.removed_file_ids,
+            vec![absolute.display().to_string()]
+        );
+        assert!(deleted_projection.upserted_files.is_empty());
+    }
+
+    #[test]
+    fn filesystem_sync_projects_supported_and_unsupported_transitions_once() {
+        let root = tempfile::tempdir().expect("source root");
+        let supported = root.path().join("transition.wav");
+        let unsupported = root.path().join("transition.flac");
+        std::fs::write(&supported, b"supported").expect("supported file");
+        sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![PathBuf::from("transition.wav")],
+            1,
+            &AtomicBool::new(false),
+        )
+        .result
+        .expect("initial supported sync");
+
+        std::fs::rename(&supported, &unsupported).expect("supported to unsupported rename");
+        let to_unsupported = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![
+                PathBuf::from("transition.wav"),
+                PathBuf::from("transition.flac"),
+            ],
+            2,
+            &AtomicBool::new(false),
+        )
+        .result
+        .expect("supported to unsupported sync");
+        let projection = to_unsupported
+            .browser_projection_delta
+            .expect("supported to unsupported projection");
+        assert_eq!(
+            projection.removed_file_ids,
+            vec![supported.display().to_string()]
+        );
+        assert_eq!(projection.upserted_files.len(), 1);
+        assert_eq!(
+            projection.upserted_files[0].id,
+            unsupported.display().to_string()
+        );
+        assert_eq!(projection.upserted_files[0].kind, "Unsupported audio");
+
+        std::fs::rename(&unsupported, &supported).expect("unsupported to supported rename");
+        let to_supported = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![
+                PathBuf::from("transition.flac"),
+                PathBuf::from("transition.wav"),
+            ],
+            2,
+            &AtomicBool::new(false),
+        )
+        .result
+        .expect("unsupported to supported sync");
+        let projection = to_supported
+            .browser_projection_delta
+            .expect("unsupported to supported projection");
+        assert_eq!(
+            projection.removed_file_ids,
+            vec![unsupported.display().to_string()]
+        );
+        assert_eq!(projection.upserted_files.len(), 1);
+        assert_eq!(
+            projection.upserted_files[0].id,
+            supported.display().to_string()
+        );
+        assert_eq!(projection.upserted_files[0].kind, "Audio");
     }
 
     #[test]

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -23,10 +23,10 @@ pub mod scan_state {
 /// Source scanning logic.
 pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
-        ChangedSample, CommittedSourceDelta, ContentAuditActivity, ContentAuditBudget,
-        ContentAuditStorage, ManifestAuditOutcome, ManifestIdentityDelta, MovedManifestIdentity,
-        RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
-        audit_source_and_record, audit_source_and_record_with_budget_and_progress,
+        ChangedSample, CommittedSourceDelta, CommittedSourceIndexDelta, ContentAuditActivity,
+        ContentAuditBudget, ContentAuditStorage, ManifestAuditOutcome, ManifestIdentityDelta,
+        MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
+        audit_source, audit_source_and_record, audit_source_and_record_with_budget_and_progress,
         audit_source_and_record_with_budget_and_progress_and_writer,
         audit_source_and_record_with_budget_and_progress_and_writer_outcome,
         audit_source_and_record_with_budget_and_progress_and_writer_with_request,
@@ -109,12 +109,13 @@ pub use wavecrate_library::sample_sources::{
     HarvestMetadataSnapshot, HarvestSourceRange, HarvestState, LIBRARY_DB_FILE_NAME, LibraryError,
     LibraryState, NewHarvestDerivation, Rating, SampleSource, SourceCollectionWrite,
     SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole, SourceDbError,
-    SourceFileWrite, SourceId, SourceMetadataStorage, SourceRole, SourceTagWrite,
-    SourceWriteCommand, WavEntry, database_path_for, default_primary_import_folder, normalize_path,
+    SourceFileWrite, SourceId, SourceIndexClassification, SourceIndexEntry, SourceMetadataStorage,
+    SourceRole, SourceTagWrite, SourceWriteCommand, WavEntry, database_path_for,
+    default_primary_import_folder, normalize_path,
 };
 pub use wavecrate_library::sample_sources::{HiddenDirectoryPolicy, SourceTraversalPolicy};
 pub use wavecrate_scan::sample_sources::ScanTracker;
 pub use wavecrate_scan::sample_sources::{
-    ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
-    RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
+    ChangedSample, CommittedSourceDelta, CommittedSourceIndexDelta, ManifestIdentityDelta,
+    MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
 };


### PR DESCRIPTION
## Goal
Carry visible UTF-8 unsupported-file source-index changes through the exact committed targeted source revision and browser projection handoff. Targeted create, update, delete, and supported/unsupported classification transitions must not advance browser state or watcher checkpoint state while the corresponding committed source-index fact is missing from the projection.

## Scope and non-goals
- Return typed source-index upserts/removals from the same bounded source-database write that assigns the source revision.
- Preserve those facts through targeted scan completion and hydrate only the exact changed paths at the committed index revision.
- Project unsupported regular files as neutral browser rows, parent folders, and exact removals without a full-source traversal.
- Keep readiness and supported-manifest identity deltas distinct from projection-only changes.
- Fail closed on revision mismatches, gaps, missing commit evidence, failed exact hydration, cancellation, uncertain traversal, and non-Unicode browser paths.
- Non-goals: source DB DDL or migrations; persistent directory truth or empty-folder create/delete; universal coordinator/profile ownership; recursive per-event hydration; UI-thread I/O; non-macOS journal work; or PR #980 changes.

## Definition of Done
- A targeted visible UTF-8 unsupported-file create returns a committed source-index upsert bound to the next source revision and produces one neutral browser row with its parent folder.
- Updating the unsupported file updates the existing row without duplication; deleting it produces an exact committed removal.
- Supported-to-unsupported and unsupported-to-supported transitions remove the old row and install exactly one correctly classified final row.
- Index-only changes do not create false supported-manifest/readiness invalidation, but they are not treated as projection-empty.
- No index removal is emitted beneath an uncertain or unreadable traversal boundary.
- Stale lifecycle, source-revision mismatch, revision gap, missing exact commit evidence, failed hydration, and projection rejection retain full recovery and do not advance a watcher checkpoint.
- PR #1043 replay/checkpoint/source-isolation behavior remains unchanged.
- No schema change or UI-thread filesystem/SQLite I/O is introduced.

## Validation
- `cargo test -p wavecrate-library --lib sample_sources::db::index_entries` — 8 passed.
- `cargo test -p wavecrate-scan --lib targeted_sync` — 25 passed.
- `cargo test -p wavecrate --lib native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::tests` — 12 passed.
- `cargo test -p wavecrate --lib native_app::sample_library::folder_browser::tests::source_scanning` — 21 passed.
- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::watcher_checkpoint` — 8 passed.
- `cargo test -p wavecrate --lib native_app::app::source_processing_events` — 6 passed.
- `cargo test -p wavecrate --lib native_app::sample_library::source_watcher::` — 125 passed, 2 existing timing/startup failures: `filesystem_event_after_initial_watcher_ready_is_not_suppressed` and `idempotent_startup_source_sync_does_not_refresh_every_source`.
- `cargo check -p wavecrate --tests --bins` via `bash scripts/ci.sh smoke` — passed; Radiant checks and branch guard passed.
- Every touched Rust file `rustfmt --edition 2024 --check` and `git diff --check` — passed.
- Full `cargo fmt --all -- --check` — reports unrelated pre-existing drift in `harvest_tracking/persistence.rs`, `source_diagnostics.rs`, `tests/transactions.rs`, `waveform/playmark_label_editor.rs`, and `tests/release_contract.rs`.

## Known limitations
- Native macOS Finder acceptance for exact unsupported-file projection and closed-app replay remains a user handoff; the current harness has no end-to-end FSEvents-to-checkpoint test.
- Persistent directory truth and empty-folder projection remain a later slice.
- Non-Unicode and inaccessible diagnostic rows remain conservative full-recovery paths.
- The two broader watcher timing/startup failures remain outside this diff and were reproduced on the merged parent lane.

Fresh independent Terra review is required before merge. User approval is required before merge; the standing approval for this task applies only after Terra gives this PR its own `APPROVE` verdict.