### PR TITLE
Add generation-published source directory truth storage

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -427,39 +427,8 @@ impl SourceDatabase {
         let mut deleted_generations = 0usize;
         let mut remaining_entry_budget = CLEANUP_ENTRY_LIMIT;
         for generation in candidates {
-            let count: i64 = transaction
-                .query_row(
-                    "SELECT COUNT(*) FROM source_directory_entries WHERE generation = ?1",
-                    [generation],
-                    |row| row.get(0),
-                )
-                .map_err(map_sql_error)?;
-            let entry_count = usize::try_from(count).map_err(|_| SourceDbError::Unexpected)?;
-            if entry_count == 0 {
-                let deleted = transaction
-                    .execute(
-                        "DELETE FROM source_directory_generations
-                         WHERE generation = ?1 AND status = 'inactive'",
-                        [generation],
-                    )
-                    .map_err(map_sql_error)?;
-                if deleted == 1 {
-                    deleted_generations = deleted_generations.saturating_add(1);
-                }
-                continue;
-            }
-            if remaining_entry_budget == 0 {
-                break;
-            }
-
-            let delete_count = entry_count.min(remaining_entry_budget);
-            let deleted = if delete_count == entry_count {
-                transaction
-                    .execute(
-                        "DELETE FROM source_directory_entries WHERE generation = ?1",
-                        [generation],
-                    )
-                    .map_err(map_sql_error)?
+            let deleted = if remaining_entry_budget == 0 {
+                0
             } else {
                 transaction
                     .execute(
@@ -474,7 +443,8 @@ impl SourceDatabase {
                            )",
                         rusqlite::params![
                             generation,
-                            i64::try_from(delete_count).map_err(|_| SourceDbError::Unexpected)?
+                            i64::try_from(remaining_entry_budget)
+                                .map_err(|_| SourceDbError::Unexpected)?
                         ],
                     )
                     .map_err(map_sql_error)?
@@ -482,7 +452,20 @@ impl SourceDatabase {
             deleted_entries = deleted_entries.saturating_add(deleted);
             remaining_entry_budget = remaining_entry_budget.saturating_sub(deleted);
 
-            if delete_count == entry_count {
+            let exhausted = transaction
+                .query_row(
+                    "SELECT 1
+                     FROM source_directory_entries
+                     WHERE generation = ?1
+                     ORDER BY path ASC
+                     LIMIT 1",
+                    [generation],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()
+                .map_err(map_sql_error)?
+                .is_none();
+            if exhausted {
                 let removed_generation = transaction
                     .execute(
                         "DELETE FROM source_directory_generations
@@ -493,9 +476,6 @@ impl SourceDatabase {
                 if removed_generation == 1 {
                     deleted_generations = deleted_generations.saturating_add(1);
                 }
-            }
-            if remaining_entry_budget == 0 {
-                break;
             }
         }
         let more_work = transaction
@@ -695,6 +675,10 @@ mod tests {
     fn malformed_persisted_lossless_directory_paths_require_audit() {
         for (path, expected_description) in [
             ("valid/~wavecrate-escaped~2f", "encoded slash/root"),
+            (
+                "valid/~wavecrate-escaped~612f62",
+                "encoded slash inside component",
+            ),
             ("valid/~wavecrate-escaped~2e2e", "encoded parent"),
         ] {
             let root = tempfile::tempdir().unwrap();
@@ -787,12 +771,61 @@ mod tests {
     }
 
     #[test]
-    fn cleanup_bounds_large_inactive_generation_without_advancing_revision() {
+    fn staging_does_not_scan_large_generation() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        const STAGING_QUERY_WORK_BUDGET: usize = 2_000;
+
         let root = tempfile::tempdir().unwrap();
         let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
-        let entry_count = super::CLEANUP_ENTRY_LIMIT + 1;
+        let entry_count = super::super::SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT * 8;
+        let existing_entries = (0..entry_count - 1)
+            .map(|index| directory(&format!("large/{index:04}"), &format!("dir-{index}")))
+            .collect::<Vec<_>>();
+
+        db.begin_source_directory_truth_generation(1, entry_count as u64)
+            .unwrap();
+        for batch in existing_entries.chunks(super::super::SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT) {
+            db.stage_source_directory_truth_entries(1, batch).unwrap();
+        }
+
+        let query_work = Arc::new(AtomicUsize::new(0));
+        db.connection.progress_handler(
+            1,
+            Some({
+                let query_work = Arc::clone(&query_work);
+                move || query_work.fetch_add(1, Ordering::Relaxed) >= STAGING_QUERY_WORK_BUDGET
+            }),
+        );
+        let stage_result = db.stage_source_directory_truth_entries(
+            1,
+            &[directory(
+                &format!("large/{:04}", entry_count - 1),
+                &format!("dir-{}", entry_count - 1),
+            )],
+        );
+        db.connection.progress_handler(0, None::<fn() -> bool>);
+
+        stage_result.expect("staging one bounded batch must not scan the generation");
+        assert!(
+            query_work.load(Ordering::Relaxed) < STAGING_QUERY_WORK_BUDGET,
+            "bounded staging exceeded query-work budget"
+        );
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+    }
+
+    #[test]
+    fn cleanup_bounds_large_inactive_generation_without_advancing_revision() {
+        const CLEANUP_QUERY_WORK_BUDGET: usize = 8_000;
+
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let entry_count = super::CLEANUP_ENTRY_LIMIT * 32;
         let entries = (0..entry_count)
-            .map(|index| directory(&format!("large/{index:03}"), &format!("dir-{index}")))
+            .map(|index| directory(&format!("large/{index:04}"), &format!("dir-{index}")))
             .collect::<Vec<_>>();
 
         db.begin_source_directory_truth_generation(1, entry_count as u64)
@@ -808,11 +841,73 @@ mod tests {
         db.finalize_source_directory_truth_generation(2, 1).unwrap();
         let revision_before_cleanup = db.get_revision().unwrap();
 
-        let cleanup = db.cleanup_source_directory_truth(1).unwrap();
+        let query_work = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        db.connection.progress_handler(
+            1,
+            Some({
+                let query_work = std::sync::Arc::clone(&query_work);
+                move || {
+                    query_work.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                        >= CLEANUP_QUERY_WORK_BUDGET
+                }
+            }),
+        );
+        let cleanup_result = db.cleanup_source_directory_truth(1);
+        db.connection.progress_handler(0, None::<fn() -> bool>);
+
+        let cleanup = cleanup_result.expect("cleanup must stay bounded for a large generation");
         assert_eq!(cleanup.deleted_entries, super::CLEANUP_ENTRY_LIMIT);
         assert_eq!(cleanup.deleted_generations, 0);
         assert!(cleanup.more_work);
         assert_eq!(db.get_revision().unwrap(), revision_before_cleanup);
+        assert!(
+            query_work.load(std::sync::atomic::Ordering::Relaxed) < CLEANUP_QUERY_WORK_BUDGET,
+            "bounded cleanup exceeded query-work budget"
+        );
+    }
+
+    #[test]
+    fn cleanup_probes_empty_candidates_after_entry_budget_is_exhausted() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let entry_count = super::CLEANUP_ENTRY_LIMIT + 1;
+        let entries = (0..entry_count)
+            .map(|index| directory(&format!("large/{index:03}"), &format!("dir-{index}")))
+            .collect::<Vec<_>>();
+
+        db.begin_source_directory_truth_generation(1, entry_count as u64)
+            .unwrap();
+        for batch in entries.chunks(super::super::SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT) {
+            db.stage_source_directory_truth_entries(1, batch).unwrap();
+        }
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+        db.begin_source_directory_truth_generation(2, 0).unwrap();
+        db.finalize_source_directory_truth_generation(2, 1).unwrap();
+
+        db.begin_source_directory_truth_generation(3, 1).unwrap();
+        db.stage_source_directory_truth_entries(3, &[directory("current", "dir-current")])
+            .unwrap();
+        db.finalize_source_directory_truth_generation(3, 2).unwrap();
+
+        let cleanup = db.cleanup_source_directory_truth(2).unwrap();
+        assert_eq!(cleanup.deleted_entries, super::CLEANUP_ENTRY_LIMIT);
+        assert_eq!(cleanup.deleted_generations, 1);
+        assert!(cleanup.more_work);
+        let generation_two_exists: bool = db
+            .connection
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1
+                    FROM source_directory_generations
+                    WHERE generation = 2
+                )",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+            != 0;
+        assert!(!generation_two_exists);
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -25,6 +25,12 @@ const GENERATION_COLUMNS: [&str; 7] = [
 const ENTRY_COLUMNS: [&str; 4] = ["generation", "path", "path_encoding", "directory_identity"];
 const CLEANUP_ENTRY_LIMIT: usize = SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DirectoryTruthInspection {
+    FullIntegrity,
+    BoundedPage,
+}
+
 /// Encode one source-relative directory path using the lossless source-index representation.
 pub(crate) fn encode_directory_path(path: &Path) -> Result<(String, i64), SourceDbError> {
     normalize_source_index_path(path).map_err(|_| {
@@ -83,18 +89,28 @@ fn source_revision(connection: &rusqlite::Connection) -> Result<u64, SourceDbErr
 
 fn inspect_directory_truth_state(
     connection: &rusqlite::Connection,
+    inspection: DirectoryTruthInspection,
 ) -> Result<SourceDirectoryTruthState, SourceDbError> {
     let current_source_revision = source_revision(connection)?;
+    let active_query = match inspection {
+        DirectoryTruthInspection::FullIntegrity => {
+            "SELECT generation, expected_entry_count, staged_entry_count, complete,
+                    published_source_revision
+             FROM source_directory_generations
+             WHERE status = 'active'
+             ORDER BY generation ASC"
+        }
+        DirectoryTruthInspection::BoundedPage => {
+            "SELECT generation, expected_entry_count, staged_entry_count, complete,
+                    published_source_revision
+             FROM source_directory_generations
+             WHERE status = 'active'
+             ORDER BY generation ASC
+             LIMIT 2"
+        }
+    };
     let active_rows = {
-        let mut statement = connection
-            .prepare(
-                "SELECT generation, expected_entry_count, staged_entry_count, complete,
-                        published_source_revision
-                 FROM source_directory_generations
-                 WHERE status = 'active'
-                 ORDER BY generation ASC",
-            )
-            .map_err(map_sql_error)?;
+        let mut statement = connection.prepare(active_query).map_err(map_sql_error)?;
         statement
             .query_map([], |row| {
                 Ok((
@@ -118,14 +134,31 @@ fn inspect_directory_truth_state(
     let Some((generation, expected, staged, complete, published_revision)) =
         active_rows.first().copied()
     else {
-        let inactive_count: i64 = connection
-            .query_row(
-                "SELECT COUNT(*) FROM source_directory_generations WHERE status = 'inactive'",
-                [],
-                |row| row.get(0),
-            )
-            .map_err(map_sql_error)?;
-        if inactive_count != 0 {
+        let has_inactive = match inspection {
+            DirectoryTruthInspection::FullIntegrity => connection
+                .query_row(
+                    "SELECT COUNT(*) FROM source_directory_generations WHERE status = 'inactive'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(map_sql_error)?
+                != 0,
+            DirectoryTruthInspection::BoundedPage => {
+                connection
+                    .query_row(
+                        "SELECT EXISTS(
+                        SELECT 1
+                        FROM source_directory_generations
+                        WHERE status = 'inactive'
+                    )",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map_err(map_sql_error)?
+                    != 0
+            }
+        };
+        if has_inactive {
             return Ok(SourceDirectoryTruthState::Unavailable {
                 reason: SourceDirectoryTruthUnavailableReason::Malformed,
             });
@@ -150,22 +183,24 @@ fn inspect_directory_truth_state(
         });
     }
 
-    let (entry_count, distinct_paths, distinct_identities): (i64, i64, i64) = connection
-        .query_row(
-            "SELECT COUNT(*), COUNT(DISTINCT path), COUNT(DISTINCT directory_identity)
-             FROM source_directory_entries
-             WHERE generation = ?1",
-            [generation],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .map_err(map_sql_error)?;
-    if entry_count != expected
-        || entry_count != distinct_paths
-        || entry_count != distinct_identities
-    {
-        return Ok(SourceDirectoryTruthState::Unavailable {
-            reason: SourceDirectoryTruthUnavailableReason::Malformed,
-        });
+    if inspection == DirectoryTruthInspection::FullIntegrity {
+        let (entry_count, distinct_paths, distinct_identities): (i64, i64, i64) = connection
+            .query_row(
+                "SELECT COUNT(*), COUNT(DISTINCT path), COUNT(DISTINCT directory_identity)
+                 FROM source_directory_entries
+                 WHERE generation = ?1",
+                [generation],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .map_err(map_sql_error)?;
+        if entry_count != expected
+            || entry_count != distinct_paths
+            || entry_count != distinct_identities
+        {
+            return Ok(SourceDirectoryTruthState::Unavailable {
+                reason: SourceDirectoryTruthUnavailableReason::Malformed,
+            });
+        }
     }
 
     Ok(SourceDirectoryTruthState::Active {
@@ -234,7 +269,8 @@ impl SourceDatabase {
             .connection
             .unchecked_transaction()
             .map_err(map_sql_error)?;
-        let state = inspect_directory_truth_state(&transaction)?;
+        let state =
+            inspect_directory_truth_state(&transaction, DirectoryTruthInspection::FullIntegrity)?;
         transaction.rollback().map_err(map_sql_error)?;
         Ok(state)
     }
@@ -258,7 +294,8 @@ impl SourceDatabase {
             .connection
             .unchecked_transaction()
             .map_err(map_sql_error)?;
-        let state = inspect_directory_truth_state(&transaction)?;
+        let state =
+            inspect_directory_truth_state(&transaction, DirectoryTruthInspection::BoundedPage)?;
         let SourceDirectoryTruthState::Active {
             generation,
             published_source_revision,
@@ -776,6 +813,67 @@ mod tests {
         assert_eq!(cleanup.deleted_generations, 0);
         assert!(cleanup.more_work);
         assert_eq!(db.get_revision().unwrap(), revision_before_cleanup);
+    }
+
+    #[test]
+    fn small_page_does_not_scan_large_active_generation() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        const PAGE_QUERY_WORK_BUDGET: usize = 2_000;
+
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let entry_count = super::super::SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT * 8;
+        db.begin_source_directory_truth_generation(1, entry_count as u64)
+            .unwrap();
+        for start in (0..entry_count).step_by(super::super::SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT) {
+            let entries = (start..start + super::super::SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT)
+                .map(|index| directory(&format!("large/{index:04}"), &format!("dir-{index}")))
+                .collect::<Vec<_>>();
+            db.stage_source_directory_truth_entries(1, &entries)
+                .unwrap();
+        }
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+        let full_query_work = Arc::new(AtomicUsize::new(0));
+        db.connection.progress_handler(
+            1,
+            Some({
+                let full_query_work = Arc::clone(&full_query_work);
+                move || {
+                    full_query_work.fetch_add(1, Ordering::Relaxed);
+                    false
+                }
+            }),
+        );
+        db.source_directory_truth_state().unwrap();
+        db.connection.progress_handler(0, None::<fn() -> bool>);
+        assert!(
+            full_query_work.load(Ordering::Relaxed) > PAGE_QUERY_WORK_BUDGET,
+            "the full integrity inspection should exceed the bounded page budget"
+        );
+
+        let query_work = Arc::new(AtomicUsize::new(0));
+        db.connection.progress_handler(
+            1,
+            Some({
+                let query_work = Arc::clone(&query_work);
+                move || query_work.fetch_add(1, Ordering::Relaxed) >= PAGE_QUERY_WORK_BUDGET
+            }),
+        );
+        let page_result = db.source_directory_truth_page(None, 1);
+        db.connection.progress_handler(0, None::<fn() -> bool>);
+
+        let page = page_result.expect("a small page must stay within its query-work budget");
+        assert_eq!(page.entries.len(), 1);
+        assert!(page.next_cursor.is_some());
+        assert!(
+            query_work.load(Ordering::Relaxed) < PAGE_QUERY_WORK_BUDGET,
+            "bounded page exceeded query-work budget"
+        );
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -767,6 +767,43 @@ mod tests {
     }
 
     #[test]
+    fn idempotent_finalization_rejects_active_revision_ahead_of_metadata() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        db.begin_source_directory_truth_generation(1, 1).unwrap();
+        db.stage_source_directory_truth_entries(1, &[directory("valid", "dir-valid")])
+            .unwrap();
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+        db.connection
+            .execute(
+                "UPDATE source_directory_generations
+                 SET published_source_revision = 2
+                 WHERE generation = 1",
+                [],
+            )
+            .unwrap();
+
+        let revision_before = db.get_revision().unwrap();
+        let error = db
+            .finalize_source_directory_truth_generation(1, 0)
+            .unwrap_err();
+        assert_eq!(
+            directory_error(error),
+            SourceDirectoryTruthError::RequiresAudit {
+                reason: SourceDirectoryTruthUnavailableReason::Malformed,
+            }
+        );
+        assert_eq!(db.get_revision().unwrap(), revision_before);
+        assert_eq!(
+            db.source_directory_truth_state().unwrap(),
+            SourceDirectoryTruthState::Unavailable {
+                reason: SourceDirectoryTruthUnavailableReason::Malformed,
+            }
+        );
+    }
+
+    #[test]
     fn reopening_source_database_preserves_active_state_and_pages() {
         let root = tempfile::tempdir().unwrap();
         let expected = vec![

--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use rusqlite::{OptionalExtension, Transaction, TransactionBehavior};
 
 use super::schema;
-use super::util::{map_sql_error, normalize_source_index_path, parse_source_index_path_from_db};
+use super::util::{
+    map_sql_error, normalize_source_index_path, parse_canonical_directory_path_from_db,
+};
 use super::{
     SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT, SOURCE_DIRECTORY_TRUTH_CLEANUP_LIMIT,
     SOURCE_DIRECTORY_TRUTH_MAX_IDENTITY_BYTES, SourceDatabase, SourceDbError, SourceDirectoryEntry,
@@ -236,7 +238,7 @@ fn active_page_entry(
     path_encoding: i64,
     directory_identity: String,
 ) -> Result<SourceDirectoryEntry, SourceDbError> {
-    let relative_path = parse_source_index_path_from_db(&raw_path, path_encoding)
+    let relative_path = parse_canonical_directory_path_from_db(&raw_path, path_encoding)
         .map_err(|_| requires_audit(SourceDirectoryTruthUnavailableReason::AuditRequired))?;
     validate_directory_identity(&directory_identity)
         .map_err(|_| requires_audit(SourceDirectoryTruthUnavailableReason::AuditRequired))?;
@@ -701,6 +703,10 @@ mod tests {
                 "encoded slash inside component",
             ),
             ("valid/~wavecrate-escaped~2e2e", "encoded parent"),
+            (
+                "valid/~wavecrate-escaped~616c696173",
+                "escaped ordinary plain path alias",
+            ),
         ] {
             let root = tempfile::tempdir().unwrap();
             let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
@@ -749,6 +755,7 @@ mod tests {
     fn finalization_rejects_corrupt_staging_rows_before_publication() {
         for (path, path_encoding, directory_identity) in [
             ("valid/~wavecrate-escaped~2f", 1, "dir-valid"),
+            ("valid/~wavecrate-escaped~616c696173", 1, "dir-valid"),
             ("valid", 0, "\u{1}"),
         ] {
             let root = tempfile::tempdir().unwrap();

--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -1,0 +1,844 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use rusqlite::{OptionalExtension, Transaction, TransactionBehavior};
+
+use super::schema;
+use super::util::{map_sql_error, normalize_source_index_path, parse_source_index_path_from_db};
+use super::{
+    SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT, SOURCE_DIRECTORY_TRUTH_CLEANUP_LIMIT,
+    SOURCE_DIRECTORY_TRUTH_MAX_IDENTITY_BYTES, SourceDatabase, SourceDbError, SourceDirectoryEntry,
+    SourceDirectoryTruthCleanup, SourceDirectoryTruthCursor, SourceDirectoryTruthError,
+    SourceDirectoryTruthPage, SourceDirectoryTruthPublication, SourceDirectoryTruthState,
+    SourceDirectoryTruthUnavailableReason,
+};
+
+const GENERATION_COLUMNS: [&str; 7] = [
+    "generation",
+    "status",
+    "expected_entry_count",
+    "staged_entry_count",
+    "complete",
+    "published_source_revision",
+    "created_at",
+];
+const ENTRY_COLUMNS: [&str; 4] = ["generation", "path", "path_encoding", "directory_identity"];
+const CLEANUP_ENTRY_LIMIT: usize = SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT;
+
+/// Encode one source-relative directory path using the lossless source-index representation.
+pub(crate) fn encode_directory_path(path: &Path) -> Result<(String, i64), SourceDbError> {
+    normalize_source_index_path(path).map_err(|_| {
+        SourceDirectoryTruthError::InvalidPath {
+            path: path.to_path_buf(),
+        }
+        .into()
+    })
+}
+
+/// Validate the stable identity recorded for one directory.
+pub(crate) fn validate_directory_identity(identity: &str) -> Result<(), SourceDbError> {
+    if identity.trim().is_empty()
+        || identity.len() > SOURCE_DIRECTORY_TRUTH_MAX_IDENTITY_BYTES
+        || identity.chars().any(char::is_control)
+    {
+        return Err(SourceDirectoryTruthError::InvalidDirectoryIdentity.into());
+    }
+    Ok(())
+}
+
+fn directory_truth_schema_available(
+    connection: &rusqlite::Connection,
+) -> Result<bool, SourceDbError> {
+    let generation_columns = schema::table_columns(connection, "source_directory_generations")?;
+    let entry_columns = schema::table_columns(connection, "source_directory_entries")?;
+    Ok(GENERATION_COLUMNS
+        .iter()
+        .all(|column| generation_columns.contains(*column))
+        && ENTRY_COLUMNS
+            .iter()
+            .all(|column| entry_columns.contains(*column)))
+}
+
+fn schema_unavailable() -> SourceDbError {
+    SourceDirectoryTruthError::SchemaUnavailable.into()
+}
+
+fn requires_audit(reason: SourceDirectoryTruthUnavailableReason) -> SourceDbError {
+    SourceDirectoryTruthError::RequiresAudit { reason }.into()
+}
+
+fn source_revision(connection: &rusqlite::Connection) -> Result<u64, SourceDbError> {
+    connection
+        .query_row(
+            "SELECT value FROM metadata WHERE key = 'revision'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(map_sql_error)?
+        .map(|value| value.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+        .transpose()
+        .map(|value| value.unwrap_or_default())
+}
+
+fn inspect_directory_truth_state(
+    connection: &rusqlite::Connection,
+) -> Result<SourceDirectoryTruthState, SourceDbError> {
+    let current_source_revision = source_revision(connection)?;
+    let active_rows = {
+        let mut statement = connection
+            .prepare(
+                "SELECT generation, expected_entry_count, staged_entry_count, complete,
+                        published_source_revision
+                 FROM source_directory_generations
+                 WHERE status = 'active'
+                 ORDER BY generation ASC",
+            )
+            .map_err(map_sql_error)?;
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, Option<i64>>(4)?,
+                ))
+            })
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?
+    };
+    if active_rows.len() > 1 {
+        return Ok(SourceDirectoryTruthState::Unavailable {
+            reason: SourceDirectoryTruthUnavailableReason::Malformed,
+        });
+    }
+
+    let Some((generation, expected, staged, complete, published_revision)) =
+        active_rows.first().copied()
+    else {
+        let inactive_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM source_directory_generations WHERE status = 'inactive'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(map_sql_error)?;
+        if inactive_count != 0 {
+            return Ok(SourceDirectoryTruthState::Unavailable {
+                reason: SourceDirectoryTruthUnavailableReason::Malformed,
+            });
+        }
+        return Ok(SourceDirectoryTruthState::Uninitialized);
+    };
+
+    let Some(published_revision) = published_revision.filter(|revision| *revision > 0) else {
+        return Ok(SourceDirectoryTruthState::Unavailable {
+            reason: SourceDirectoryTruthUnavailableReason::Malformed,
+        });
+    };
+    if generation <= 0
+        || expected < 0
+        || staged < 0
+        || complete != 1
+        || expected != staged
+        || u64::try_from(published_revision).unwrap_or_default() > current_source_revision
+    {
+        return Ok(SourceDirectoryTruthState::Unavailable {
+            reason: SourceDirectoryTruthUnavailableReason::Malformed,
+        });
+    }
+
+    let (entry_count, distinct_paths, distinct_identities): (i64, i64, i64) = connection
+        .query_row(
+            "SELECT COUNT(*), COUNT(DISTINCT path), COUNT(DISTINCT directory_identity)
+             FROM source_directory_entries
+             WHERE generation = ?1",
+            [generation],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .map_err(map_sql_error)?;
+    if entry_count != expected
+        || entry_count != distinct_paths
+        || entry_count != distinct_identities
+    {
+        return Ok(SourceDirectoryTruthState::Unavailable {
+            reason: SourceDirectoryTruthUnavailableReason::Malformed,
+        });
+    }
+
+    Ok(SourceDirectoryTruthState::Active {
+        generation: u64::try_from(generation).map_err(|_| SourceDbError::Unexpected)?,
+        published_source_revision: u64::try_from(published_revision)
+            .map_err(|_| SourceDbError::Unexpected)?,
+    })
+}
+
+fn active_page_entry(
+    raw_path: String,
+    path_encoding: i64,
+    directory_identity: String,
+) -> Result<SourceDirectoryEntry, SourceDbError> {
+    let relative_path = parse_source_index_path_from_db(&raw_path, path_encoding)
+        .map_err(|_| requires_audit(SourceDirectoryTruthUnavailableReason::AuditRequired))?;
+    validate_directory_identity(&directory_identity)
+        .map_err(|_| requires_audit(SourceDirectoryTruthUnavailableReason::AuditRequired))?;
+    Ok(SourceDirectoryEntry {
+        relative_path,
+        directory_identity,
+    })
+}
+
+impl SourceDatabase {
+    /// Start a revision-neutral source-directory generation.
+    pub fn begin_source_directory_truth_generation(
+        &self,
+        generation: u64,
+        expected_entry_count: u64,
+    ) -> Result<(), SourceDbError> {
+        let mut batch = self.write_batch()?;
+        batch.begin_source_directory_truth_generation(generation, expected_entry_count)?;
+        batch.commit_auxiliary_state()
+    }
+
+    /// Stage one bounded batch of validated descendant directories.
+    pub fn stage_source_directory_truth_entries(
+        &self,
+        generation: u64,
+        entries: &[SourceDirectoryEntry],
+    ) -> Result<(), SourceDbError> {
+        let mut batch = self.write_batch()?;
+        batch.stage_source_directory_truth_entries(generation, entries)?;
+        batch.commit_auxiliary_state()
+    }
+
+    /// Atomically publish one complete directory generation at the expected source revision.
+    pub fn finalize_source_directory_truth_generation(
+        &self,
+        generation: u64,
+        expected_source_revision: u64,
+    ) -> Result<SourceDirectoryTruthPublication, SourceDbError> {
+        let batch = self.write_batch()?;
+        batch.finalize_source_directory_truth_generation(generation, expected_source_revision)
+    }
+
+    /// Read the active directory truth without migrating or creating a legacy reader schema.
+    pub fn source_directory_truth_state(&self) -> Result<SourceDirectoryTruthState, SourceDbError> {
+        if !directory_truth_schema_available(&self.connection)? {
+            return Ok(SourceDirectoryTruthState::Unavailable {
+                reason: SourceDirectoryTruthUnavailableReason::SchemaUnavailable,
+            });
+        }
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(map_sql_error)?;
+        let state = inspect_directory_truth_state(&transaction)?;
+        transaction.rollback().map_err(map_sql_error)?;
+        Ok(state)
+    }
+
+    /// Read one bounded, revision-fenced page of the active directory generation.
+    pub fn source_directory_truth_page(
+        &self,
+        after_cursor: Option<&SourceDirectoryTruthCursor>,
+        requested_limit: usize,
+    ) -> Result<SourceDirectoryTruthPage, SourceDbError> {
+        if !directory_truth_schema_available(&self.connection)? {
+            return Ok(SourceDirectoryTruthPage {
+                state: SourceDirectoryTruthState::Unavailable {
+                    reason: SourceDirectoryTruthUnavailableReason::SchemaUnavailable,
+                },
+                entries: Vec::new(),
+                next_cursor: None,
+            });
+        }
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(map_sql_error)?;
+        let state = inspect_directory_truth_state(&transaction)?;
+        let SourceDirectoryTruthState::Active {
+            generation,
+            published_source_revision,
+        } = state
+        else {
+            transaction.rollback().map_err(map_sql_error)?;
+            return Ok(SourceDirectoryTruthPage {
+                state,
+                entries: Vec::new(),
+                next_cursor: None,
+            });
+        };
+
+        if let Some(cursor) = after_cursor
+            && (cursor.generation != generation
+                || cursor.published_source_revision != published_source_revision)
+        {
+            return Err(SourceDirectoryTruthError::StaleCursor.into());
+        }
+
+        let limit = requested_limit.clamp(1, SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT);
+        let fetch_limit = i64::try_from(limit + 1).map_err(|_| SourceDbError::Unexpected)?;
+        let raw_rows: Vec<(String, i64, String)> = if let Some(cursor) = after_cursor {
+            let mut statement = transaction
+                .prepare(
+                    "SELECT path, path_encoding, directory_identity
+                     FROM source_directory_entries
+                     WHERE generation = ?1 AND path > ?2 COLLATE BINARY
+                     ORDER BY path ASC
+                     LIMIT ?3",
+                )
+                .map_err(map_sql_error)?;
+            statement
+                .query_map(
+                    rusqlite::params![generation as i64, cursor.raw_path.as_str(), fetch_limit],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?
+        } else {
+            let mut statement = transaction
+                .prepare(
+                    "SELECT path, path_encoding, directory_identity
+                     FROM source_directory_entries
+                     WHERE generation = ?1
+                     ORDER BY path ASC
+                     LIMIT ?2",
+                )
+                .map_err(map_sql_error)?;
+            statement
+                .query_map(rusqlite::params![generation as i64, fetch_limit], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?
+        };
+        let has_more = raw_rows.len() > limit;
+        let visible_rows = raw_rows.into_iter().take(limit).collect::<Vec<_>>();
+        let mut identities = HashSet::with_capacity(visible_rows.len());
+        let mut entries = Vec::with_capacity(visible_rows.len());
+        for (raw_path, path_encoding, identity) in visible_rows.iter().cloned() {
+            if !identities.insert(identity.clone()) {
+                return Err(requires_audit(
+                    SourceDirectoryTruthUnavailableReason::AuditRequired,
+                ));
+            }
+            entries.push(active_page_entry(raw_path, path_encoding, identity)?);
+        }
+        let next_cursor = has_more
+            .then(|| {
+                visible_rows.last().map(|(raw_path, _, _)| {
+                    SourceDirectoryTruthCursor::from_parts(
+                        generation,
+                        published_source_revision,
+                        raw_path.clone(),
+                    )
+                })
+            })
+            .flatten();
+        transaction.rollback().map_err(map_sql_error)?;
+        Ok(SourceDirectoryTruthPage {
+            state,
+            entries,
+            next_cursor,
+        })
+    }
+
+    /// Remove a bounded number of oldest inactive generations without advancing source revision.
+    pub fn cleanup_source_directory_truth(
+        &self,
+        requested_limit: usize,
+    ) -> Result<SourceDirectoryTruthCleanup, SourceDbError> {
+        if !directory_truth_schema_available(&self.connection)? {
+            return Err(schema_unavailable());
+        }
+        let limit = requested_limit.min(SOURCE_DIRECTORY_TRUTH_CLEANUP_LIMIT);
+        if limit == 0 {
+            return Ok(SourceDirectoryTruthCleanup {
+                deleted_entries: 0,
+                deleted_generations: 0,
+                more_work: self.has_inactive_directory_generations()?,
+            });
+        }
+        let transaction =
+            Transaction::new_unchecked(&self.connection, TransactionBehavior::Immediate)
+                .map_err(map_sql_error)?;
+        let candidates = {
+            let mut statement = transaction
+                .prepare(
+                    "SELECT generation
+                     FROM source_directory_generations
+                     WHERE status = 'inactive'
+                     ORDER BY generation ASC
+                     LIMIT ?1",
+                )
+                .map_err(map_sql_error)?;
+            statement
+                .query_map(
+                    [i64::try_from(limit).map_err(|_| SourceDbError::Unexpected)?],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?
+        };
+        let mut deleted_entries = 0usize;
+        let mut deleted_generations = 0usize;
+        let mut remaining_entry_budget = CLEANUP_ENTRY_LIMIT;
+        for generation in candidates {
+            let count: i64 = transaction
+                .query_row(
+                    "SELECT COUNT(*) FROM source_directory_entries WHERE generation = ?1",
+                    [generation],
+                    |row| row.get(0),
+                )
+                .map_err(map_sql_error)?;
+            let entry_count = usize::try_from(count).map_err(|_| SourceDbError::Unexpected)?;
+            if entry_count == 0 {
+                let deleted = transaction
+                    .execute(
+                        "DELETE FROM source_directory_generations
+                         WHERE generation = ?1 AND status = 'inactive'",
+                        [generation],
+                    )
+                    .map_err(map_sql_error)?;
+                if deleted == 1 {
+                    deleted_generations = deleted_generations.saturating_add(1);
+                }
+                continue;
+            }
+            if remaining_entry_budget == 0 {
+                break;
+            }
+
+            let delete_count = entry_count.min(remaining_entry_budget);
+            let deleted = if delete_count == entry_count {
+                transaction
+                    .execute(
+                        "DELETE FROM source_directory_entries WHERE generation = ?1",
+                        [generation],
+                    )
+                    .map_err(map_sql_error)?
+            } else {
+                transaction
+                    .execute(
+                        "DELETE FROM source_directory_entries
+                         WHERE generation = ?1
+                           AND path IN (
+                               SELECT path
+                               FROM source_directory_entries
+                               WHERE generation = ?1
+                               ORDER BY path ASC
+                               LIMIT ?2
+                           )",
+                        rusqlite::params![
+                            generation,
+                            i64::try_from(delete_count).map_err(|_| SourceDbError::Unexpected)?
+                        ],
+                    )
+                    .map_err(map_sql_error)?
+            };
+            deleted_entries = deleted_entries.saturating_add(deleted);
+            remaining_entry_budget = remaining_entry_budget.saturating_sub(deleted);
+
+            if delete_count == entry_count {
+                let removed_generation = transaction
+                    .execute(
+                        "DELETE FROM source_directory_generations
+                         WHERE generation = ?1 AND status = 'inactive'",
+                        [generation],
+                    )
+                    .map_err(map_sql_error)?;
+                if removed_generation == 1 {
+                    deleted_generations = deleted_generations.saturating_add(1);
+                }
+            }
+            if remaining_entry_budget == 0 {
+                break;
+            }
+        }
+        let more_work = transaction
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM source_directory_generations WHERE status = 'inactive'
+                 )",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(map_sql_error)?
+            != 0;
+        let db_path = self.db_path.clone();
+        let telemetry_label = self.telemetry_label;
+        transaction.commit().map_err(map_sql_error)?;
+        crate::sqlite_wal::maybe_checkpoint_database_file(&db_path, "source_db", telemetry_label);
+        Ok(SourceDirectoryTruthCleanup {
+            deleted_entries,
+            deleted_generations,
+            more_work,
+        })
+    }
+
+    fn has_inactive_directory_generations(&self) -> Result<bool, SourceDbError> {
+        Ok(self
+            .connection
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM source_directory_generations WHERE status = 'inactive'
+                 )",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(map_sql_error)?
+            != 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::super::{
+        SourceDatabase, SourceDbError, SourceDirectoryEntry, SourceDirectoryTruthError,
+        SourceDirectoryTruthState,
+    };
+
+    fn directory(path: &str, identity: &str) -> SourceDirectoryEntry {
+        SourceDirectoryEntry {
+            relative_path: Path::new(path).to_path_buf(),
+            directory_identity: identity.to_owned(),
+        }
+    }
+
+    fn directory_error(error: SourceDbError) -> SourceDirectoryTruthError {
+        match error {
+            SourceDbError::DirectoryTruth(error) => error,
+            other => panic!("expected directory-truth error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stages_and_publishes_directory_truth_once_at_one_revision() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        db.begin_source_directory_truth_generation(1, 2).unwrap();
+        db.stage_source_directory_truth_entries(
+            1,
+            &[
+                directory("drums", "dir-1"),
+                directory("drums/kicks", "dir-2"),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(db.get_revision().unwrap(), 0);
+        assert_eq!(
+            db.source_directory_truth_state().unwrap(),
+            SourceDirectoryTruthState::Uninitialized
+        );
+
+        let publication = db.finalize_source_directory_truth_generation(1, 0).unwrap();
+        assert_eq!(publication.generation, 1);
+        assert_eq!(publication.source_revision, 1);
+        assert!(!publication.idempotent);
+        assert_eq!(db.get_revision().unwrap(), 1);
+
+        let retry = db.finalize_source_directory_truth_generation(1, 0).unwrap();
+        assert!(retry.idempotent);
+        assert_eq!(retry.source_revision, 1);
+        assert_eq!(db.get_revision().unwrap(), 1);
+
+        let first = db.source_directory_truth_page(None, 1).unwrap();
+        assert_eq!(first.entries.len(), 1);
+        assert_eq!(first.entries[0].relative_path, Path::new("drums"));
+        let second = db
+            .source_directory_truth_page(first.next_cursor.as_ref(), 1)
+            .unwrap();
+        assert_eq!(second.entries.len(), 1);
+        assert!(second.next_cursor.is_none());
+    }
+
+    #[test]
+    fn unicode_directory_path_round_trips_through_storage() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let expected = directory("samples/東京/🎛️", "dir-unicode");
+
+        db.begin_source_directory_truth_generation(1, 1).unwrap();
+        db.stage_source_directory_truth_entries(1, std::slice::from_ref(&expected))
+            .unwrap();
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+        let page = db.source_directory_truth_page(None, 1).unwrap();
+        assert_eq!(page.entries, vec![expected]);
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[test]
+    fn reserved_prefix_unicode_directory_path_round_trips_through_storage() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let expected = directory(
+            "~wavecrate-nu~café/~wavecrate-escaped~東京",
+            "dir-reserved-unicode",
+        );
+
+        db.begin_source_directory_truth_generation(1, 1).unwrap();
+        db.stage_source_directory_truth_entries(1, std::slice::from_ref(&expected))
+            .unwrap();
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+        let page = db.source_directory_truth_page(None, 1).unwrap();
+        assert_eq!(page.entries, vec![expected]);
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_non_unicode_directory_path_round_trips_through_storage() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+        use std::path::PathBuf;
+
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let mut path = PathBuf::from("samples");
+        path.push(OsString::from_vec(b"raw-\xFF".to_vec()));
+        let expected = SourceDirectoryEntry {
+            relative_path: path.clone(),
+            directory_identity: "dir-non-unicode".to_owned(),
+        };
+
+        db.begin_source_directory_truth_generation(1, 1).unwrap();
+        db.stage_source_directory_truth_entries(1, std::slice::from_ref(&expected))
+            .unwrap();
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+        let page = db.source_directory_truth_page(None, 1).unwrap();
+        assert_eq!(page.entries.len(), 1);
+        assert_eq!(
+            page.entries[0].directory_identity,
+            expected.directory_identity
+        );
+        assert_eq!(
+            page.entries[0].relative_path.as_os_str().as_bytes(),
+            expected.relative_path.as_os_str().as_bytes()
+        );
+    }
+
+    #[test]
+    fn reopening_source_database_preserves_active_state_and_pages() {
+        let root = tempfile::tempdir().unwrap();
+        let expected = vec![
+            directory("samples/kicks", "dir-kicks"),
+            directory("samples/snare", "dir-snare"),
+        ];
+
+        {
+            let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+            db.begin_source_directory_truth_generation(1, expected.len() as u64)
+                .unwrap();
+            db.stage_source_directory_truth_entries(1, &expected)
+                .unwrap();
+            db.finalize_source_directory_truth_generation(1, 0).unwrap();
+        }
+
+        let reopened = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        assert_eq!(
+            reopened.source_directory_truth_state().unwrap(),
+            SourceDirectoryTruthState::Active {
+                generation: 1,
+                published_source_revision: 1,
+            }
+        );
+        let first = reopened.source_directory_truth_page(None, 1).unwrap();
+        assert_eq!(first.entries, vec![expected[0].clone()]);
+        let second = reopened
+            .source_directory_truth_page(first.next_cursor.as_ref(), 1)
+            .unwrap();
+        assert_eq!(second.entries, vec![expected[1].clone()]);
+        assert!(second.next_cursor.is_none());
+    }
+
+    #[test]
+    fn finalization_flips_active_generation_and_cleanup_is_revision_neutral() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        db.begin_source_directory_truth_generation(1, 1).unwrap();
+        db.stage_source_directory_truth_entries(1, &[directory("one", "dir-1")])
+            .unwrap();
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+        db.begin_source_directory_truth_generation(2, 1).unwrap();
+        db.stage_source_directory_truth_entries(2, &[directory("two", "dir-2")])
+            .unwrap();
+        db.finalize_source_directory_truth_generation(2, 1).unwrap();
+        assert_eq!(db.get_revision().unwrap(), 2);
+        assert_eq!(
+            db.source_directory_truth_state().unwrap(),
+            SourceDirectoryTruthState::Active {
+                generation: 2,
+                published_source_revision: 2,
+            }
+        );
+
+        let cleanup = db.cleanup_source_directory_truth(1).unwrap();
+        assert_eq!(cleanup.deleted_generations, 1);
+        assert_eq!(cleanup.deleted_entries, 1);
+        assert!(!cleanup.more_work);
+        assert_eq!(db.get_revision().unwrap(), 2);
+    }
+
+    #[test]
+    fn cleanup_bounds_large_inactive_generation_without_advancing_revision() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let entry_count = super::CLEANUP_ENTRY_LIMIT + 1;
+        let entries = (0..entry_count)
+            .map(|index| directory(&format!("large/{index:03}"), &format!("dir-{index}")))
+            .collect::<Vec<_>>();
+
+        db.begin_source_directory_truth_generation(1, entry_count as u64)
+            .unwrap();
+        for batch in entries.chunks(super::super::SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT) {
+            db.stage_source_directory_truth_entries(1, batch).unwrap();
+        }
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+        db.begin_source_directory_truth_generation(2, 1).unwrap();
+        db.stage_source_directory_truth_entries(2, &[directory("current", "dir-current")])
+            .unwrap();
+        db.finalize_source_directory_truth_generation(2, 1).unwrap();
+        let revision_before_cleanup = db.get_revision().unwrap();
+
+        let cleanup = db.cleanup_source_directory_truth(1).unwrap();
+        assert_eq!(cleanup.deleted_entries, super::CLEANUP_ENTRY_LIMIT);
+        assert_eq!(cleanup.deleted_generations, 0);
+        assert!(cleanup.more_work);
+        assert_eq!(db.get_revision().unwrap(), revision_before_cleanup);
+    }
+
+    #[test]
+    fn stale_incomplete_duplicate_collision_and_invalid_inputs_fail_closed() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+
+        db.begin_source_directory_truth_generation(1, 2).unwrap();
+        let error = db
+            .stage_source_directory_truth_entries(
+                1,
+                &[directory("same", "dir-1"), directory("same", "dir-2")],
+            )
+            .unwrap_err();
+        assert!(matches!(
+            directory_error(error),
+            SourceDirectoryTruthError::DuplicatePath { .. }
+        ));
+        let error = db
+            .stage_source_directory_truth_entries(
+                1,
+                &[directory("one", "dir-1"), directory("two", "dir-1")],
+            )
+            .unwrap_err();
+        assert!(matches!(
+            directory_error(error),
+            SourceDirectoryTruthError::DuplicateDirectoryIdentity { .. }
+        ));
+        let error = db
+            .stage_source_directory_truth_entries(1, &[directory("../escape", "dir-1")])
+            .unwrap_err();
+        assert!(matches!(
+            directory_error(error),
+            SourceDirectoryTruthError::InvalidPath { .. }
+        ));
+        let error = db
+            .stage_source_directory_truth_entries(1, &[directory("one", " ")])
+            .unwrap_err();
+        assert!(matches!(
+            directory_error(error),
+            SourceDirectoryTruthError::InvalidDirectoryIdentity
+        ));
+
+        let error = db
+            .finalize_source_directory_truth_generation(1, 0)
+            .unwrap_err();
+        assert!(matches!(
+            directory_error(error),
+            SourceDirectoryTruthError::Incomplete { .. }
+        ));
+        let error = db
+            .finalize_source_directory_truth_generation(99, 0)
+            .unwrap_err();
+        assert!(matches!(
+            directory_error(error),
+            SourceDirectoryTruthError::GenerationMissing { .. }
+        ));
+
+        db.stage_source_directory_truth_entries(
+            1,
+            &[directory("one", "dir-1"), directory("two", "dir-2")],
+        )
+        .unwrap();
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+        let error = db.finalize_source_directory_truth_generation(1, 0).unwrap();
+        assert!(error.idempotent);
+
+        db.begin_source_directory_truth_generation(2, 1).unwrap();
+        db.stage_source_directory_truth_entries(2, &[directory("two", "dir-2")])
+            .unwrap();
+        let error = db
+            .finalize_source_directory_truth_generation(2, 0)
+            .unwrap_err();
+        assert!(matches!(
+            directory_error(error),
+            SourceDirectoryTruthError::StaleRevision { .. }
+        ));
+        let error = db
+            .begin_source_directory_truth_generation(1, 1)
+            .unwrap_err();
+        assert!(matches!(
+            directory_error(error),
+            SourceDirectoryTruthError::GenerationCollision { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_directory_truth_schema_is_read_compatible_without_creation() {
+        let root = tempfile::tempdir().unwrap();
+        let db_path = root.path().join(super::super::DB_FILE_NAME);
+        let connection = rusqlite::Connection::open(&db_path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 CREATE TABLE wav_files (
+                     path TEXT PRIMARY KEY, file_size INTEGER NOT NULL, modified_ns INTEGER NOT NULL
+                 );
+                 PRAGMA user_version = 11;",
+            )
+            .unwrap();
+        drop(connection);
+
+        let db = SourceDatabase::open_for_ui_read(root.path()).unwrap();
+        assert_eq!(
+            db.source_directory_truth_state().unwrap(),
+            SourceDirectoryTruthState::Unavailable {
+                reason: super::super::SourceDirectoryTruthUnavailableReason::SchemaUnavailable,
+            }
+        );
+        let page = db.source_directory_truth_page(None, 32).unwrap();
+        assert!(page.entries.is_empty());
+        let table_count: i64 = db
+            .connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type = 'table' AND name LIKE 'source_directory_%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(table_count, 0);
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -184,6 +184,27 @@ fn inspect_directory_truth_state(
     }
 
     if inspection == DirectoryTruthInspection::FullIntegrity {
+        {
+            let mut statement = connection
+                .prepare(
+                    "SELECT path, path_encoding, directory_identity
+                     FROM source_directory_entries
+                     WHERE generation = ?1",
+                )
+                .map_err(map_sql_error)?;
+            let mut rows = statement.query([generation]).map_err(map_sql_error)?;
+            while let Some(row) = rows.next().map_err(map_sql_error)? {
+                let raw_path = row.get::<_, String>(0).map_err(map_sql_error)?;
+                let path_encoding = row.get::<_, i64>(1).map_err(map_sql_error)?;
+                let directory_identity = row.get::<_, String>(2).map_err(map_sql_error)?;
+                if active_page_entry(raw_path, path_encoding, directory_identity).is_err() {
+                    return Ok(SourceDirectoryTruthState::Unavailable {
+                        reason: SourceDirectoryTruthUnavailableReason::AuditRequired,
+                    });
+                }
+            }
+        }
+
         let (entry_count, distinct_paths, distinct_identities): (i64, i64, i64) = connection
             .query_row(
                 "SELECT COUNT(*), COUNT(DISTINCT path), COUNT(DISTINCT directory_identity)
@@ -696,6 +717,13 @@ mod tests {
                     [path],
                 )
                 .unwrap_or_else(|error| panic!("persist {expected_description}: {error}"));
+
+            assert_eq!(
+                db.source_directory_truth_state().unwrap(),
+                SourceDirectoryTruthState::Unavailable {
+                    reason: SourceDirectoryTruthUnavailableReason::AuditRequired,
+                }
+            );
 
             let error = db.source_directory_truth_page(None, 1).unwrap_err();
             assert_eq!(

--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -503,7 +503,7 @@ mod tests {
 
     use super::super::{
         SourceDatabase, SourceDbError, SourceDirectoryEntry, SourceDirectoryTruthError,
-        SourceDirectoryTruthState,
+        SourceDirectoryTruthState, SourceDirectoryTruthUnavailableReason,
     };
 
     fn directory(path: &str, identity: &str) -> SourceDirectoryEntry {
@@ -627,6 +627,63 @@ mod tests {
             page.entries[0].relative_path.as_os_str().as_bytes(),
             expected.relative_path.as_os_str().as_bytes()
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_unicode_literal_backslash_directory_path_round_trips_through_storage() {
+        use std::ffi::OsString;
+        use std::path::PathBuf;
+
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let mut path = PathBuf::from("samples");
+        path.push(OsString::from(r"kick\raw"));
+        let expected = SourceDirectoryEntry {
+            relative_path: path,
+            directory_identity: "dir-unicode-backslash".to_owned(),
+        };
+
+        db.begin_source_directory_truth_generation(1, 1).unwrap();
+        db.stage_source_directory_truth_entries(1, std::slice::from_ref(&expected))
+            .unwrap();
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+        let page = db.source_directory_truth_page(None, 1).unwrap();
+        assert_eq!(page.entries, vec![expected]);
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[test]
+    fn malformed_persisted_lossless_directory_paths_require_audit() {
+        for (path, expected_description) in [
+            ("valid/~wavecrate-escaped~2f", "encoded slash/root"),
+            ("valid/~wavecrate-escaped~2e2e", "encoded parent"),
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+            db.begin_source_directory_truth_generation(1, 1).unwrap();
+            db.stage_source_directory_truth_entries(1, &[directory("valid", "dir-valid")])
+                .unwrap();
+            db.finalize_source_directory_truth_generation(1, 0).unwrap();
+
+            db.connection
+                .execute(
+                    "UPDATE source_directory_entries
+                     SET path = ?1, path_encoding = 1
+                     WHERE generation = 1",
+                    [path],
+                )
+                .unwrap_or_else(|error| panic!("persist {expected_description}: {error}"));
+
+            let error = db.source_directory_truth_page(None, 1).unwrap_err();
+            assert_eq!(
+                directory_error(error),
+                SourceDirectoryTruthError::RequiresAudit {
+                    reason: SourceDirectoryTruthUnavailableReason::AuditRequired,
+                }
+            );
+        }
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -704,6 +704,65 @@ mod tests {
                     reason: SourceDirectoryTruthUnavailableReason::AuditRequired,
                 }
             );
+
+            let error = db
+                .finalize_source_directory_truth_generation(1, 0)
+                .unwrap_err();
+            assert_eq!(
+                directory_error(error),
+                SourceDirectoryTruthError::RequiresAudit {
+                    reason: SourceDirectoryTruthUnavailableReason::AuditRequired,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn finalization_rejects_corrupt_staging_rows_before_publication() {
+        for (path, path_encoding, directory_identity) in [
+            ("valid/~wavecrate-escaped~2f", 1, "dir-valid"),
+            ("valid", 0, "\u{1}"),
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+            db.begin_source_directory_truth_generation(1, 1).unwrap();
+            db.stage_source_directory_truth_entries(1, &[directory("valid", "dir-valid")])
+                .unwrap();
+
+            db.connection
+                .execute(
+                    "UPDATE source_directory_entries
+                     SET path = ?1, path_encoding = ?2, directory_identity = ?3
+                     WHERE generation = 1",
+                    rusqlite::params![path, path_encoding, directory_identity],
+                )
+                .unwrap();
+
+            let error = db
+                .finalize_source_directory_truth_generation(1, 0)
+                .unwrap_err();
+            assert_eq!(
+                directory_error(error),
+                SourceDirectoryTruthError::RequiresAudit {
+                    reason: SourceDirectoryTruthUnavailableReason::AuditRequired,
+                }
+            );
+            assert_eq!(db.get_revision().unwrap(), 0);
+            assert_eq!(
+                db.source_directory_truth_state().unwrap(),
+                SourceDirectoryTruthState::Uninitialized
+            );
+            let active_generation_count: i64 = db
+                .connection
+                .query_row(
+                    "SELECT COUNT(*)
+                     FROM source_directory_generations
+                     WHERE status = 'active'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(active_generation_count, 0);
         }
     }
 

--- a/crates/wavecrate-library/src/sample_sources/db/error.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/error.rs
@@ -2,6 +2,105 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+use super::types::SourceDirectoryTruthUnavailableReason;
+
+/// Typed fail-closed errors from the directory-truth publication contract.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum SourceDirectoryTruthError {
+    /// A generation number is not a valid positive source-local generation.
+    #[error("directory truth generation {generation} is invalid")]
+    InvalidGeneration {
+        /// Invalid generation supplied by the caller.
+        generation: u64,
+    },
+    /// An entry count cannot be represented safely by the source database.
+    #[error("directory truth entry count {count} is invalid")]
+    InvalidEntryCount {
+        /// Invalid entry count supplied by the caller.
+        count: u64,
+    },
+    /// The caller's expected source revision no longer matches the writer transaction.
+    #[error("directory truth expected source revision {expected}, found {actual}")]
+    StaleRevision {
+        /// Revision supplied by the caller.
+        expected: u64,
+        /// Revision observed under the writer lock.
+        actual: u64,
+    },
+    /// The requested generation does not exist.
+    #[error("directory truth generation {generation} does not exist")]
+    GenerationMissing {
+        /// Generation requested by the caller.
+        generation: u64,
+    },
+    /// The staged generation does not contain its declared number of entries.
+    #[error(
+        "directory truth generation {generation} is incomplete: expected {expected}, staged {staged}"
+    )]
+    Incomplete {
+        /// Generation being finalized.
+        generation: u64,
+        /// Declared entry count.
+        expected: u64,
+        /// Persisted entry count.
+        staged: u64,
+    },
+    /// A batch contains the same normalized path more than once.
+    #[error("directory truth path is duplicated: {path}")]
+    DuplicatePath {
+        /// Duplicate normalized path.
+        path: PathBuf,
+    },
+    /// A generation already contains the same path.
+    #[error("directory truth path already exists in the generation: {path}")]
+    ExistingPath {
+        /// Existing normalized path.
+        path: PathBuf,
+    },
+    /// A batch or generation contains the same stable directory identity more than once.
+    #[error("directory truth directory identity is duplicated: {identity}")]
+    DuplicateDirectoryIdentity {
+        /// Duplicate stable identity.
+        identity: String,
+    },
+    /// A requested generation collides with a generation in another lifecycle state.
+    #[error("directory truth generation {generation} has already been published or retired")]
+    GenerationCollision {
+        /// Colliding generation.
+        generation: u64,
+    },
+    /// A batch would exceed the generation's declared entry count.
+    #[error("directory truth generation {generation} would exceed its declared entry count")]
+    EntryCountExceeded {
+        /// Generation receiving the batch.
+        generation: u64,
+    },
+    /// A batch exceeds the bounded staging limit.
+    #[error("directory truth staging batch exceeds the bounded limit")]
+    BatchTooLarge,
+    /// A path or identity cannot be persisted without losing its meaning.
+    #[error("directory truth entry is invalid: {path}")]
+    InvalidPath {
+        /// Invalid path supplied by the caller.
+        path: PathBuf,
+    },
+    /// A directory identity is empty or contains unsupported control data.
+    #[error("directory truth directory identity is invalid")]
+    InvalidDirectoryIdentity,
+    /// The database shape is not safe to write.
+    #[error("directory truth schema is unavailable or malformed")]
+    SchemaUnavailable,
+    /// A read cursor belongs to a different active generation or revision.
+    #[error("directory truth cursor is stale")]
+    StaleCursor,
+    /// Persisted directory state requires an audit before mutation.
+    #[error("directory truth requires an audit: {reason:?}")]
+    RequiresAudit {
+        /// Fail-closed reason.
+        reason: SourceDirectoryTruthUnavailableReason,
+    },
+}
+
 /// Errors returned when managing a source database.
 #[derive(Debug, Error)]
 pub enum SourceDbError {
@@ -37,6 +136,9 @@ pub enum SourceDbError {
     /// SQLite returned an unexpected result.
     #[error("SQLite returned an unexpected result")]
     Unexpected,
+    /// Directory-truth storage rejected a stale, malformed, or conflicting operation.
+    #[error(transparent)]
+    DirectoryTruth(#[from] SourceDirectoryTruthError),
     /// Provided tag text cannot be normalized to a non-empty identity.
     #[error("Tag label cannot be empty")]
     EmptyTagLabel,

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use super::source_entry::SourceTraversalPolicy;
 
 mod content_audit;
+mod directories;
 mod error;
 /// Persistent file operation journal for crash recovery.
 pub mod file_ops_journal;
@@ -45,7 +46,7 @@ pub use content_audit::{
     ContentAuditCheckpoint, ContentAuditEntryState, ContentAuditForwardCandidate,
     ContentAuditReport, ContentAuditRetryCandidate, ContentAuditSkipReason,
 };
-pub use error::SourceDbError;
+pub use error::{SourceDbError, SourceDirectoryTruthError};
 pub(crate) use open::SourceDatabaseOpenMode;
 #[cfg(test)]
 pub(crate) use open::open_source_database;
@@ -59,9 +60,12 @@ pub use pending_renames::{PendingRenameDiagnostics, PendingRenameEntry, PendingR
 pub use rename_metadata::RenameMetadataSnapshot;
 pub use types::{
     BrowserFileMetadata, BrowserMetadataCursor, BrowserMetadataPage, BrowserMetadataSnapshot,
-    ExistingFileMetadataUpdate, Rating, SampleCollection, SampleSoundType,
-    SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot,
-    SourceManifestEntry, SourceTag, SourceTagUsage, WavEntry,
+    ExistingFileMetadataUpdate, Rating, SampleCollection, SampleSoundType, SourceDirectoryEntry,
+    SourceDirectoryTruthCleanup, SourceDirectoryTruthCursor, SourceDirectoryTruthPage,
+    SourceDirectoryTruthPublication, SourceDirectoryTruthState,
+    SourceDirectoryTruthUnavailableReason, SourceIndexClassification, SourceIndexDiagnostic,
+    SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage,
+    WavEntry,
 };
 pub use util::normalize_relative_path;
 pub use write::{
@@ -97,6 +101,12 @@ pub const META_READINESS_DUPLICATE_IDENTITY: &str = "readiness_duplicate_identit
 pub const META_SOURCE_INDEX_REVISION: &str = "source_index_revision_v1";
 /// Metadata key for the persisted source traversal/visibility policy.
 pub const META_SOURCE_TRAVERSAL_POLICY: &str = "source_traversal_policy_v1";
+/// Maximum number of directory entries accepted by one staging batch or read page.
+pub const SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT: usize = 256;
+/// Maximum number of inactive directory generations removed by one cleanup transaction.
+pub const SOURCE_DIRECTORY_TRUTH_CLEANUP_LIMIT: usize = 8;
+/// Maximum encoded length of one persisted stable directory identity.
+pub const SOURCE_DIRECTORY_TRUTH_MAX_IDENTITY_BYTES: usize = 1024;
 /// Env var that enables read-only source DB opening by default.
 pub const SOURCE_DB_READ_ONLY_ENV: &str = "WAVECRATE_SOURCE_DB_READ_ONLY";
 

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -347,7 +347,36 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         path TEXT PRIMARY KEY,
         scan_generation INTEGER NOT NULL,
         retained_hash TEXT
-    );";
+    );
+    CREATE TABLE IF NOT EXISTS source_directory_generations (
+        generation INTEGER PRIMARY KEY CHECK(generation > 0),
+        status TEXT NOT NULL CHECK(status IN ('staging', 'active', 'inactive')),
+        expected_entry_count INTEGER NOT NULL CHECK(expected_entry_count >= 0),
+        staged_entry_count INTEGER NOT NULL DEFAULT 0
+            CHECK(staged_entry_count >= 0 AND staged_entry_count <= expected_entry_count),
+        complete INTEGER NOT NULL DEFAULT 0 CHECK(complete IN (0, 1)),
+        published_source_revision INTEGER
+            CHECK(published_source_revision IS NULL OR published_source_revision > 0),
+        created_at INTEGER NOT NULL DEFAULT 0,
+        CHECK (
+            (status = 'staging' AND published_source_revision IS NULL)
+            OR (status IN ('active', 'inactive') AND published_source_revision IS NOT NULL)
+        ),
+        CHECK(
+            status = 'staging'
+            OR (complete = 1 AND staged_entry_count = expected_entry_count)
+        )
+    );
+    CREATE TABLE IF NOT EXISTS source_directory_entries (
+        generation INTEGER NOT NULL,
+        path TEXT NOT NULL CHECK(length(path) > 0),
+        path_encoding INTEGER NOT NULL DEFAULT 0 CHECK(path_encoding IN (0, 1)),
+        directory_identity TEXT NOT NULL CHECK(length(trim(directory_identity)) > 0),
+        PRIMARY KEY (generation, path),
+        UNIQUE (generation, directory_identity),
+        FOREIGN KEY(generation) REFERENCES source_directory_generations(generation)
+            ON DELETE CASCADE
+    ) WITHOUT ROWID;";
 
 const INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_wav_files_missing
          ON wav_files(path) WHERE missing != 0;
@@ -397,7 +426,12 @@ const INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_wav_files_missing
      CREATE INDEX IF NOT EXISTS idx_source_readiness_artifacts_generation
          ON source_readiness_artifacts (source_id, source_generation, stage);
      CREATE INDEX IF NOT EXISTS idx_file_ops_journal_stage
-         ON file_ops_journal (stage);";
+         ON file_ops_journal (stage);
+     CREATE UNIQUE INDEX IF NOT EXISTS idx_source_directory_generations_active
+         ON source_directory_generations(status)
+         WHERE status = 'active';
+     CREATE INDEX IF NOT EXISTS idx_source_directory_generations_status_generation
+         ON source_directory_generations(status, generation);";
 
 /// Create all base tables used by the source database.
 pub(super) fn apply_base_schema(connection: &Connection) -> Result<(), SourceDbError> {

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
@@ -57,6 +57,71 @@ fn apply_structural_migrations(connection: &Connection) -> Result<(), SourceDbEr
     ensure_collection_membership_schema(connection)?;
     ensure_pending_rename_destination_schema(connection)?;
     ensure_aspect_descriptor_tables(connection)?;
+    ensure_directory_truth_schema(connection)?;
+    Ok(())
+}
+
+fn ensure_directory_truth_schema(connection: &Connection) -> Result<(), SourceDbError> {
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS source_directory_generations (
+                generation INTEGER PRIMARY KEY CHECK(generation > 0),
+                status TEXT NOT NULL CHECK(status IN ('staging', 'active', 'inactive')),
+                expected_entry_count INTEGER NOT NULL CHECK(expected_entry_count >= 0),
+                staged_entry_count INTEGER NOT NULL DEFAULT 0
+                    CHECK(staged_entry_count >= 0 AND staged_entry_count <= expected_entry_count),
+                complete INTEGER NOT NULL DEFAULT 0 CHECK(complete IN (0, 1)),
+                published_source_revision INTEGER
+                    CHECK(published_source_revision IS NULL OR published_source_revision > 0),
+                created_at INTEGER NOT NULL DEFAULT 0,
+                CHECK (
+                    (status = 'staging' AND published_source_revision IS NULL)
+                    OR (status IN ('active', 'inactive') AND published_source_revision IS NOT NULL)
+                ),
+                CHECK(
+                    status = 'staging'
+                    OR (complete = 1 AND staged_entry_count = expected_entry_count)
+                )
+            );
+            CREATE TABLE IF NOT EXISTS source_directory_entries (
+                generation INTEGER NOT NULL,
+                path TEXT NOT NULL CHECK(length(path) > 0),
+                path_encoding INTEGER NOT NULL DEFAULT 0 CHECK(path_encoding IN (0, 1)),
+                directory_identity TEXT NOT NULL CHECK(length(trim(directory_identity)) > 0),
+                PRIMARY KEY (generation, path),
+                UNIQUE (generation, directory_identity),
+                FOREIGN KEY(generation) REFERENCES source_directory_generations(generation)
+                    ON DELETE CASCADE
+            ) WITHOUT ROWID;
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_source_directory_generations_active
+                ON source_directory_generations(status)
+                WHERE status = 'active';
+            CREATE INDEX IF NOT EXISTS idx_source_directory_generations_status_generation
+                ON source_directory_generations(status, generation);",
+        )
+        .map_err(map_sql_error)?;
+
+    let generation_columns = table_columns(connection, "source_directory_generations")?;
+    let entry_columns = table_columns(connection, "source_directory_entries")?;
+    let generation_required = [
+        "generation",
+        "status",
+        "expected_entry_count",
+        "staged_entry_count",
+        "complete",
+        "published_source_revision",
+        "created_at",
+    ];
+    let entry_required = ["generation", "path", "path_encoding", "directory_identity"];
+    if generation_required
+        .iter()
+        .any(|column| !generation_columns.contains(*column))
+        || entry_required
+            .iter()
+            .any(|column| !entry_columns.contains(*column))
+    {
+        return Err(SourceDbError::Unexpected);
+    }
     Ok(())
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/schema/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use migrations::table_columns;
 /// A matching stamp means the file has already passed the full schema-assurance
 /// path once. Current-stamped opens still run low-cost additive table/column
 /// repairs, but they skip index rebuilds and deferred cleanup work.
-pub(super) const SOURCE_DB_SCHEMA_VERSION: i64 = 11;
+pub(super) const SOURCE_DB_SCHEMA_VERSION: i64 = 12;
 
 /// Apply the full source-database schema, including deferred cleanup work.
 pub(super) fn apply_schema(connection: &Connection) -> Result<SchemaApplyOutcome, SourceDbError> {

--- a/crates/wavecrate-library/src/sample_sources/db/types.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/types.rs
@@ -447,6 +447,130 @@ pub struct SourceIndexSnapshot {
     pub entries: Vec<SourceIndexEntry>,
 }
 
+/// One directory observed relative to a source root.
+///
+/// The source root itself is implicit and is therefore never represented by an entry. The path
+/// can use the same lossless storage encoding as index-only source paths, including raw Unix
+/// names that are not valid Unicode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceDirectoryEntry {
+    /// Directory path relative to the source root.
+    pub relative_path: PathBuf,
+    /// Stable filesystem identity for the directory.
+    pub directory_identity: String,
+}
+
+/// Why persisted directory truth cannot currently be trusted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SourceDirectoryTruthUnavailableReason {
+    /// The additive directory-truth schema is absent from a read-only database.
+    SchemaUnavailable,
+    /// The persisted generation metadata is structurally inconsistent.
+    Malformed,
+    /// A stored path or identity requires an audit before it can be exposed.
+    AuditRequired,
+}
+
+/// Coherent source-directory state published by the source database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SourceDirectoryTruthState {
+    /// No directory generation has ever been published.
+    Uninitialized,
+    /// One complete directory generation is active at this source revision.
+    Active {
+        /// Stable source-local generation number.
+        generation: u64,
+        /// Generic source revision assigned by the publication transaction.
+        published_source_revision: u64,
+    },
+    /// Directory truth exists but is not safe to expose.
+    Unavailable {
+        /// Reason the state failed closed.
+        reason: SourceDirectoryTruthUnavailableReason,
+    },
+}
+
+impl SourceDirectoryTruthState {
+    /// Return the active generation, if one is published and trusted.
+    pub fn active_generation(self) -> Option<u64> {
+        match self {
+            Self::Active { generation, .. } => Some(generation),
+            Self::Uninitialized | Self::Unavailable { .. } => None,
+        }
+    }
+
+    /// Return the exact source revision at which the active generation was published.
+    pub fn published_source_revision(self) -> Option<u64> {
+        match self {
+            Self::Active {
+                published_source_revision,
+                ..
+            } => Some(published_source_revision),
+            Self::Uninitialized | Self::Unavailable { .. } => None,
+        }
+    }
+}
+
+/// Opaque keyset cursor for bounded directory-truth reads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceDirectoryTruthCursor {
+    pub(crate) generation: u64,
+    pub(crate) published_source_revision: u64,
+    pub(crate) raw_path: String,
+}
+
+impl SourceDirectoryTruthCursor {
+    pub(crate) fn from_parts(
+        generation: u64,
+        published_source_revision: u64,
+        raw_path: String,
+    ) -> Self {
+        Self {
+            generation,
+            published_source_revision,
+            raw_path,
+        }
+    }
+
+    /// Borrow the exact encoded SQLite path key represented by this cursor.
+    pub fn as_str(&self) -> &str {
+        &self.raw_path
+    }
+}
+
+/// One bounded page of the active directory-truth generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceDirectoryTruthPage {
+    /// Directory-truth state observed by the page.
+    pub state: SourceDirectoryTruthState,
+    /// Entries in deterministic encoded-path order.
+    pub entries: Vec<SourceDirectoryEntry>,
+    /// Cursor for the next bounded page, if more entries remain.
+    pub next_cursor: Option<SourceDirectoryTruthCursor>,
+}
+
+/// Result of a directory-generation publication attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceDirectoryTruthPublication {
+    /// Generation made active by this publication.
+    pub generation: u64,
+    /// Generic source revision assigned to the active generation.
+    pub source_revision: u64,
+    /// True when this call observed the same generation already published.
+    pub idempotent: bool,
+}
+
+/// Bounded result from deleting inactive directory generations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceDirectoryTruthCleanup {
+    /// Number of entry rows deleted by the cleanup transaction.
+    pub deleted_entries: usize,
+    /// Number of inactive generation rows deleted by the cleanup transaction.
+    pub deleted_generations: usize,
+    /// Whether another bounded cleanup pass is needed.
+    pub more_work: bool,
+}
+
 /// One normal library tag stored in a source database.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SourceTag {

--- a/crates/wavecrate-library/src/sample_sources/db/util.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/util.rs
@@ -138,6 +138,22 @@ pub(super) fn parse_source_index_path_from_db(
     }
 }
 
+/// Parse a directory path and require its stored key to be the canonical encoding.
+///
+/// The generic source-index decoder remains compatible with every valid lossless spelling. Directory
+/// truth rows need a stronger invariant because their encoded path is also their durable identity.
+pub(super) fn parse_canonical_directory_path_from_db(
+    path: &str,
+    encoding: i64,
+) -> Result<PathBuf, SourceDbError> {
+    let decoded = parse_source_index_path_from_db(path, encoding)?;
+    let (canonical_path, canonical_encoding) = normalize_source_index_path(&decoded)?;
+    if canonical_path != path || canonical_encoding != encoding {
+        return Err(SourceDbError::InvalidRelativePath(PathBuf::from(path)));
+    }
+    Ok(decoded)
+}
+
 #[cfg(unix)]
 fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
     if path.is_empty() {
@@ -426,6 +442,47 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(error, SourceDbError::InvalidRelativePath(_)));
+    }
+
+    #[test]
+    fn canonical_directory_path_rejects_noncanonical_aliases() {
+        let escaped_alias = "valid/~wavecrate-escaped~616c696173";
+        assert_eq!(
+            parse_source_index_path_from_db(escaped_alias, INDEX_PATH_ENCODING_LOSSLESS).unwrap(),
+            Path::new("valid/alias")
+        );
+        assert!(
+            parse_canonical_directory_path_from_db(escaped_alias, INDEX_PATH_ENCODING_LOSSLESS)
+                .is_err()
+        );
+
+        let reserved_prefix_plain = "valid/~wavecrate-escaped~616c696173";
+        assert_eq!(
+            parse_source_index_path_from_db(reserved_prefix_plain, INDEX_PATH_ENCODING_PLAIN)
+                .unwrap(),
+            Path::new(reserved_prefix_plain)
+        );
+        assert!(
+            parse_canonical_directory_path_from_db(
+                reserved_prefix_plain,
+                INDEX_PATH_ENCODING_PLAIN
+            )
+            .is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_directory_path_rejects_noncanonical_hex_case() {
+        let uppercase_hex = "valid/~wavecrate-escaped~6B69636B5C726177";
+        assert_eq!(
+            parse_source_index_path_from_db(uppercase_hex, INDEX_PATH_ENCODING_LOSSLESS).unwrap(),
+            Path::new(r"valid/kick\raw")
+        );
+        assert!(
+            parse_canonical_directory_path_from_db(uppercase_hex, INDEX_PATH_ENCODING_LOSSLESS)
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/util.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/util.rs
@@ -1,4 +1,3 @@
-#[cfg(unix)]
 use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
 
@@ -149,19 +148,19 @@ fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
         if component.is_empty() {
             return Err(SourceDbError::InvalidRelativePath(PathBuf::from(path)));
         }
-        let value = if let Some(hex) = component.strip_prefix(INDEX_NON_UNICODE_COMPONENT_PREFIX) {
-            OsString::from_vec(
+        if let Some(hex) = component.strip_prefix(INDEX_NON_UNICODE_COMPONENT_PREFIX) {
+            let value = OsString::from_vec(
                 decode_hex(hex)
                     .ok_or_else(|| SourceDbError::InvalidRelativePath(PathBuf::from(path)))?,
-            )
+            );
+            append_lossless_decoded_component(&mut decoded, value, path)?;
         } else if let Some(hex) = component.strip_prefix(INDEX_ESCAPED_COMPONENT_PREFIX) {
             let bytes = decode_hex(hex)
                 .ok_or_else(|| SourceDbError::InvalidRelativePath(PathBuf::from(path)))?;
-            OsString::from_vec(bytes)
+            append_lossless_decoded_component(&mut decoded, OsString::from_vec(bytes), path)?;
         } else {
-            OsString::from(component)
-        };
-        decoded.push(value);
+            decoded.push(component);
+        }
     }
     sanitize_relative_path(&decoded)
 }
@@ -178,7 +177,7 @@ fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
                 .ok_or_else(|| SourceDbError::InvalidRelativePath(PathBuf::from(path)))?;
             let value = String::from_utf8(bytes)
                 .map_err(|_| SourceDbError::InvalidRelativePath(PathBuf::from(path)))?;
-            decoded.push(value);
+            append_lossless_decoded_component(&mut decoded, OsString::from(value), path)?;
         } else {
             // A non-Unicode source key can only be authored on Unix. Preserve
             // that component's encoded projection on platforms that cannot
@@ -187,6 +186,31 @@ fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
         }
     }
     sanitize_relative_path(&decoded)
+}
+
+fn append_lossless_decoded_component(
+    decoded: &mut PathBuf,
+    value: OsString,
+    encoded_path: &str,
+) -> Result<(), SourceDbError> {
+    #[cfg(unix)]
+    let contains_separator = value.as_os_str().as_bytes().contains(&b'/');
+    #[cfg(not(unix))]
+    let contains_separator = value
+        .to_string_lossy()
+        .chars()
+        .any(|character| matches!(character, '/' | '\\'));
+    let mut components = Path::new(&value).components();
+    if contains_separator
+        || !matches!(components.next(), Some(Component::Normal(_)))
+        || components.next().is_some()
+    {
+        return Err(SourceDbError::InvalidRelativePath(PathBuf::from(
+            encoded_path,
+        )));
+    }
+    decoded.push(value);
+    Ok(())
 }
 
 fn encode_hex(bytes: &[u8]) -> String {
@@ -392,6 +416,16 @@ mod tests {
             parse_source_index_path_from_db(&raw_key, raw_encoding).unwrap(),
             raw
         );
+    }
+
+    #[test]
+    fn lossless_path_rejects_encoded_separator_inside_component() {
+        let error = parse_source_index_path_from_db(
+            "valid/~wavecrate-escaped~612f62",
+            INDEX_PATH_ENCODING_LOSSLESS,
+        )
+        .unwrap_err();
+        assert!(matches!(error, SourceDbError::InvalidRelativePath(_)));
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/util.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/util.rs
@@ -78,7 +78,16 @@ pub(super) fn normalize_source_index_path(path: &Path) -> Result<(String, i64), 
                 || value.starts_with(INDEX_ESCAPED_COMPONENT_PREFIX)
         })
     });
-    if cleaned.to_str().is_some() && !has_reserved_component {
+    if cleaned.to_str().is_some()
+        && !has_reserved_component
+        && !cleaned.components().any(|component| {
+            let Component::Normal(part) = component else {
+                return false;
+            };
+            part.to_str()
+                .is_some_and(|value| cfg!(unix) && value.contains('\\'))
+        })
+    {
         return normalize_relative_path(&cleaned).map(|value| (value, INDEX_PATH_ENCODING_PLAIN));
     }
 
@@ -90,7 +99,8 @@ pub(super) fn normalize_source_index_path(path: &Path) -> Result<(String, i64), 
         let encoded = match part.to_str() {
             Some(value)
                 if !value.starts_with(INDEX_NON_UNICODE_COMPONENT_PREFIX)
-                    && !value.starts_with(INDEX_ESCAPED_COMPONENT_PREFIX) =>
+                    && !value.starts_with(INDEX_ESCAPED_COMPONENT_PREFIX)
+                    && !(cfg!(unix) && value.contains('\\')) =>
             {
                 value.to_owned()
             }
@@ -153,7 +163,7 @@ fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
         };
         decoded.push(value);
     }
-    Ok(decoded)
+    sanitize_relative_path(&decoded)
 }
 
 #[cfg(not(unix))]
@@ -176,7 +186,7 @@ fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
             decoded.push(component);
         }
     }
-    Ok(decoded)
+    sanitize_relative_path(&decoded)
 }
 
 fn encode_hex(bytes: &[u8]) -> String {
@@ -343,6 +353,22 @@ mod tests {
         ]);
         let (encoded, encoding) = normalize_source_index_path(&path).unwrap();
         assert_eq!(encoding, INDEX_PATH_ENCODING_LOSSLESS);
+        assert_eq!(
+            parse_source_index_path_from_db(&encoded, encoding).unwrap(),
+            path
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_index_path_encoding_round_trips_unicode_literal_backslashes() {
+        let path = PathBuf::from_iter([
+            std::ffi::OsString::from("folder"),
+            std::ffi::OsString::from(r"kick\raw.wav"),
+        ]);
+        let (encoded, encoding) = normalize_source_index_path(&path).unwrap();
+        assert_eq!(encoding, INDEX_PATH_ENCODING_LOSSLESS);
+        assert!(encoded.contains(INDEX_ESCAPED_COMPONENT_PREFIX));
         assert_eq!(
             parse_source_index_path_from_db(&encoded, encoding).unwrap(),
             path

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -118,19 +118,6 @@ impl SourceWriteBatch<'_> {
         if staged_entry_count > expected_entry_count {
             return Err(SourceDirectoryTruthError::EntryCountExceeded { generation }.into());
         }
-        let actual_entry_count = self
-            .tx
-            .query_row(
-                "SELECT COUNT(*)
-                 FROM source_directory_entries
-                 WHERE generation = ?1",
-                [generation_sql],
-                |row| row.get::<_, i64>(0),
-            )
-            .map_err(map_sql_error)?;
-        if actual_entry_count != staged_entry_count {
-            return Err(directory_requires_audit());
-        }
 
         let mut encoded_paths = HashSet::with_capacity(entries.len());
         let mut identities = HashSet::with_capacity(entries.len());

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -249,6 +249,10 @@ impl SourceWriteBatch<'_> {
         if status == "active" {
             validate_generation_entries(&self.tx, generation_sql)?;
             let published_revision = valid_published_revision(published_revision)?;
+            let current_source_revision = manifest_revision(&self.tx)?;
+            if published_revision > current_source_revision {
+                return Err(directory_requires_audit());
+            }
             validate_generation_counts(
                 &self.tx,
                 generation_sql,

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::OptionalExtension;
 
-use super::super::util::{map_sql_error, normalize_relative_path};
+use super::super::util::{map_sql_error, normalize_relative_path, parse_source_index_path_from_db};
 use super::super::{
     META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError, SourceDirectoryEntry,
     SourceDirectoryTruthError, SourceDirectoryTruthPublication, SourceIndexEntry,
@@ -247,6 +247,7 @@ impl SourceWriteBatch<'_> {
         };
 
         if status == "active" {
+            validate_generation_entries(&self.tx, generation_sql)?;
             let published_revision = valid_published_revision(published_revision)?;
             validate_generation_counts(
                 &self.tx,
@@ -277,6 +278,7 @@ impl SourceWriteBatch<'_> {
             }
             .into());
         }
+        validate_generation_entries(&self.tx, generation_sql)?;
         validate_generation_counts(
             &self.tx,
             generation_sql,
@@ -662,11 +664,48 @@ fn directory_requires_audit() -> SourceDbError {
     .into()
 }
 
+fn directory_entry_requires_audit() -> SourceDbError {
+    SourceDirectoryTruthError::RequiresAudit {
+        reason: super::super::SourceDirectoryTruthUnavailableReason::AuditRequired,
+    }
+    .into()
+}
+
 fn valid_published_revision(value: Option<i64>) -> Result<u64, SourceDbError> {
     let Some(value) = value.filter(|value| *value > 0) else {
         return Err(directory_requires_audit());
     };
     u64::try_from(value).map_err(|_| directory_requires_audit())
+}
+
+fn validate_generation_entries(
+    connection: &rusqlite::Transaction<'_>,
+    generation: i64,
+) -> Result<(), SourceDbError> {
+    let mut statement = connection
+        .prepare(
+            "SELECT path, path_encoding, directory_identity
+             FROM source_directory_entries
+             WHERE generation = ?1",
+        )
+        .map_err(map_sql_error)?;
+    let mut rows = statement.query([generation]).map_err(map_sql_error)?;
+    while let Some(row) = rows.next().map_err(map_sql_error)? {
+        let path = row
+            .get::<_, String>(0)
+            .map_err(|_| directory_entry_requires_audit())?;
+        let path_encoding = row
+            .get::<_, i64>(1)
+            .map_err(|_| directory_entry_requires_audit())?;
+        let directory_identity = row
+            .get::<_, String>(2)
+            .map_err(|_| directory_entry_requires_audit())?;
+        parse_source_index_path_from_db(&path, path_encoding)
+            .map_err(|_| directory_entry_requires_audit())?;
+        super::super::directories::validate_directory_identity(&directory_identity)
+            .map_err(|_| directory_entry_requires_audit())?;
+    }
+    Ok(())
 }
 
 fn validate_generation_counts(

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -4,7 +4,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::OptionalExtension;
 
-use super::super::util::{map_sql_error, normalize_relative_path, parse_source_index_path_from_db};
+use super::super::util::{
+    map_sql_error, normalize_relative_path, parse_canonical_directory_path_from_db,
+};
 use super::super::{
     META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError, SourceDirectoryEntry,
     SourceDirectoryTruthError, SourceDirectoryTruthPublication, SourceIndexEntry,
@@ -704,7 +706,7 @@ fn validate_generation_entries(
         let directory_identity = row
             .get::<_, String>(2)
             .map_err(|_| directory_entry_requires_audit())?;
-        parse_source_index_path_from_db(&path, path_encoding)
+        parse_canonical_directory_path_from_db(&path, path_encoding)
             .map_err(|_| directory_entry_requires_audit())?;
         super::super::directories::validate_directory_identity(&directory_identity)
             .map_err(|_| directory_entry_requires_audit())?;

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -1,10 +1,13 @@
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::OptionalExtension;
 
 use super::super::util::{map_sql_error, normalize_relative_path};
 use super::super::{
-    META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError, SourceIndexEntry,
+    META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError, SourceDirectoryEntry,
+    SourceDirectoryTruthError, SourceDirectoryTruthPublication, SourceIndexEntry,
     SourceManifestEntry, SourceTraversalPolicy, SourceWriteBatch,
 };
 use crate::sample_sources::reconciliation::{RootIdentity, SourceAuditCommit, SourceAuditRequest};
@@ -34,6 +37,355 @@ pub struct SourceIndexCommitResult {
 }
 
 impl SourceWriteBatch<'_> {
+    pub(crate) fn begin_source_directory_truth_generation(
+        &mut self,
+        generation: u64,
+        expected_entry_count: u64,
+    ) -> Result<(), SourceDbError> {
+        let generation = directory_generation_sql_value(generation)?;
+        let expected_entry_count = directory_entry_count_sql_value(expected_entry_count)?;
+        let existing = self
+            .tx
+            .query_row(
+                "SELECT status, expected_entry_count
+                 FROM source_directory_generations
+                 WHERE generation = ?1",
+                [generation],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()
+            .map_err(map_sql_error)?;
+
+        if let Some((status, existing_expected)) = existing {
+            if status == "staging" && existing_expected == expected_entry_count {
+                return Ok(());
+            }
+            return Err(SourceDirectoryTruthError::GenerationCollision {
+                generation: u64::try_from(generation).unwrap_or_default(),
+            }
+            .into());
+        }
+
+        let complete = i64::from(expected_entry_count == 0);
+        self.tx
+            .execute(
+                "INSERT INTO source_directory_generations (
+                    generation, status, expected_entry_count, staged_entry_count, complete,
+                    published_source_revision, created_at
+                 ) VALUES (?1, 'staging', ?2, 0, ?3, NULL, ?4)",
+                rusqlite::params![generation, expected_entry_count, complete, unix_timestamp()],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+
+    pub(crate) fn stage_source_directory_truth_entries(
+        &mut self,
+        generation: u64,
+        entries: &[SourceDirectoryEntry],
+    ) -> Result<(), SourceDbError> {
+        if entries.len() > super::super::SOURCE_DIRECTORY_TRUTH_BATCH_LIMIT {
+            return Err(SourceDirectoryTruthError::BatchTooLarge.into());
+        }
+        let generation_sql = directory_generation_sql_value(generation)?;
+        let Some((status, expected_entry_count, staged_entry_count, complete)) = self
+            .tx
+            .query_row(
+                "SELECT status, expected_entry_count, staged_entry_count, complete
+                 FROM source_directory_generations
+                 WHERE generation = ?1",
+                [generation_sql],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(map_sql_error)?
+        else {
+            return Err(SourceDirectoryTruthError::GenerationMissing { generation }.into());
+        };
+        if status != "staging" {
+            return Err(SourceDirectoryTruthError::GenerationCollision { generation }.into());
+        }
+        if expected_entry_count < 0 || staged_entry_count < 0 || complete < 0 {
+            return Err(directory_requires_audit());
+        }
+        if staged_entry_count > expected_entry_count {
+            return Err(SourceDirectoryTruthError::EntryCountExceeded { generation }.into());
+        }
+        let actual_entry_count = self
+            .tx
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM source_directory_entries
+                 WHERE generation = ?1",
+                [generation_sql],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(map_sql_error)?;
+        if actual_entry_count != staged_entry_count {
+            return Err(directory_requires_audit());
+        }
+
+        let mut encoded_paths = HashSet::with_capacity(entries.len());
+        let mut identities = HashSet::with_capacity(entries.len());
+        let mut encoded_entries = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let (path, path_encoding) =
+                super::super::directories::encode_directory_path(&entry.relative_path)?;
+            super::super::directories::validate_directory_identity(&entry.directory_identity)?;
+            if !encoded_paths.insert(path.clone()) {
+                return Err(SourceDirectoryTruthError::DuplicatePath {
+                    path: entry.relative_path.clone(),
+                }
+                .into());
+            }
+            if !identities.insert(entry.directory_identity.clone()) {
+                return Err(SourceDirectoryTruthError::DuplicateDirectoryIdentity {
+                    identity: entry.directory_identity.clone(),
+                }
+                .into());
+            }
+            encoded_entries.push((path, path_encoding, entry.directory_identity.clone()));
+        }
+
+        let incoming_count = i64::try_from(encoded_entries.len()).map_err(|_| {
+            SourceDirectoryTruthError::InvalidEntryCount {
+                count: encoded_entries.len() as u64,
+            }
+        })?;
+        let new_staged_entry_count = staged_entry_count.checked_add(incoming_count).ok_or(
+            SourceDirectoryTruthError::InvalidEntryCount {
+                count: u64::try_from(staged_entry_count).unwrap_or_default(),
+            },
+        )?;
+        if new_staged_entry_count > expected_entry_count {
+            return Err(SourceDirectoryTruthError::EntryCountExceeded { generation }.into());
+        }
+
+        for (path, path_encoding, identity) in encoded_entries {
+            if self
+                .tx
+                .query_row(
+                    "SELECT 1
+                     FROM source_directory_entries
+                     WHERE generation = ?1 AND path = ?2 COLLATE BINARY",
+                    rusqlite::params![generation_sql, path],
+                    |_| Ok(()),
+                )
+                .optional()
+                .map_err(map_sql_error)?
+                .is_some()
+            {
+                return Err(SourceDirectoryTruthError::ExistingPath {
+                    path: PathBuf::from(path),
+                }
+                .into());
+            }
+            if self
+                .tx
+                .query_row(
+                    "SELECT 1
+                     FROM source_directory_entries
+                     WHERE generation = ?1 AND directory_identity = ?2",
+                    rusqlite::params![generation_sql, identity],
+                    |_| Ok(()),
+                )
+                .optional()
+                .map_err(map_sql_error)?
+                .is_some()
+            {
+                return Err(
+                    SourceDirectoryTruthError::DuplicateDirectoryIdentity { identity }.into(),
+                );
+            }
+            self.tx
+                .execute(
+                    "INSERT INTO source_directory_entries (
+                        generation, path, path_encoding, directory_identity
+                     ) VALUES (?1, ?2, ?3, ?4)",
+                    rusqlite::params![generation_sql, path, path_encoding, identity],
+                )
+                .map_err(map_sql_error)?;
+        }
+
+        self.tx
+            .execute(
+                "UPDATE source_directory_generations
+                 SET staged_entry_count = ?1, complete = ?2
+                 WHERE generation = ?3 AND status = 'staging'",
+                rusqlite::params![
+                    new_staged_entry_count,
+                    i64::from(new_staged_entry_count == expected_entry_count),
+                    generation_sql
+                ],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+
+    pub(crate) fn finalize_source_directory_truth_generation(
+        self,
+        generation: u64,
+        expected_source_revision: u64,
+    ) -> Result<SourceDirectoryTruthPublication, SourceDbError> {
+        let generation_sql = directory_generation_sql_value(generation)?;
+        let Some((status, expected_entry_count, staged_entry_count, complete, published_revision)) =
+            self.tx
+                .query_row(
+                    "SELECT status, expected_entry_count, staged_entry_count, complete,
+                            published_source_revision
+                     FROM source_directory_generations
+                     WHERE generation = ?1",
+                    [generation_sql],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, i64>(3)?,
+                            row.get::<_, Option<i64>>(4)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(map_sql_error)?
+        else {
+            return Err(SourceDirectoryTruthError::GenerationMissing { generation }.into());
+        };
+
+        if status == "active" {
+            let published_revision = valid_published_revision(published_revision)?;
+            validate_generation_counts(
+                &self.tx,
+                generation_sql,
+                expected_entry_count,
+                staged_entry_count,
+                complete,
+            )?;
+            let db_path = self.db_path.clone();
+            let telemetry_label = self.telemetry_label;
+            self.tx.commit().map_err(map_sql_error)?;
+            checkpoint_source_database(&db_path, telemetry_label);
+            return Ok(SourceDirectoryTruthPublication {
+                generation,
+                source_revision: published_revision,
+                idempotent: true,
+            });
+        }
+        if status != "staging" {
+            return Err(SourceDirectoryTruthError::GenerationCollision { generation }.into());
+        }
+
+        let actual_source_revision = manifest_revision(&self.tx)?;
+        if actual_source_revision != expected_source_revision {
+            return Err(SourceDirectoryTruthError::StaleRevision {
+                expected: expected_source_revision,
+                actual: actual_source_revision,
+            }
+            .into());
+        }
+        validate_generation_counts(
+            &self.tx,
+            generation_sql,
+            expected_entry_count,
+            staged_entry_count,
+            complete,
+        )?;
+        let active_generations: Vec<(i64, i64, i64, i64, Option<i64>)> = {
+            let mut statement = self
+                .tx
+                .prepare(
+                    "SELECT generation, expected_entry_count, staged_entry_count, complete,
+                            published_source_revision
+                     FROM source_directory_generations
+                     WHERE status = 'active'",
+                )
+                .map_err(map_sql_error)?;
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Option<i64>>(4)?,
+                    ))
+                })
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?
+        };
+        if active_generations.len() > 1 {
+            return Err(directory_requires_audit());
+        }
+        if let Some((
+            active_generation,
+            active_expected_entry_count,
+            active_staged_entry_count,
+            active_complete,
+            published_revision,
+        )) = active_generations.first().copied()
+        {
+            if valid_published_revision(published_revision).is_err() {
+                return Err(directory_requires_audit());
+            }
+            validate_generation_counts(
+                &self.tx,
+                active_generation,
+                active_expected_entry_count,
+                active_staged_entry_count,
+                active_complete,
+            )?;
+            if active_generation == generation_sql {
+                return Err(directory_requires_audit());
+            }
+        }
+
+        let next_source_revision = expected_source_revision
+            .checked_add(1)
+            .ok_or(SourceDbError::Unexpected)?;
+        SourceDatabase::bump_revision(&self.tx)?;
+        let committed_source_revision = manifest_revision(&self.tx)?;
+        if committed_source_revision != next_source_revision {
+            return Err(SourceDbError::Unexpected);
+        }
+        self.tx
+            .execute(
+                "UPDATE source_directory_generations
+                 SET status = 'inactive'
+                 WHERE status = 'active'",
+                [],
+            )
+            .map_err(map_sql_error)?;
+        let changed = self
+            .tx
+            .execute(
+                "UPDATE source_directory_generations
+                 SET status = 'active', complete = 1, published_source_revision = ?1
+                 WHERE generation = ?2 AND status = 'staging'",
+                rusqlite::params![committed_source_revision as i64, generation_sql],
+            )
+            .map_err(map_sql_error)?;
+        if changed != 1 {
+            return Err(SourceDirectoryTruthError::GenerationMissing { generation }.into());
+        }
+        let db_path = self.db_path.clone();
+        let telemetry_label = self.telemetry_label;
+        self.tx.commit().map_err(map_sql_error)?;
+        checkpoint_source_database(&db_path, telemetry_label);
+        Ok(SourceDirectoryTruthPublication {
+            generation,
+            source_revision: committed_source_revision,
+            idempotent: false,
+        })
+    }
+
     /// Read a metadata value from the active write transaction.
     ///
     /// The value is read from the same snapshot and writer reservation that will commit the
@@ -295,6 +647,91 @@ impl SourceWriteBatch<'_> {
         }
         Ok(())
     }
+}
+
+fn directory_generation_sql_value(generation: u64) -> Result<i64, SourceDbError> {
+    if generation == 0 {
+        return Err(SourceDirectoryTruthError::InvalidGeneration { generation }.into());
+    }
+    i64::try_from(generation)
+        .map_err(|_| SourceDirectoryTruthError::InvalidGeneration { generation }.into())
+}
+
+fn directory_entry_count_sql_value(count: u64) -> Result<i64, SourceDbError> {
+    i64::try_from(count).map_err(|_| SourceDirectoryTruthError::InvalidEntryCount { count }.into())
+}
+
+fn unix_timestamp() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
+        .unwrap_or_default()
+}
+
+fn directory_requires_audit() -> SourceDbError {
+    SourceDirectoryTruthError::RequiresAudit {
+        reason: super::super::SourceDirectoryTruthUnavailableReason::Malformed,
+    }
+    .into()
+}
+
+fn valid_published_revision(value: Option<i64>) -> Result<u64, SourceDbError> {
+    let Some(value) = value.filter(|value| *value > 0) else {
+        return Err(directory_requires_audit());
+    };
+    u64::try_from(value).map_err(|_| directory_requires_audit())
+}
+
+fn validate_generation_counts(
+    connection: &rusqlite::Transaction<'_>,
+    generation: i64,
+    expected_entry_count: i64,
+    staged_entry_count: i64,
+    complete: i64,
+) -> Result<(), SourceDbError> {
+    if expected_entry_count < 0 || staged_entry_count < 0 || complete < 0 {
+        return Err(directory_requires_audit());
+    }
+    let actual_entry_count = connection
+        .query_row(
+            "SELECT COUNT(*), COUNT(DISTINCT path), COUNT(DISTINCT directory_identity)
+             FROM source_directory_entries
+             WHERE generation = ?1",
+            [generation],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .map_err(map_sql_error)?;
+    if actual_entry_count.0 != actual_entry_count.1 || actual_entry_count.0 != actual_entry_count.2
+    {
+        return Err(directory_requires_audit());
+    }
+    if complete != 1 || expected_entry_count != staged_entry_count {
+        return Err(SourceDirectoryTruthError::Incomplete {
+            generation: u64::try_from(generation).unwrap_or_default(),
+            expected: u64::try_from(expected_entry_count).unwrap_or_default(),
+            staged: u64::try_from(actual_entry_count.0).unwrap_or_default(),
+        }
+        .into());
+    }
+    if actual_entry_count.0 != staged_entry_count {
+        return Err(SourceDirectoryTruthError::Incomplete {
+            generation: u64::try_from(generation).unwrap_or_default(),
+            expected: u64::try_from(expected_entry_count).unwrap_or_default(),
+            staged: u64::try_from(actual_entry_count.0).unwrap_or_default(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+fn checkpoint_source_database(db_path: &Path, telemetry_label: &'static str) {
+    crate::sqlite_wal::maybe_checkpoint_database_file(db_path, "source_db", telemetry_label);
 }
 
 fn manifest_snapshot(

--- a/tests/unit/source_db_migration_tests/contract.rs
+++ b/tests/unit/source_db_migration_tests/contract.rs
@@ -102,6 +102,37 @@ fn current_stamped_source_database_repairs_schema_contract() {
     assert_eq!(analysis_job_count(&db.connection), 1);
 }
 
+#[test]
+fn v11_source_database_adds_directory_truth_without_losing_existing_rows() {
+    let dir = with_legacy_db(
+        "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+         INSERT INTO metadata (key, value) VALUES ('revision', '7');
+         CREATE TABLE wav_files (
+             path TEXT PRIMARY KEY,
+             file_size INTEGER NOT NULL,
+             modified_ns INTEGER NOT NULL
+         );
+         INSERT INTO wav_files (path, file_size, modified_ns)
+         VALUES ('legacy/one.wav', 42, 99);
+         PRAGMA user_version = 11;",
+    );
+
+    let db = SourceDatabase::open_for_test_fixture_source_write(dir.path()).unwrap();
+
+    assert_eq!(
+        schema_version(&db.connection),
+        schema::SOURCE_DB_SCHEMA_VERSION
+    );
+    assert_source_db_schema_contract(&db.connection);
+    assert_eq!(db.get_revision().unwrap(), 7);
+    assert_eq!(
+        db.entry_for_path(std::path::Path::new("legacy/one.wav"))
+            .unwrap()
+            .map(|entry| (entry.file_size, entry.modified_ns)),
+        Some((42, 99))
+    );
+}
+
 fn schema_version(connection: &rusqlite::Connection) -> i64 {
     connection
         .query_row("PRAGMA user_version", [], |row| row.get(0))

--- a/tests/unit/source_db_migration_tests/fixtures.rs
+++ b/tests/unit/source_db_migration_tests/fixtures.rs
@@ -46,6 +46,22 @@ pub(super) const SOURCE_DB_SCHEMA_CONTRACT: &[TableContract] = &[
         ],
     },
     TableContract {
+        name: "source_directory_generations",
+        columns: &[
+            "generation",
+            "status",
+            "expected_entry_count",
+            "staged_entry_count",
+            "complete",
+            "published_source_revision",
+            "created_at",
+        ],
+    },
+    TableContract {
+        name: "source_directory_entries",
+        columns: &["generation", "path", "path_encoding", "directory_identity"],
+    },
+    TableContract {
         name: "source_tags",
         columns: &["id", "normalized_text", "display_label"],
     },


### PR DESCRIPTION
## Goal

Add the next dependency-correct Wavecrate I/O slice: durable source-directory truth storage that can later be populated by scanner-owned publication without exposing incomplete generations.

## Scope

- Additive source schema v12 for staged, active, and inactive directory generations plus lossless relative directory entries.
- Typed source-directory state, bounded staging, keyset reads, bounded inactive-generation cleanup, and fail-closed validation.
- Finalize a complete generation inside the existing source writer transaction, checking the expected source revision and advancing the generic source revision exactly once.
- Same-generation finalization is idempotent; stale, missing, incomplete, duplicate, collision, invalid, malformed, and audit-required states do not publish.
- Validate every persisted staging row before publication without materializing the generation; corrupt paths or identities fail closed and do not advance revision.
- Preserve literal-backslash, Unicode, reserved-prefix, and Unix non-Unicode relative paths without loss; reject malformed lossless keys before exposure.
- Directory truth requires each stored `(path, path_encoding)` pair to exactly match the canonical encoder after decoding, preventing alternate spellings from aliasing a valid path.
- Normal paginated reads validate only bounded metadata and selected rows; full integrity scans remain on explicit state/publication/audit paths.
- Update base DDL, legacy/current-stamp migration repair, schema contract coverage, and read-only legacy compatibility.

## Non-goals

- Scanner traversal or full/targeted directory publication integration.
- BrowserProjectionDelta, readiness, watcher, GUI, coordinator, journal, or filesystem-operation integration.
- Empty-folder user-visible behavior.

## Definition of Done

- Fresh and current-stamped databases expose the additive schema; v11 writable fixtures migrate without losing existing manifest rows.
- UI/background read-only opens do not create or migrate the directory schema on legacy databases and return typed unavailable state.
- Staging and cleanup query work are bounded; incomplete or corrupt generations remain unpublished; active-generation reads are revision-fenced and bounded.
- Final publication validates persisted rows, flips generations atomically, and advances source revision once; cleanup is revision-neutral.
- Valid Unicode, reserved-prefix, literal-backslash, and Unix non-Unicode relative paths round-trip without loss.
- Malformed decoded lossless paths, non-canonical stored directory keys, and inconsistent active revision metadata fail closed as audit-required instead of being reported successfully.
- Large-generation progress-budget regressions guard staging, page reads, and cleanup against full-generation scans.

## Validation

- `cargo test -p wavecrate-library sample_sources::db::directories::tests` — 16 passed.
- `cargo test -p wavecrate-library sample_sources::db::util::tests` — 15 passed.
- `cargo test -p wavecrate-library source_index_path_encoding` — 4 passed.
- `cargo test -p wavecrate-library source_db_migration_tests` — 15 passed.
- `cargo test -p wavecrate-library sample_sources::db::read` — 23 passed.
- `cargo test -p wavecrate-library sample_sources::library` — 23 passed.
- `cargo check -p wavecrate-library` — passed.
- `bash scripts/ci.sh smoke` — passed.
- Touched-file Rust 2024 formatting check and `git diff --check` — passed.

## Known limitations

- This PR intentionally stops at storage; scanner-owned full/targeted directory publication and downstream projection are subsequent slices.
- `bash scripts/ci.sh agent` currently fails at the pre-existing `native_app_ui_update_paths_do_not_call_blocking_business_apis` guardrail in `tests/gui_boundary.rs`, reporting existing violations in native-app source diagnostics, journal, transaction-history, and recovery files outside this diff. No changed file is named by that failure.
- No native Finder acceptance is claimed for this storage-only slice.

Merge requires explicit user approval. For this task, the user's approval is conditional on Terra providing its own terminal `APPROVE` verdict on the current exact head.

