### PR TITLE
Preserve typed reconciliation scopes through refresh

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/mod.rs
@@ -32,7 +32,7 @@ pub use model::{
 };
 pub use normalize::{
     NormalizationReason, NormalizedObservation, ReconciliationScope, ReconciliationScopeKind,
-    normalize_observation,
+    coalesce_scopes, normalize_observation,
 };
 pub use owner::{
     AdmissionOwnerError, OwnedAdmissionLane, OwnerReplayAdmission, ReconciliationAdmissionOwner,

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/normalize.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/normalize.rs
@@ -168,6 +168,48 @@ pub fn normalize_observation(envelope: RawObservationEnvelope) -> NormalizedObse
     NormalizedObservation { envelope, scopes }
 }
 
+/// Coalesce normalized scopes without narrowing their evidence.
+///
+/// A source audit dominates every path scope. A subtree dominates an exact entry at
+/// the same path and covers descendant scopes. The first retained scope keeps its
+/// diagnostic reason and role; no filesystem or database state is consulted.
+pub fn coalesce_scopes(
+    scopes: impl IntoIterator<Item = ReconciliationScope>,
+) -> Vec<ReconciliationScope> {
+    let mut coalesced: Vec<ReconciliationScope> = Vec::new();
+    for scope in scopes {
+        if scope.kind() == ReconciliationScopeKind::SourceAudit {
+            return vec![scope];
+        }
+        let Some(path) = scope.path() else {
+            return vec![ReconciliationScope::source_audit(
+                NormalizationReason::MissingPath,
+            )];
+        };
+        let covered_by_existing = coalesced.iter().any(|existing: &ReconciliationScope| {
+            let Some(existing_path) = existing.path() else {
+                return false;
+            };
+            let same_path = existing_path.as_path() == path.as_path();
+            let covered_by_subtree = existing.kind() == ReconciliationScopeKind::Subtree
+                && path.as_path().starts_with(existing_path.as_path());
+            same_path && existing.kind() >= scope.kind() || covered_by_subtree
+        });
+        if covered_by_existing {
+            continue;
+        }
+        coalesced.retain(|existing: &ReconciliationScope| {
+            !(scope.kind() == ReconciliationScopeKind::Subtree
+                && existing.path().is_some_and(|existing_path| {
+                    existing_path.as_path() == path.as_path()
+                        || existing_path.as_path().starts_with(path.as_path())
+                }))
+        });
+        coalesced.push(scope);
+    }
+    coalesced
+}
+
 fn normalize_record(observation: &RawObservation, scopes: &mut Vec<ReconciliationScope>) {
     match observation.kind() {
         RawEventKind::Create | RawEventKind::Modify => {

--- a/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/reconciliation/tests.rs
@@ -394,6 +394,69 @@ fn create_modify_directory_empty_folder_symlink_and_duplicates_keep_order() {
 }
 
 #[test]
+fn coalesce_scopes_keeps_exact_entries_non_recursive_and_widens_subtrees() {
+    let exact_entries = normalized(vec![
+        RawObservation::new(
+            RawEventKind::Modify,
+            vec![path("folder", RawPathRole::Subject)],
+        ),
+        RawObservation::new(
+            RawEventKind::Modify,
+            vec![path("folder/child.wav", RawPathRole::Subject)],
+        ),
+    ]);
+    let exact_scopes = coalesce_scopes(exact_entries.scopes().iter().cloned());
+    assert_eq!(exact_scopes.len(), 2);
+    assert_eq!(exact_scopes[0].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&exact_scopes[0]), Some(Path::new("folder")));
+    assert_eq!(exact_scopes[1].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(
+        scope_path(&exact_scopes[1]),
+        Some(Path::new("folder/child.wav"))
+    );
+
+    let normalized = normalized(vec![
+        RawObservation::new(
+            RawEventKind::Create,
+            vec![path("folder", RawPathRole::Subject).with_hint(RawPathHint::Directory)],
+        ),
+        RawObservation::new(
+            RawEventKind::Modify,
+            vec![path("folder/sibling.wav", RawPathRole::Subject)],
+        ),
+        RawObservation::new(
+            RawEventKind::Modify,
+            vec![path("other.wav", RawPathRole::Subject)],
+        ),
+    ]);
+
+    let scopes = coalesce_scopes(normalized.scopes().iter().cloned());
+
+    assert_eq!(scopes.len(), 2);
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(scope_path(&scopes[0]), Some(Path::new("folder")));
+    assert_eq!(scopes[1].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scope_path(&scopes[1]), Some(Path::new("other.wav")));
+}
+
+#[test]
+fn coalesce_scopes_routes_source_audit_as_widest_scope() {
+    let normalized = normalized(vec![
+        RawObservation::new(
+            RawEventKind::Modify,
+            vec![path("folder/file.wav", RawPathRole::Subject)],
+        ),
+        RawObservation::new(RawEventKind::RootChanged, Vec::new()),
+    ]);
+
+    let scopes = coalesce_scopes(normalized.scopes().iter().cloned());
+
+    assert_eq!(scopes.len(), 1);
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::SourceAudit);
+    assert!(scopes[0].path().is_none());
+}
+
+#[test]
 fn delete_root_and_missing_parent_evidence_widens_conservatively() {
     let result = normalized(vec![
         RawObservation::new(

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -9,6 +9,7 @@ use wavecrate::sample_sources::{
 };
 use wavecrate::selection::SelectionRange;
 use wavecrate_analysis::aspects::SimilarityAspect;
+use wavecrate_library::sample_sources::reconciliation::ReconciliationScope;
 
 use crate::native_app::app::ExtractedFilePlaybackType;
 use crate::native_app::app::OperationJournalRestoreCompletion;
@@ -87,9 +88,17 @@ pub(in crate::native_app) enum GuiMessage {
     SelectedFolderVerifyFinished(ui::TaskCompletion<FolderVerifyResult>),
     SourceFilesystemChanged {
         source_id: String,
+        /// `Some` is the authoritative normalized scope transport. An empty vector is scope loss;
+        /// it must not fall back to the compatibility paths below.
+        scopes: Option<Vec<ReconciliationScope>>,
+        /// Retained only for legacy watcher messages where `scopes` is `None`.
         paths: Vec<PathBuf>,
         overflowed: bool,
         source_root_available: bool,
+        /// Root identity authority carried by a typed replay handoff.
+        source_root_identity: Option<String>,
+        /// Source-processing lifecycle authority, when the producer has one.
+        lifecycle_generation: Option<u64>,
         /// A durable FSEvents cursor that may advance only after this targeted sync commits.
         journal_checkpoint_event_id: Option<u64>,
         /// Backend evidence for a targeted replay cursor. Legacy cursor-only messages remain
@@ -470,6 +479,31 @@ pub(in crate::native_app) enum BrowserScrollSurface {
     MetadataTags,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum SourceFilesystemSyncAuditReason {
+    ScopeLost,
+    SourceAuditScope,
+    RootIdentityUncertain,
+    LifecycleStale,
+    Cancelled,
+    TypedScopeDispatchUnavailable,
+    WorkerPanic,
+}
+
+impl SourceFilesystemSyncAuditReason {
+    pub(in crate::native_app) const fn label(self) -> &'static str {
+        match self {
+            Self::ScopeLost => "reconciliation_scope_lost",
+            Self::SourceAuditScope => "reconciliation_source_audit_scope",
+            Self::RootIdentityUncertain => "targeted_sync_root_identity_uncertain",
+            Self::LifecycleStale => "targeted_sync_stale_lifecycle",
+            Self::Cancelled => "targeted_sync_cancelled",
+            Self::TypedScopeDispatchUnavailable => "typed_scope_dispatch_unavailable",
+            Self::WorkerPanic => "targeted_sync_worker_panic",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(in crate::native_app) struct SourceFilesystemSyncResult {
     pub(in crate::native_app) source_id: String,
@@ -480,6 +514,7 @@ pub(in crate::native_app) struct SourceFilesystemSyncResult {
     pub(in crate::native_app) journal_checkpoint_event_id: Option<u64>,
     pub(in crate::native_app) watcher_continuity_proof: Option<WatcherContinuityProof>,
     pub(in crate::native_app) cancelled: bool,
+    pub(in crate::native_app) audit_required: Option<SourceFilesystemSyncAuditReason>,
     pub(in crate::native_app) result: Result<SourceFilesystemSyncSuccess, String>,
 }
 

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -97,7 +97,10 @@ pub(in crate::native_app) enum GuiMessage {
         source_root_available: bool,
         /// Root identity authority carried by a typed replay handoff.
         source_root_identity: Option<String>,
-        /// Source-processing lifecycle authority, when the producer has one.
+        /// Producer-supplied current source-processing lifecycle authority. Typed replay may
+        /// intentionally carry `None` until current-token transport exists; consumers must not
+        /// substitute the GUI's current generation for `scopes: Some(_)`. Path-only legacy
+        /// messages may use `None` for the compatibility fallback.
         lifecycle_generation: Option<u64>,
         /// A durable FSEvents cursor that may advance only after this targeted sync commits.
         journal_checkpoint_event_id: Option<u64>,

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -20,8 +20,9 @@ pub(in crate::native_app) use loading::{
 };
 pub(in crate::native_app) use message::{
     AudioOutputPersistResult, BrowserProjectionDelta, BrowserScrollSurface, GuiMessage,
-    MetadataMessage, SettingsMessage, SimilaritySettingsPersistResult, SourceFilesystemSyncResult,
-    SourceFilesystemSyncSuccess, TrashMoveTarget, VolumeSettingsPersistResult,
+    MetadataMessage, SettingsMessage, SimilaritySettingsPersistResult,
+    SourceFilesystemSyncAuditReason, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess,
+    TrashMoveTarget, VolumeSettingsPersistResult,
 };
 pub(in crate::native_app) use progress::{
     FileMoveProgress, NormalizationFailure, NormalizationHarvestDerivation, NormalizationProgress,

--- a/src/native_app/app/state/library.rs
+++ b/src/native_app/app/state/library.rs
@@ -173,6 +173,33 @@ impl LibraryAppState {
         )
     }
 
+    pub(in crate::native_app) fn plan_filesystem_change_with_scopes(
+        &mut self,
+        source_id: String,
+        scopes: Option<&[wavecrate_library::sample_sources::reconciliation::ReconciliationScope]>,
+        paths: &[std::path::PathBuf],
+        overflowed: bool,
+        source_root_available: bool,
+        source_root_identity: Option<String>,
+        lifecycle_generation: Option<u64>,
+        journal_checkpoint_event_id: Option<u64>,
+        watcher_continuity_proof: Option<WatcherContinuityProof>,
+    ) -> SourceFilesystemChangePlan {
+        self.source_scan
+            .plan_filesystem_change_with_scopes_for_generation(
+                &mut self.folder_browser,
+                source_id,
+                scopes,
+                paths,
+                overflowed,
+                source_root_available,
+                source_root_identity,
+                lifecycle_generation,
+                journal_checkpoint_event_id,
+                watcher_continuity_proof,
+            )
+    }
+
     pub(in crate::native_app) fn next_pending_source_refresh_if_idle(
         &mut self,
     ) -> Option<PendingSourceRefresh> {

--- a/src/native_app/app/state/source_refresh.rs
+++ b/src/native_app/app/state/source_refresh.rs
@@ -1,5 +1,7 @@
 use std::{collections::BTreeSet, path::PathBuf, time::Instant};
 
+use wavecrate_library::sample_sources::reconciliation::ReconciliationScope;
+
 use crate::native_app::sample_library::source_watcher::WatcherContinuityProof;
 
 pub(super) struct QueuedSourceRefresh {
@@ -13,7 +15,11 @@ pub(super) struct QueuedSourceRefresh {
 
 pub(super) struct QueuedTargetedSourceSync {
     pub(super) source_id: String,
+    /// `Some` is the typed scope lane. Its paths are never reconstructed from the legacy set.
+    pub(super) scopes: Option<Vec<ReconciliationScope>>,
+    /// Compatibility-only paths, valid only while `scopes` is `None`.
     pub(super) paths: BTreeSet<PathBuf>,
+    pub(super) source_root_identity: Option<String>,
     pub(super) lifecycle_generation: Option<u64>,
     pub(super) journal_checkpoint_event_id: Option<u64>,
     pub(super) watcher_continuity_proof: Option<WatcherContinuityProof>,
@@ -92,7 +98,9 @@ pub(in crate::native_app) struct PendingSourceRefresh {
 
 pub(in crate::native_app) struct PendingTargetedSourceSync {
     pub(in crate::native_app) source_id: String,
+    pub(in crate::native_app) scopes: Option<Vec<ReconciliationScope>>,
     pub(in crate::native_app) paths: Vec<PathBuf>,
+    pub(in crate::native_app) source_root_identity: Option<String>,
     pub(in crate::native_app) lifecycle_generation: Option<u64>,
     pub(in crate::native_app) journal_checkpoint_event_id: Option<u64>,
     pub(in crate::native_app) watcher_continuity_proof: Option<WatcherContinuityProof>,

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -20,6 +20,12 @@ use crate::native_app::sample_library::source_watcher::{
     WatcherContinuityProof, watcher_replay_evidence_is_well_formed,
 };
 use wavecrate::sample_sources::scanner::CommittedSourceDelta;
+use wavecrate_library::sample_sources::reconciliation::{
+    ReconciliationScope, ReconciliationScopeKind, coalesce_scopes,
+};
+
+const MAX_TYPED_SCOPE_COUNT: usize = 4096;
+const MAX_TYPED_SCOPE_PATH_BYTES: usize = 256 * 1024;
 
 #[cfg(test)]
 #[path = "source_scan_workflow/tests.rs"]
@@ -42,6 +48,19 @@ pub(in crate::native_app) enum SourceFilesystemChangePlan {
     SyncPaths {
         source_id: String,
         changed_count: usize,
+    },
+    SyncScopes {
+        source_id: String,
+        scopes: Vec<ReconciliationScope>,
+        changed_count: usize,
+        source_root_identity: Option<String>,
+        lifecycle_generation: Option<u64>,
+        journal_checkpoint_event_id: Option<u64>,
+        watcher_continuity_proof: Option<WatcherContinuityProof>,
+    },
+    SourceAuditRequired {
+        source_id: String,
+        reason: &'static str,
     },
     DeferredAlreadyRunning {
         source_id: String,
@@ -385,6 +404,33 @@ impl SourceScanWorkflow {
         journal_checkpoint_event_id: Option<u64>,
         watcher_continuity_proof: Option<WatcherContinuityProof>,
     ) -> SourceFilesystemChangePlan {
+        self.plan_filesystem_change_with_scopes_for_generation(
+            browser,
+            source_id,
+            None,
+            paths,
+            overflowed,
+            source_root_available,
+            None,
+            lifecycle_generation,
+            journal_checkpoint_event_id,
+            watcher_continuity_proof,
+        )
+    }
+
+    pub(in crate::native_app) fn plan_filesystem_change_with_scopes_for_generation(
+        &mut self,
+        browser: &mut FolderBrowserState,
+        source_id: String,
+        scopes: Option<&[ReconciliationScope]>,
+        paths: &[PathBuf],
+        overflowed: bool,
+        source_root_available: bool,
+        source_root_identity: Option<String>,
+        lifecycle_generation: Option<u64>,
+        journal_checkpoint_event_id: Option<u64>,
+        watcher_continuity_proof: Option<WatcherContinuityProof>,
+    ) -> SourceFilesystemChangePlan {
         let Some(source_missing) =
             browser.apply_observed_source_availability(&source_id, source_root_available)
         else {
@@ -396,6 +442,94 @@ impl SourceScanWorkflow {
             self.remove_pending_refresh(&source_id);
             self.remove_targeted_sync(&source_id);
             return SourceFilesystemChangePlan::IgnoredSourceMissing { source_id };
+        }
+        if let Some(scopes) = scopes {
+            let scopes = coalesce_scopes(scopes.iter().cloned());
+            if scopes.is_empty() {
+                return SourceFilesystemChangePlan::SourceAuditRequired {
+                    source_id,
+                    reason: "reconciliation_scope_lost",
+                };
+            }
+            if scopes
+                .iter()
+                .any(|scope| scope.kind() == ReconciliationScopeKind::SourceAudit)
+            {
+                return SourceFilesystemChangePlan::SourceAuditRequired {
+                    source_id,
+                    reason: "reconciliation_source_audit_scope",
+                };
+            }
+            let scope_path_bytes = scopes
+                .iter()
+                .filter_map(|scope| scope.path())
+                .map(|path| path.as_path().to_string_lossy().len())
+                .sum::<usize>();
+            if scopes.len() > MAX_TYPED_SCOPE_COUNT
+                || scope_path_bytes > MAX_TYPED_SCOPE_PATH_BYTES
+                || overflowed
+            {
+                return SourceFilesystemChangePlan::SourceAuditRequired {
+                    source_id,
+                    reason: "reconciliation_scope_budget_exceeded",
+                };
+            }
+            let authority_is_valid = lifecycle_generation.is_some()
+                && watcher_replay_evidence_is_well_formed(
+                    journal_checkpoint_event_id,
+                    watcher_continuity_proof.as_ref(),
+                )
+                && source_root_identity.as_deref()
+                    == watcher_continuity_proof
+                        .as_ref()
+                        .map(|proof| proof.root_identity.as_str());
+            if !authority_is_valid {
+                return SourceFilesystemChangePlan::SourceAuditRequired {
+                    source_id,
+                    reason: "targeted_sync_authority_unproven",
+                };
+            }
+            let full_scan_active_for_source = self
+                .progress
+                .as_ref()
+                .is_some_and(|progress| progress.source_id == source_id);
+            let full_scan_pending_for_source = self
+                .pending_refreshes
+                .iter()
+                .any(|pending| pending.source_id == source_id);
+            if full_scan_pending_for_source && !full_scan_active_for_source {
+                self.queue_targeted_sync(
+                    source_id.clone(),
+                    Some(&scopes),
+                    &[],
+                    source_root_identity,
+                    lifecycle_generation,
+                    journal_checkpoint_event_id,
+                    watcher_continuity_proof,
+                );
+                return SourceFilesystemChangePlan::DeferredAlreadyRunning { source_id };
+            }
+            if full_scan_active_for_source || self.active_targeted_syncs.contains_key(&source_id) {
+                self.queue_targeted_sync(
+                    source_id.clone(),
+                    Some(&scopes),
+                    &[],
+                    source_root_identity,
+                    lifecycle_generation,
+                    journal_checkpoint_event_id,
+                    watcher_continuity_proof,
+                );
+                return SourceFilesystemChangePlan::DeferredAlreadyRunning { source_id };
+            }
+            return SourceFilesystemChangePlan::SyncScopes {
+                source_id,
+                changed_count: scopes.len(),
+                scopes,
+                source_root_identity,
+                lifecycle_generation,
+                journal_checkpoint_event_id,
+                watcher_continuity_proof,
+            };
         }
         if !overflowed && !paths.is_empty() {
             let watcher_replay_proven = watcher_replay_evidence_is_well_formed(
@@ -414,7 +548,9 @@ impl SourceScanWorkflow {
                 if watcher_replay_proven {
                     self.queue_targeted_sync(
                         source_id.clone(),
+                        None,
                         paths,
+                        None,
                         lifecycle_generation,
                         journal_checkpoint_event_id,
                         watcher_continuity_proof,
@@ -438,7 +574,9 @@ impl SourceScanWorkflow {
             if full_scan_active_for_source || self.active_targeted_syncs.contains_key(&source_id) {
                 self.queue_targeted_sync(
                     source_id.clone(),
+                    None,
                     paths,
+                    None,
                     lifecycle_generation,
                     journal_checkpoint_event_id,
                     watcher_continuity_proof,
@@ -520,7 +658,9 @@ impl SourceScanWorkflow {
         let pending = self.pending_targeted_syncs.remove(&source_id)?;
         Some(PendingTargetedSourceSync {
             source_id: pending.source_id,
+            scopes: pending.scopes,
             paths: pending.paths.into_iter().collect(),
+            source_root_identity: pending.source_root_identity,
             lifecycle_generation: pending.lifecycle_generation,
             journal_checkpoint_event_id: pending.journal_checkpoint_event_id,
             watcher_continuity_proof: pending.watcher_continuity_proof,
@@ -785,7 +925,9 @@ impl SourceScanWorkflow {
     fn queue_targeted_sync(
         &mut self,
         source_id: String,
+        scopes: Option<&[ReconciliationScope]>,
         paths: &[PathBuf],
+        source_root_identity: Option<String>,
         lifecycle_generation: Option<u64>,
         journal_checkpoint_event_id: Option<u64>,
         watcher_continuity_proof: Option<WatcherContinuityProof>,
@@ -795,7 +937,9 @@ impl SourceScanWorkflow {
             .entry(source_id.clone())
             .or_insert_with(|| QueuedTargetedSourceSync {
                 source_id: source_id.clone(),
+                scopes: None,
                 paths: BTreeSet::new(),
+                source_root_identity: None,
                 lifecycle_generation,
                 journal_checkpoint_event_id: None,
                 watcher_continuity_proof: None,
@@ -804,7 +948,9 @@ impl SourceScanWorkflow {
                 enqueued_at: Instant::now(),
             });
         if pending.lifecycle_generation != lifecycle_generation {
+            pending.scopes = None;
             pending.paths.clear();
+            pending.source_root_identity = None;
             pending.lifecycle_generation = lifecycle_generation;
             pending.journal_checkpoint_event_id = None;
             pending.watcher_continuity_proof = None;
@@ -812,7 +958,68 @@ impl SourceScanWorkflow {
             pending.audit_required = false;
             pending.enqueued_at = Instant::now();
         }
-        pending.paths.extend(paths.iter().cloned());
+        let incoming_scopes = scopes.map(|scopes| coalesce_scopes(scopes.iter().cloned()));
+        if let Some(incoming_scopes) = incoming_scopes {
+            let incoming_scope_path_bytes = incoming_scopes
+                .iter()
+                .filter_map(|scope| scope.path())
+                .map(|path| path.as_path().to_string_lossy().len())
+                .sum::<usize>();
+            let incoming_scope_is_safe = !incoming_scopes.is_empty()
+                && incoming_scopes.len() <= MAX_TYPED_SCOPE_COUNT
+                && incoming_scope_path_bytes <= MAX_TYPED_SCOPE_PATH_BYTES
+                && incoming_scopes
+                    .iter()
+                    .all(|scope| scope.kind() != ReconciliationScopeKind::SourceAudit);
+            if pending.scopes.is_none() && !pending.paths.is_empty() {
+                pending.audit_required = true;
+                pending.paths.clear();
+            }
+            if !incoming_scope_is_safe {
+                pending.audit_required = true;
+                pending.scopes = Some(Vec::new());
+                pending.paths.clear();
+            } else {
+                let merged_scopes = coalesce_scopes(
+                    pending
+                        .scopes
+                        .take()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .chain(incoming_scopes),
+                );
+                let merged_scope_path_bytes = merged_scopes
+                    .iter()
+                    .filter_map(|scope| scope.path())
+                    .map(|path| path.as_path().to_string_lossy().len())
+                    .sum::<usize>();
+                if merged_scopes.len() > MAX_TYPED_SCOPE_COUNT
+                    || merged_scope_path_bytes > MAX_TYPED_SCOPE_PATH_BYTES
+                    || merged_scopes
+                        .iter()
+                        .any(|scope| scope.kind() == ReconciliationScopeKind::SourceAudit)
+                {
+                    pending.audit_required = true;
+                    pending.scopes = Some(Vec::new());
+                    pending.paths.clear();
+                } else {
+                    pending.scopes = Some(merged_scopes);
+                    pending.paths.clear();
+                    if pending.source_root_identity.is_none() {
+                        pending.source_root_identity = source_root_identity.clone();
+                    } else if pending.source_root_identity != source_root_identity {
+                        pending.audit_required = true;
+                        pending.scopes = Some(Vec::new());
+                    }
+                }
+            }
+        } else if pending.scopes.is_some() {
+            // A legacy path event cannot narrow or supplement an already typed handoff.
+            pending.audit_required = true;
+            pending.paths.clear();
+        } else {
+            pending.paths.extend(paths.iter().cloned());
+        }
         if journal_checkpoint_event_id.is_none() || watcher_continuity_proof.is_none() {
             pending.proofless_evidence_seen = true;
         }
@@ -842,10 +1049,11 @@ impl SourceScanWorkflow {
         tracing::info!(
             target: "wavecrate::source_processing",
             source_id,
+            scope_count = pending.scopes.as_ref().map_or(0, Vec::len),
             path_count = pending.paths.len(),
             lifecycle_generation = ?pending.lifecycle_generation,
-            outcome = "coalesced_targeted_paths",
-            "Source discovery causal plan merged watcher paths"
+            outcome = "coalesced_targeted_scope_or_compatibility_event",
+            "Source discovery causal plan merged watcher evidence"
         );
     }
 

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -474,15 +474,19 @@ impl SourceScanWorkflow {
                     reason: "reconciliation_scope_budget_exceeded",
                 };
             }
-            let authority_is_valid = lifecycle_generation.is_some()
-                && watcher_replay_evidence_is_well_formed(
-                    journal_checkpoint_event_id,
-                    watcher_continuity_proof.as_ref(),
-                )
-                && source_root_identity.as_deref()
-                    == watcher_continuity_proof
-                        .as_ref()
-                        .map(|proof| proof.root_identity.as_str());
+            if lifecycle_generation.is_none() {
+                return SourceFilesystemChangePlan::SourceAuditRequired {
+                    source_id,
+                    reason: "targeted_sync_lifecycle_uncertain",
+                };
+            }
+            let authority_is_valid = watcher_replay_evidence_is_well_formed(
+                journal_checkpoint_event_id,
+                watcher_continuity_proof.as_ref(),
+            ) && source_root_identity.as_deref()
+                == watcher_continuity_proof
+                    .as_ref()
+                    .map(|proof| proof.root_identity.as_str());
             if !authority_is_valid {
                 return SourceFilesystemChangePlan::SourceAuditRequired {
                     source_id,

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -1221,9 +1221,14 @@ fn typed_scope_plan_preserves_exact_and_subtree_kinds_and_ignores_legacy_paths()
 
 #[test]
 fn typed_source_audit_and_scope_loss_route_before_targeted_dispatch() {
-    for (scopes, reason) in [
-        (source_audit_scope(), "reconciliation_source_audit_scope"),
-        (Vec::new(), "reconciliation_scope_lost"),
+    for (scopes, reason, lifecycle_generation) in [
+        (
+            source_audit_scope(),
+            "reconciliation_source_audit_scope",
+            Some(7),
+        ),
+        (Vec::new(), "reconciliation_scope_lost", Some(7)),
+        (typed_scopes(), "targeted_sync_lifecycle_uncertain", None),
     ] {
         let root = temp_dir_with_wav();
         let mut browser = FolderBrowserState::load_default();
@@ -1247,7 +1252,7 @@ fn typed_source_audit_and_scope_loss_route_before_targeted_dispatch() {
                 false,
                 true,
                 Some(String::from("root-a")),
-                Some(7),
+                lifecycle_generation,
                 Some(9),
                 Some(replay_proof(9)),
             ),

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -5,6 +5,12 @@ use crate::native_app::sample_library::folder_browser::scan::{
     FolderScanProgress, FolderScanRequest, scan_source_with_progress,
 };
 use crate::native_app::sample_library::source_watcher::{WatcherBackend, WatcherContinuityProof};
+use wavecrate::sample_sources::SourceId;
+use wavecrate_library::sample_sources::reconciliation::{
+    BackendStreamIdentity, CaptureBoundary, RawEventKind, RawObservation, RawObservationEnvelope,
+    RawObservationLimits, RawObservationProvenance, RawObservedPath, RawPathHint, RawPathRole,
+    ReconciliationScopeKind, RootIdentity, WatcherGeneration, normalize_observation,
+};
 
 fn temp_dir_with_wav() -> tempfile::TempDir {
     let root = tempfile::tempdir().expect("source root");
@@ -22,6 +28,55 @@ fn replay_proof(end_event_id: u64) -> WatcherContinuityProof {
         replay_coverage_end_event_id: end_event_id,
         acknowledged_end_event_id: end_event_id,
     }
+}
+
+fn typed_scopes() -> Vec<ReconciliationScope> {
+    let provenance = RawObservationProvenance::new(
+        SourceId::from_string("source-a"),
+        Some(RootIdentity::from_bytes(vec![1])),
+        Some(BackendStreamIdentity::from_bytes(vec![2])),
+        WatcherGeneration::new(4),
+        CaptureBoundary::try_new(9, Some(8), Some(9)).expect("capture boundary"),
+    );
+    let envelope = RawObservationEnvelope::try_new(
+        provenance,
+        vec![
+            RawObservation::new(
+                RawEventKind::Modify,
+                vec![RawObservedPath::new(
+                    PathBuf::from("file.wav"),
+                    RawPathRole::Subject,
+                )],
+            ),
+            RawObservation::new(
+                RawEventKind::Create,
+                vec![
+                    RawObservedPath::new(PathBuf::from("folder"), RawPathRole::Subject)
+                        .with_hint(RawPathHint::Directory),
+                ],
+            ),
+        ],
+        RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("observation limits"),
+    )
+    .expect("observation envelope");
+    normalize_observation(envelope).scopes().to_vec()
+}
+
+fn source_audit_scope() -> Vec<ReconciliationScope> {
+    let provenance = RawObservationProvenance::new(
+        SourceId::from_string("source-a"),
+        Some(RootIdentity::from_bytes(vec![1])),
+        Some(BackendStreamIdentity::from_bytes(vec![2])),
+        WatcherGeneration::new(4),
+        CaptureBoundary::try_new(9, Some(8), Some(9)).expect("capture boundary"),
+    );
+    let envelope = RawObservationEnvelope::try_new(
+        provenance,
+        vec![RawObservation::new(RawEventKind::RootChanged, Vec::new())],
+        RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("observation limits"),
+    )
+    .expect("observation envelope");
+    normalize_observation(envelope).scopes().to_vec()
 }
 
 #[test]
@@ -1117,6 +1172,89 @@ fn targeted_watcher_hint_does_not_patch_browser_before_commit() {
         1,
         "the watcher path is only a hint until the source database commit completes"
     );
+}
+
+#[test]
+fn typed_scope_plan_preserves_exact_and_subtree_kinds_and_ignores_legacy_paths() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 126)
+        .expect("source scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+    workflow.finish_scan(
+        &mut browser,
+        scan_source_with_progress(request, |_| {}, |_| {}),
+    );
+
+    let plan = workflow.plan_filesystem_change_with_scopes_for_generation(
+        &mut browser,
+        source_id,
+        Some(&typed_scopes()),
+        &[PathBuf::from("legacy-fallback.wav")],
+        false,
+        true,
+        Some(String::from("root-a")),
+        Some(7),
+        Some(9),
+        Some(replay_proof(9)),
+    );
+
+    let SourceFilesystemChangePlan::SyncScopes {
+        scopes,
+        changed_count,
+        source_root_identity,
+        lifecycle_generation,
+        ..
+    } = plan
+    else {
+        panic!("typed replay should remain in the typed sync plan");
+    };
+    assert_eq!(changed_count, 2);
+    assert_eq!(scopes[0].kind(), ReconciliationScopeKind::ExactEntry);
+    assert_eq!(scopes[1].kind(), ReconciliationScopeKind::Subtree);
+    assert_eq!(source_root_identity.as_deref(), Some("root-a"));
+    assert_eq!(lifecycle_generation, Some(7));
+}
+
+#[test]
+fn typed_source_audit_and_scope_loss_route_before_targeted_dispatch() {
+    for (scopes, reason) in [
+        (source_audit_scope(), "reconciliation_source_audit_scope"),
+        (Vec::new(), "reconciliation_scope_lost"),
+    ] {
+        let root = temp_dir_with_wav();
+        let mut browser = FolderBrowserState::load_default();
+        let mut workflow = SourceScanWorkflow::new();
+        let request = workflow
+            .begin_add_source_path(&mut browser, root.path().to_path_buf(), 127)
+            .expect("source scan");
+        let source_id = request.source_id.clone();
+        workflow.start_scan(&request);
+        workflow.finish_scan(
+            &mut browser,
+            scan_source_with_progress(request, |_| {}, |_| {}),
+        );
+
+        assert!(matches!(
+            workflow.plan_filesystem_change_with_scopes_for_generation(
+                &mut browser,
+                source_id,
+                Some(&scopes),
+                &[PathBuf::from("must-not-be-used.wav")],
+                false,
+                true,
+                Some(String::from("root-a")),
+                Some(7),
+                Some(9),
+                Some(replay_proof(9)),
+            ),
+            SourceFilesystemChangePlan::SourceAuditRequired { reason: actual, .. }
+                if actual == reason
+        ));
+    }
 }
 
 #[test]

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -66,12 +66,16 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let started_at = Instant::now();
-        let lifecycle_generation = message_lifecycle_generation.or_else(|| {
-            self.background
-                .source_lifecycle_generations
-                .get(&source_id)
-                .copied()
-        });
+        let lifecycle_generation = if scopes.is_some() {
+            message_lifecycle_generation
+        } else {
+            message_lifecycle_generation.or_else(|| {
+                self.background
+                    .source_lifecycle_generations
+                    .get(&source_id)
+                    .copied()
+            })
+        };
         match self.library.plan_filesystem_change_with_scopes(
             source_id,
             scopes.as_deref(),

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -3,13 +3,13 @@ use std::{path::PathBuf, time::Instant};
 use radiant::prelude as ui;
 
 use crate::native_app::app::{
-    GuiMessage, NativeAppState, SourceFilesystemChangePlan, SourceFilesystemSyncResult,
-    SourceRefreshCause, SourceRefreshRequest, emit_gui_action,
+    GuiMessage, NativeAppState, SourceFilesystemChangePlan, SourceFilesystemSyncAuditReason,
+    SourceFilesystemSyncResult, SourceRefreshCause, SourceRefreshRequest, emit_gui_action,
 };
 use crate::native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::{
     capture_source_root_identity, recover_source_filesystem_sync,
     root_identity_matches_watcher_proof, run_targeted_sync_after_root_identity_gate,
-    sync_source_database_paths_with_writer,
+    sync_source_database_paths_with_writer, sync_source_database_scopes_with_writer,
 };
 use crate::native_app::sample_library::source_prep::{
     CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
@@ -22,6 +22,7 @@ use crate::native_app::sample_library::source_watcher::{
 use crate::native_app::source_processing::{
     ExternalScanHandoff, manifest_delta_requires_browser_refresh,
 };
+use wavecrate_library::sample_sources::reconciliation::ReconciliationScope;
 
 pub(in crate::native_app) const FILESYSTEM_SYNC_PREP_INTENTS: SourcePrepIntents =
     SourcePrepIntents {
@@ -54,24 +55,30 @@ impl NativeAppState {
     pub(in crate::native_app) fn refresh_source_after_filesystem_change(
         &mut self,
         source_id: String,
+        scopes: Option<Vec<ReconciliationScope>>,
         paths: Vec<PathBuf>,
         overflowed: bool,
         source_root_available: bool,
+        source_root_identity: Option<String>,
+        message_lifecycle_generation: Option<u64>,
         journal_checkpoint_event_id: Option<u64>,
         watcher_continuity_proof: Option<WatcherContinuityProof>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let started_at = Instant::now();
-        let lifecycle_generation = self
-            .background
-            .source_lifecycle_generations
-            .get(&source_id)
-            .copied();
-        match self.library.plan_filesystem_change(
+        let lifecycle_generation = message_lifecycle_generation.or_else(|| {
+            self.background
+                .source_lifecycle_generations
+                .get(&source_id)
+                .copied()
+        });
+        match self.library.plan_filesystem_change_with_scopes(
             source_id,
+            scopes.as_deref(),
             &paths,
             overflowed,
             source_root_available,
+            source_root_identity,
             lifecycle_generation,
             journal_checkpoint_event_id,
             watcher_continuity_proof.clone(),
@@ -102,8 +109,11 @@ impl NativeAppState {
             } => {
                 self.queue_source_filesystem_sync(
                     source_id.clone(),
+                    None,
                     paths,
                     changed_count,
+                    None,
+                    lifecycle_generation,
                     journal_checkpoint_event_id,
                     watcher_continuity_proof,
                     context,
@@ -115,6 +125,48 @@ impl NativeAppState {
                     "sync_queued",
                     started_at,
                     None,
+                );
+            }
+            SourceFilesystemChangePlan::SyncScopes {
+                source_id,
+                scopes,
+                changed_count,
+                source_root_identity,
+                lifecycle_generation,
+                journal_checkpoint_event_id,
+                watcher_continuity_proof,
+            } => {
+                self.queue_source_filesystem_sync(
+                    source_id.clone(),
+                    Some(scopes),
+                    Vec::new(),
+                    changed_count,
+                    source_root_identity,
+                    lifecycle_generation,
+                    journal_checkpoint_event_id,
+                    watcher_continuity_proof,
+                    context,
+                );
+                emit_gui_action(
+                    "folder_browser.source.filesystem_change",
+                    Some("sources"),
+                    Some(&source_id),
+                    "sync_queued",
+                    started_at,
+                    None,
+                );
+            }
+            SourceFilesystemChangePlan::SourceAuditRequired { source_id, reason } => {
+                self.background
+                    .source_processing
+                    .request_source_manifest_audit(&source_id, reason);
+                emit_gui_action(
+                    "folder_browser.source.filesystem_change",
+                    Some("sources"),
+                    Some(&source_id),
+                    "audit_required",
+                    started_at,
+                    Some(reason),
                 );
             }
             SourceFilesystemChangePlan::DeferredAlreadyRunning { source_id } => {
@@ -158,10 +210,15 @@ impl NativeAppState {
                 lifecycle_generation = result.lifecycle_generation,
                 "Ignoring filesystem sync completion from an inactive source generation"
             );
+            self.background
+                .source_processing
+                .request_source_manifest_audit(
+                    &source_id,
+                    SourceFilesystemSyncAuditReason::LifecycleStale.label(),
+                );
             self.maybe_run_pending_source_refresh(context);
             return;
         }
-        let changed_count = result.changed_count;
         if !self.library.folder_browser.source_exists(&source_id) {
             tracing::debug!(
                 source_id = %source_id,
@@ -170,6 +227,47 @@ impl NativeAppState {
             self.maybe_run_pending_source_refresh(context);
             return;
         }
+        let audit_required = result.audit_required.or(result
+            .cancelled
+            .then_some(SourceFilesystemSyncAuditReason::Cancelled));
+        if let Some(reason) = audit_required {
+            self.background
+                .source_processing
+                .request_source_manifest_audit(&source_id, reason.label());
+            let (refresh_cause, reconciliation_reason) = match reason {
+                SourceFilesystemSyncAuditReason::RootIdentityUncertain => (
+                    SourceRefreshCause::WatcherAuthorityUnproven,
+                    "targeted_sync_watcher_authority_unproven",
+                ),
+                SourceFilesystemSyncAuditReason::ScopeLost
+                | SourceFilesystemSyncAuditReason::SourceAuditScope
+                | SourceFilesystemSyncAuditReason::LifecycleStale
+                | SourceFilesystemSyncAuditReason::Cancelled
+                | SourceFilesystemSyncAuditReason::TypedScopeDispatchUnavailable
+                | SourceFilesystemSyncAuditReason::WorkerPanic => (
+                    SourceRefreshCause::FilesystemSyncIncomplete,
+                    "filesystem_sync_incomplete_after_commit",
+                ),
+            };
+            self.background
+                .source_processing
+                .wake_source_for_full_reconciliation(&source_id, reconciliation_reason);
+            if let Err(error) = result.result.as_ref()
+                && source_id == self.library.folder_browser.selected_source_id()
+            {
+                self.ui.status.sample = format!("Source sync failed: {error}");
+            }
+            self.queue_filesystem_source_refresh(
+                source_id,
+                refresh_cause,
+                Some(result.lifecycle_generation),
+                Instant::now(),
+                context,
+            );
+            self.maybe_run_pending_source_refresh(context);
+            return;
+        }
+        let changed_count = result.changed_count;
         let watcher_root_identity_is_aligned = root_identity_matches_watcher_proof(
             root_identity.as_deref(),
             watcher_continuity_proof.as_ref(),
@@ -429,6 +527,12 @@ impl NativeAppState {
                     outcome = "stale_lifecycle",
                     "Suppressing stale pending source refresh"
                 );
+                self.background
+                    .source_processing
+                    .request_source_manifest_audit(
+                        &pending.source_id,
+                        SourceFilesystemSyncAuditReason::LifecycleStale.label(),
+                    );
                 continue;
             }
             self.queue_filesystem_source_refresh(
@@ -458,7 +562,31 @@ impl NativeAppState {
                     outcome = "stale_lifecycle",
                     "Suppressing stale targeted source sync"
                 );
+                self.background
+                    .source_processing
+                    .request_source_manifest_audit(
+                        &pending.source_id,
+                        SourceFilesystemSyncAuditReason::LifecycleStale.label(),
+                    );
                 continue;
+            }
+            let typed_scope_audit_reason = pending.scopes.as_ref().and_then(|scopes| {
+                if scopes.is_empty() {
+                    Some(SourceFilesystemSyncAuditReason::ScopeLost)
+                } else if scopes.iter().any(|scope| {
+                    scope.kind()
+                        == wavecrate_library::sample_sources::reconciliation::ReconciliationScopeKind::SourceAudit
+                }) {
+                    Some(SourceFilesystemSyncAuditReason::SourceAuditScope)
+                } else {
+                    None
+                }
+            });
+            if let Some(reason) = typed_scope_audit_reason {
+                self.background
+                    .source_processing
+                    .request_source_manifest_audit(&pending.source_id, reason.label());
+                break;
             }
             if pending.audit_required
                 || !watcher_replay_evidence_is_well_formed(
@@ -482,11 +610,15 @@ impl NativeAppState {
                 );
                 break;
             }
-            let changed_count = pending.paths.len();
+            let changed_count = pending
+                .scopes
+                .as_ref()
+                .map_or(pending.paths.len(), Vec::len);
             tracing::info!(
                 target: "wavecrate::source_processing",
                 source_id = pending.source_id,
-                path_count = changed_count,
+                scope_count = pending.scopes.as_ref().map_or(0, Vec::len),
+                path_count = pending.paths.len(),
                 lifecycle_generation = ?pending.lifecycle_generation,
                 queue_age_ms = pending.enqueued_at.elapsed().as_millis(),
                 outcome = "targeted_sync_admitted",
@@ -494,8 +626,11 @@ impl NativeAppState {
             );
             self.queue_source_filesystem_sync(
                 pending.source_id,
+                pending.scopes,
                 pending.paths,
                 changed_count,
+                pending.source_root_identity,
+                pending.lifecycle_generation,
                 pending.journal_checkpoint_event_id,
                 pending.watcher_continuity_proof,
                 context,
@@ -599,16 +734,50 @@ impl NativeAppState {
     fn queue_source_filesystem_sync(
         &mut self,
         source_id: String,
+        scopes: Option<Vec<ReconciliationScope>>,
         paths: Vec<PathBuf>,
         changed_count: usize,
+        source_root_identity: Option<String>,
+        lifecycle_generation: Option<u64>,
         journal_checkpoint_event_id: Option<u64>,
         watcher_continuity_proof: Option<WatcherContinuityProof>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
-        if paths.is_empty() {
+        let scopes = scopes.map(|scopes| {
+            wavecrate_library::sample_sources::reconciliation::coalesce_scopes(scopes)
+        });
+        if let Some(scopes) = scopes.as_ref() {
+            let typed_authority_is_valid = !scopes.is_empty()
+                && scopes.iter().all(|scope| {
+                    scope.kind()
+                        != wavecrate_library::sample_sources::reconciliation::ReconciliationScopeKind::SourceAudit
+                })
+                && lifecycle_generation.is_some()
+                && watcher_replay_evidence_is_well_formed(
+                    journal_checkpoint_event_id,
+                    watcher_continuity_proof.as_ref(),
+                )
+                && source_root_identity.as_deref()
+                    == watcher_continuity_proof
+                        .as_ref()
+                        .map(|proof| proof.root_identity.as_str())
+                && self
+                    .background
+                    .source_lifecycle_generations
+                    .get(&source_id)
+                    == lifecycle_generation.as_ref();
+            if !typed_authority_is_valid {
+                self.background
+                    .source_processing
+                    .request_source_manifest_audit(
+                        &source_id,
+                        SourceFilesystemSyncAuditReason::RootIdentityUncertain.label(),
+                    );
+                return;
+            }
+        } else if paths.is_empty() {
             return;
-        }
-        if !watcher_replay_evidence_is_well_formed(
+        } else if !watcher_replay_evidence_is_well_formed(
             journal_checkpoint_event_id,
             watcher_continuity_proof.as_ref(),
         ) {
@@ -657,19 +826,44 @@ impl NativeAppState {
                     return;
                 }
             };
+        if let Some(lifecycle_generation) = lifecycle_generation
+            && lifecycle_generation != expected_lifecycle_generation
+        {
+            self.background
+                .source_processing
+                .request_source_manifest_audit(
+                    &source_id,
+                    SourceFilesystemSyncAuditReason::LifecycleStale.label(),
+                );
+            return;
+        }
         if !self
             .library
             .mark_targeted_source_sync_started(&source_id, expected_lifecycle_generation)
         {
-            self.library.plan_filesystem_change(
-                source_id.clone(),
-                &paths,
-                false,
-                true,
-                Some(expected_lifecycle_generation),
-                journal_checkpoint_event_id,
-                watcher_continuity_proof.clone(),
-            );
+            if scopes.is_some() {
+                self.library.plan_filesystem_change_with_scopes(
+                    source_id.clone(),
+                    scopes.as_deref(),
+                    &[],
+                    false,
+                    true,
+                    source_root_identity.clone(),
+                    Some(expected_lifecycle_generation),
+                    journal_checkpoint_event_id,
+                    watcher_continuity_proof.clone(),
+                );
+            } else {
+                self.library.plan_filesystem_change(
+                    source_id.clone(),
+                    &paths,
+                    false,
+                    true,
+                    Some(expected_lifecycle_generation),
+                    journal_checkpoint_event_id,
+                    watcher_continuity_proof.clone(),
+                );
+            }
             return;
         }
         let budget = self.background.source_processing.budget_handle();
@@ -686,6 +880,7 @@ impl NativeAppState {
                         journal_checkpoint_event_id,
                         watcher_continuity_proof,
                         cancelled: true,
+                        audit_required: Some(SourceFilesystemSyncAuditReason::Cancelled),
                         result: Err(String::from("Source filesystem sync canceled")),
                     };
                 };
@@ -706,8 +901,18 @@ impl NativeAppState {
                             captured_root_identity.clone(),
                             journal_checkpoint_event_id,
                             watcher_continuity_proof.clone(),
-                            || {
-                                sync_source_database_paths_with_writer(
+                            || match scopes {
+                                Some(scopes) => sync_source_database_scopes_with_writer(
+                                    source_id,
+                                    root,
+                                    scopes,
+                                    changed_count,
+                                    source_root_identity,
+                                    cancel.as_ref(),
+                                    watcher_continuity_proof.clone(),
+                                    &scan_writer,
+                                ),
+                                None => sync_source_database_paths_with_writer(
                                     source_id,
                                     root,
                                     database_root,
@@ -716,7 +921,7 @@ impl NativeAppState {
                                     cancel.as_ref(),
                                     watcher_continuity_proof.clone(),
                                     &scan_writer,
-                                )
+                                ),
                             },
                         )
                     },
@@ -725,7 +930,8 @@ impl NativeAppState {
                 result.watcher_continuity_proof = watcher_continuity_proof;
                 let projection_ticket = match &mut result.result {
                     Ok(success)
-                        if !result.cancelled
+                        if result.audit_required.is_none()
+                            && !result.cancelled
                             && success.incomplete_error.is_none()
                             && success.browser_projection_delta.is_some() =>
                     {
@@ -736,7 +942,9 @@ impl NativeAppState {
                     }
                     _ => {
                         permit.release_after_handoff(ExternalScanHandoff::FullReconciliation {
-                            reason: "targeted_source_sync_incomplete",
+                            reason: result
+                                .audit_required
+                                .map_or("targeted_source_sync_incomplete", |reason| reason.label()),
                         });
                         None
                     }
@@ -822,7 +1030,10 @@ mod tests {
 
     use super::{ManifestAuditFollowup, manifest_audit_followup};
     use crate::native_app::{
-        app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
+        app::{
+            BrowserProjectionDelta, SourceFilesystemSyncAuditReason, SourceFilesystemSyncResult,
+            SourceFilesystemSyncSuccess,
+        },
         sample_library::folder_browser::{FolderBrowserState, scan::scan_source_with_progress},
         sample_library::source_watcher::{
             CheckpointCause, WatcherBackend, WatcherContinuityProof,
@@ -931,6 +1142,7 @@ mod tests {
             journal_checkpoint_event_id: Some(73),
             watcher_continuity_proof: None,
             cancelled: false,
+            audit_required: None,
             result: Ok(SourceFilesystemSyncSuccess {
                 renames_reconciled: 0,
                 incomplete_error: None,
@@ -985,6 +1197,7 @@ mod tests {
             journal_checkpoint_event_id: Some(73),
             watcher_continuity_proof,
             cancelled: false,
+            audit_required: None,
             result: Ok(SourceFilesystemSyncSuccess {
                 renames_reconciled: 0,
                 incomplete_error: None,
@@ -1107,6 +1320,7 @@ mod tests {
             journal_checkpoint_event_id: Some(73),
             watcher_continuity_proof: Some(proof),
             cancelled: false,
+            audit_required: Some(SourceFilesystemSyncAuditReason::RootIdentityUncertain),
             result: Err(String::from(
                 "Targeted source sync rejected because the captured source root identity does not match watcher replay evidence",
             )),

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -8,12 +8,18 @@ use std::{
 
 use wavecrate::sample_sources::{Rating, SourceDatabase, SourceIndexClassification};
 use wavecrate_library::filesystem_identity::stable_filesystem_identity;
+use wavecrate_library::sample_sources::reconciliation::{
+    ReconciliationScope, ReconciliationScopeKind,
+};
 use wavecrate_scan::sample_sources::scanner::{
     self, ScanWritePhase, ScanWriter, UncoordinatedScanWriter,
 };
 
 use crate::native_app::{
-    app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
+    app::{
+        BrowserProjectionDelta, SourceFilesystemSyncAuditReason, SourceFilesystemSyncResult,
+        SourceFilesystemSyncSuccess,
+    },
     sample_library::folder_browser::model::file_entry_with_snapshot_metadata,
     sample_library::source_watcher::WatcherContinuityProof,
 };
@@ -41,6 +47,7 @@ pub(in crate::native_app) fn recover_source_filesystem_sync(
             journal_checkpoint_event_id: None,
             watcher_continuity_proof: None,
             cancelled: false,
+            audit_required: Some(SourceFilesystemSyncAuditReason::WorkerPanic),
             result: Err(String::from(
                 "Source filesystem sync worker stopped unexpectedly",
             )),
@@ -107,6 +114,7 @@ pub(in crate::native_app) fn run_targeted_sync_after_root_identity_gate(
             journal_checkpoint_event_id,
             watcher_continuity_proof,
             cancelled: false,
+            audit_required: Some(SourceFilesystemSyncAuditReason::RootIdentityUncertain),
             result: Err(String::from(
                 "Targeted source sync rejected because the captured source root identity is unavailable or does not match watcher replay evidence",
             )),
@@ -145,6 +153,7 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
             journal_checkpoint_event_id: None,
             watcher_continuity_proof,
             cancelled: cancel.load(Ordering::Acquire),
+            audit_required: Some(SourceFilesystemSyncAuditReason::RootIdentityUncertain),
             result: Err(String::from(
                 "Targeted source sync rejected because the live source root identity is unavailable or does not match watcher replay evidence",
             )),
@@ -182,6 +191,7 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
             break;
         }
     }
+    let cancelled = cancel.load(Ordering::Acquire);
     SourceFilesystemSyncResult {
         source_id,
         lifecycle_generation: 0,
@@ -189,8 +199,61 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
         root_identity: observed_root_identity,
         journal_checkpoint_event_id: None,
         watcher_continuity_proof,
-        cancelled: cancel.load(Ordering::Acquire),
+        cancelled,
+        audit_required: cancelled.then_some(SourceFilesystemSyncAuditReason::Cancelled),
         result,
+    }
+}
+
+/// Admit typed scopes at the refresh-worker boundary without narrowing them into compatibility
+/// paths. The scanner collection contract is deliberately deferred to the next slice, so every
+/// typed scope is conservatively routed to the existing source-audit owner before any DB work.
+pub(in crate::native_app) fn sync_source_database_scopes_with_writer(
+    source_id: String,
+    root: PathBuf,
+    scopes: Vec<ReconciliationScope>,
+    changed_count: usize,
+    source_root_identity: Option<String>,
+    cancel: &AtomicBool,
+    watcher_continuity_proof: Option<WatcherContinuityProof>,
+    _writer: &impl ScanWriter,
+) -> SourceFilesystemSyncResult {
+    let root_identity = capture_source_root_identity(&root);
+    let cancelled = cancel.load(Ordering::Acquire);
+    let audit_required = if cancelled {
+        SourceFilesystemSyncAuditReason::Cancelled
+    } else if scopes.is_empty() {
+        SourceFilesystemSyncAuditReason::ScopeLost
+    } else if scopes
+        .iter()
+        .any(|scope| scope.kind() == ReconciliationScopeKind::SourceAudit)
+    {
+        SourceFilesystemSyncAuditReason::SourceAuditScope
+    } else if !root_identity_matches_watcher_proof(
+        root_identity.as_deref(),
+        watcher_continuity_proof.as_ref(),
+    ) || source_root_identity.as_deref()
+        != watcher_continuity_proof
+            .as_ref()
+            .map(|proof| proof.root_identity.as_str())
+    {
+        SourceFilesystemSyncAuditReason::RootIdentityUncertain
+    } else {
+        SourceFilesystemSyncAuditReason::TypedScopeDispatchUnavailable
+    };
+    SourceFilesystemSyncResult {
+        source_id,
+        lifecycle_generation: 0,
+        changed_count,
+        root_identity,
+        journal_checkpoint_event_id: None,
+        watcher_continuity_proof,
+        cancelled,
+        audit_required: Some(audit_required),
+        result: Err(format!(
+            "Typed reconciliation scope dispatch requires source audit: {}",
+            audit_required.label()
+        )),
     }
 }
 
@@ -550,6 +613,11 @@ mod tests {
     };
 
     use wavecrate::sample_sources::{Rating, SourceDatabase, scanner};
+    use wavecrate_library::sample_sources::reconciliation::{
+        BackendStreamIdentity, CaptureBoundary, RawEventKind, RawObservation,
+        RawObservationEnvelope, RawObservationLimits, RawObservationProvenance, RawObservedPath,
+        RawPathRole, RootIdentity, WatcherGeneration, normalize_observation,
+    };
     use wavecrate_scan::sample_sources::scanner::{ScanWritePhase, ScanWriter};
 
     use crate::native_app::sample_library::source_watcher::{
@@ -559,7 +627,7 @@ mod tests {
     use super::{
         capture_source_root_identity, recover_source_filesystem_sync,
         run_targeted_sync_after_root_identity_gate, sync_source_database_paths,
-        sync_source_database_paths_with_writer,
+        sync_source_database_paths_with_writer, sync_source_database_scopes_with_writer,
     };
 
     #[derive(Clone)]
@@ -623,6 +691,63 @@ mod tests {
             replay_coverage_end_event_id: event_id,
             acknowledged_end_event_id: event_id,
         }
+    }
+
+    fn exact_scope() -> wavecrate_library::sample_sources::reconciliation::ReconciliationScope {
+        let provenance = RawObservationProvenance::new(
+            wavecrate::sample_sources::SourceId::from_string("source-a"),
+            Some(RootIdentity::from_bytes(vec![1])),
+            Some(BackendStreamIdentity::from_bytes(vec![2])),
+            WatcherGeneration::new(4),
+            CaptureBoundary::try_new(9, Some(8), Some(9)).expect("capture boundary"),
+        );
+        let envelope = RawObservationEnvelope::try_new(
+            provenance,
+            vec![RawObservation::new(
+                RawEventKind::Modify,
+                vec![RawObservedPath::new(
+                    PathBuf::from("exact.wav"),
+                    RawPathRole::Subject,
+                )],
+            )],
+            RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("observation limits"),
+        )
+        .expect("observation envelope");
+        normalize_observation(envelope)
+            .scopes()
+            .first()
+            .cloned()
+            .expect("exact scope")
+    }
+
+    #[test]
+    fn typed_scope_dispatch_routes_to_audit_without_opening_database_or_using_paths() {
+        let root = tempfile::tempdir().expect("source root");
+        let root_identity = capture_source_root_identity(root.path()).expect("root identity");
+        let proof = watcher_proof(&root_identity, 73);
+        let writer = CountingWriter {
+            database_open_started: Arc::new(AtomicBool::new(false)),
+        };
+
+        let result = sync_source_database_scopes_with_writer(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            vec![exact_scope()],
+            1,
+            Some(root_identity.clone()),
+            &AtomicBool::new(false),
+            Some(proof),
+            &writer,
+        );
+
+        assert_eq!(
+            result.audit_required,
+            Some(
+                crate::native_app::app::SourceFilesystemSyncAuditReason::TypedScopeDispatchUnavailable
+            )
+        );
+        assert!(result.result.is_err());
+        assert!(!writer.database_open_started.load(Ordering::Acquire));
     }
 
     #[test]
@@ -1098,6 +1223,10 @@ mod tests {
         );
 
         assert!(result.cancelled);
+        assert_eq!(
+            result.audit_required,
+            Some(crate::native_app::app::SourceFilesystemSyncAuditReason::Cancelled)
+        );
         assert!(result.result.is_err());
         let db =
             SourceDatabase::open_for_test_fixture_source_write(root.path()).expect("source db");

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -14,7 +14,7 @@ use wavecrate::sample_sources::{SampleSource, SourceDatabase, SourceId};
 use wavecrate_library::sample_sources::reconciliation::{
     AdapterDisposition, AdmissionOutcome, BackendStreamIdentity, CaptureBoundary, DispatchTicket,
     LiveAuditCorrelation, ReconciliationLifecycle, ReconciliationScopeKind, RootIdentity,
-    SourceAuditReceipt, WatcherGeneration,
+    SourceAuditReceipt, WatcherGeneration, coalesce_scopes,
 };
 
 use super::admission_lifecycle::{AdmissionLifecycle, FseventsReplayEvidence};
@@ -1089,9 +1089,14 @@ fn run_source_watcher(
             );
             let _ = message_tx.send(GuiMessage::SourceFilesystemChanged {
                 source_id: event.source_id,
+                // Debounced native events are the explicit compatibility lane: no typed
+                // normalized scope is available after the live event collector coalesces them.
+                scopes: None,
                 paths: event.paths,
                 overflowed: event.overflowed,
                 source_root_available: event.source_root_available,
+                source_root_identity: None,
+                lifecycle_generation: None,
                 journal_checkpoint_event_id: None,
                 watcher_continuity_proof: None,
             });
@@ -1537,10 +1542,9 @@ fn handoff_dispatched_capture(
         state.mark_all_overflowed(now);
         return (false, false);
     }
+    let scopes = coalesce_scopes(dispatched.normalized().scopes().iter().cloned());
     let source_audit = context.conservative
-        || dispatched
-            .normalized()
-            .scopes()
+        || scopes
             .iter()
             .any(|scope| scope.kind() == ReconciliationScopeKind::SourceAudit);
     if let Some(correlation) = context.correlation.as_ref() {
@@ -1557,7 +1561,7 @@ fn handoff_dispatched_capture(
         state.mark_source_overflowed(context.source_id.as_str(), now);
         return (true, false);
     }
-    if source_audit {
+    if source_audit && context.replay.is_none() {
         widen_source(state, &context.source_root, now);
         return (true, false);
     }
@@ -1566,9 +1570,12 @@ fn handoff_dispatched_capture(
         if message_tx
             .send(GuiMessage::SourceFilesystemChanged {
                 source_id: context.source_id.as_str().to_string(),
+                scopes: Some(scopes),
                 paths: replay.paths.clone(),
                 overflowed: false,
                 source_root_available: true,
+                source_root_identity: Some(replay.proof.root_identity.clone()),
+                lifecycle_generation: None,
                 journal_checkpoint_event_id: Some(replay.proof.acknowledged_end_event_id),
                 watcher_continuity_proof: Some(replay.proof.clone()),
             })
@@ -4702,16 +4709,25 @@ mod lifecycle_tests {
         {
             GuiMessage::SourceFilesystemChanged {
                 source_id,
+                scopes,
                 paths,
                 overflowed,
                 source_root_available,
+                source_root_identity,
+                lifecycle_generation,
                 journal_checkpoint_event_id,
                 watcher_continuity_proof,
             } => {
                 assert_eq!(source_id, second.id.as_str());
+                assert!(scopes.is_some());
                 assert_eq!(paths, vec![PathBuf::from("second.wav")]);
                 assert!(!overflowed);
                 assert!(source_root_available);
+                assert_eq!(
+                    source_root_identity,
+                    Some(second_proof.root_identity.clone())
+                );
+                assert_eq!(lifecycle_generation, None);
                 assert_eq!(journal_checkpoint_event_id, Some(21));
                 assert_eq!(watcher_continuity_proof, Some(second_proof.clone()));
             }

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -1575,6 +1575,9 @@ fn handoff_dispatched_capture(
                 overflowed: false,
                 source_root_available: true,
                 source_root_identity: Some(replay.proof.root_identity.clone()),
+                // The replay/checkpoint generation is historical watcher authority, not the
+                // current source-processing lifecycle generation. This lane has no current-token
+                // transport yet; leave it unset so typed scopes fail closed at the GUI boundary.
                 lifecycle_generation: None,
                 journal_checkpoint_event_id: Some(replay.proof.acknowledged_end_event_id),
                 watcher_continuity_proof: Some(replay.proof.clone()),

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -134,17 +134,23 @@ impl NativeAppState {
             }
             GuiMessage::SourceFilesystemChanged {
                 source_id,
+                scopes,
                 paths,
                 overflowed,
                 source_root_available,
+                source_root_identity,
+                lifecycle_generation,
                 journal_checkpoint_event_id,
                 watcher_continuity_proof,
             } => {
                 self.refresh_source_after_filesystem_change(
                     source_id,
+                    scopes,
                     paths,
                     overflowed,
                     source_root_available,
+                    source_root_identity,
+                    lifecycle_generation,
                     journal_checkpoint_event_id,
                     watcher_continuity_proof,
                     context,

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -651,6 +651,7 @@ fn source_completions_from_previous_readded_epoch_are_ignored() {
             journal_checkpoint_event_id: None,
             watcher_continuity_proof: None,
             cancelled: true,
+            audit_required: None,
             result: Err(String::from("old epoch cancelled")),
         }),
         &mut context,

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -275,9 +275,12 @@ fn source_filesystem_change_queues_refresh_without_clearing_loaded_tree() {
     state.apply_message(
         crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
             source_id: source_id.clone(),
+            scopes: None,
             paths: Vec::new(),
             overflowed: true,
             source_root_available: true,
+            source_root_identity: None,
+            lifecycle_generation: None,
             journal_checkpoint_event_id: None,
             watcher_continuity_proof: None,
         },
@@ -331,9 +334,12 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
     state.apply_message(
         crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
             source_id: source_id.clone(),
+            scopes: None,
             paths: vec![PathBuf::from("stale.wav")],
             overflowed: false,
             source_root_available: true,
+            source_root_identity: None,
+            lifecycle_generation: None,
             journal_checkpoint_event_id: Some(21),
             watcher_continuity_proof: Some(replay_proof(source_root.path(), 21)),
         },

--- a/src/native_app/tests/config_sources/scan_handoff.rs
+++ b/src/native_app/tests/config_sources/scan_handoff.rs
@@ -1,7 +1,13 @@
 use super::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::native_app::sample_library::source_watcher::{WatcherBackend, WatcherContinuityProof};
+use wavecrate::sample_sources::SourceId;
+use wavecrate_library::sample_sources::reconciliation::{
+    BackendStreamIdentity, CaptureBoundary, RawEventKind, RawObservation, RawObservationEnvelope,
+    RawObservationLimits, RawObservationProvenance, RawObservedPath, RawPathRole,
+    ReconciliationScope, RootIdentity, WatcherGeneration, normalize_observation,
+};
 
 fn replay_proof(root: &Path, end_event_id: u64) -> WatcherContinuityProof {
     let metadata = fs::metadata(root).expect("source metadata");
@@ -17,6 +23,29 @@ fn replay_proof(root: &Path, end_event_id: u64) -> WatcherContinuityProof {
         replay_coverage_end_event_id: end_event_id,
         acknowledged_end_event_id: end_event_id,
     }
+}
+
+fn typed_scopes() -> Vec<ReconciliationScope> {
+    let provenance = RawObservationProvenance::new(
+        SourceId::from_string("source-a"),
+        Some(RootIdentity::from_bytes(vec![1])),
+        Some(BackendStreamIdentity::from_bytes(vec![2])),
+        WatcherGeneration::new(4),
+        CaptureBoundary::try_new(9, Some(8), Some(9)).expect("capture boundary"),
+    );
+    let envelope = RawObservationEnvelope::try_new(
+        provenance,
+        vec![RawObservation::new(
+            RawEventKind::Modify,
+            vec![RawObservedPath::new(
+                PathBuf::from("file.wav"),
+                RawPathRole::Subject,
+            )],
+        )],
+        RawObservationLimits::new(8, usize::MAX, usize::MAX).expect("observation limits"),
+    )
+    .expect("observation envelope");
+    normalize_observation(envelope).scopes().to_vec()
 }
 
 #[test]
@@ -144,6 +173,41 @@ fn foreground_scan_terminal_release_admits_coalesced_watcher_paths() {
             .library
             .targeted_source_sync_active_for_tests(&source_id),
         "terminal scan release must immediately admit the coalesced targeted follow-up"
+    );
+}
+
+#[test]
+fn typed_replay_without_producer_lifecycle_generation_routes_to_audit() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 106)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let mut context = ui::UiUpdateContext::default();
+    state.launch_folder_scan(request, &mut context);
+    let proof = replay_proof(source_root.path(), 11);
+
+    state.refresh_source_after_filesystem_change(
+        source_id.clone(),
+        Some(typed_scopes()),
+        vec![PathBuf::from("legacy-fallback.wav")],
+        false,
+        true,
+        Some(proof.root_identity.clone()),
+        None,
+        Some(11),
+        Some(proof),
+        &mut context,
+    );
+
+    assert!(
+        !state
+            .library
+            .targeted_source_sync_active_for_tests(&source_id),
+        "typed replay without producer lifecycle authority must not use the GUI current generation"
     );
 }
 

--- a/src/native_app/tests/config_sources/scan_handoff.rs
+++ b/src/native_app/tests/config_sources/scan_handoff.rs
@@ -115,9 +115,12 @@ fn foreground_scan_terminal_release_admits_coalesced_watcher_paths() {
     state.launch_folder_scan(request.clone(), &mut context);
     state.refresh_source_after_filesystem_change(
         source_id.clone(),
+        None,
         vec![sample_path],
         false,
         true,
+        None,
+        None,
         Some(11),
         Some(replay_proof(source_root.path(), 11)),
         &mut context,
@@ -269,9 +272,12 @@ fn source_filesystem_change_during_scan_is_refreshed_after_scan_finishes() {
     let mut context = ui::UiUpdateContext::default();
     state.refresh_source_after_filesystem_change(
         source_id.clone(),
+        None,
         Vec::new(),
         true,
         true,
+        None,
+        None,
         None,
         None,
         &mut context,
@@ -280,9 +286,12 @@ fn source_filesystem_change_during_scan_is_refreshed_after_scan_finishes() {
     state.apply_message(
         crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
             source_id: source_id.clone(),
+            scopes: None,
             paths: Vec::new(),
             overflowed: true,
             source_root_available: true,
+            source_root_identity: None,
+            lifecycle_generation: None,
             journal_checkpoint_event_id: None,
             watcher_continuity_proof: None,
         },


### PR DESCRIPTION
## Goal

Preserve normalized watcher reconciliation scope authority through the native refresh handoff so the next scanner-budget slice can consume `ExactEntry` and `Subtree` without reconstructing recursive work from path lists.

## Scope

- Carry typed `ReconciliationScope` values and source/root/lifecycle/continuity authority through watcher replay handoff, `GuiMessage`, source-scan planning, coalescing queues, and refresh-worker admission.
- Keep `ExactEntry`, `Subtree`, and `SourceAudit` distinct; coalesce only by widening evidence, with source audit dominating all path scopes.
- Treat `Some(Vec::new())` as scope loss and `None` as the explicit legacy path-only compatibility lane; a legacy path event cannot narrow or supplement an already typed handoff.
- For typed replay (`scopes: Some(_)`), accept only the producer-supplied current source-processing lifecycle generation. Missing generation is `targeted_sync_lifecycle_uncertain` and routes to audit; it never falls back to GUI-time state. The persisted replay generation remains historical checkpoint authority only.
- Bound typed scope count and path bytes before queue/dispatch; stale lifecycle, cancellation, root-identity uncertainty, scope loss, source-audit scopes, and unavailable typed scanner dispatch request source audit before targeted projection or watcher checkpoint.
- Preserve the existing audit-plus-full-refresh recovery behavior for failed, cancelled, or authority-uncertain completions.

## Non-goals

- Scanner collection, bounded/keyset manifest/index reads, or targeted `ExactEntry`/`Subtree` consumption.
- Directory-truth publication, empty-folder projection, readiness redesign, watcher persistence redesign, or the universal coordinator/journal.
- Transport of the current source-processing lifecycle token through watcher startup/replacement; that is the next prerequisite.
- Any change to unrelated open PR #980.

## Definition of Done

- A continuity-proven replay reaches the application with its normalized scopes, source root identity, and watcher proof intact.
- Exact-entry scopes remain non-recursive and subtree scopes widen/cover only the evidence they actually authorize; source audit cannot be narrowed.
- Scope loss, malformed/uncertain authority, missing or stale typed lifecycle, cancellation, budget overflow, and typed scanner unavailability request the existing source-audit/full-reconciliation path without applying a targeted browser delta or advancing a watcher checkpoint.
- Legacy path messages remain behavior-compatible only when no typed scope lane is present.
- Existing source lifecycle, projection-handoff, readiness, and checkpoint fences remain intact.

## Validation

- `cargo test -p wavecrate-library --lib sample_sources::reconciliation` — 87 passed.
- `cargo test -p wavecrate --lib native_app::app::state::source_scan_workflow::tests` — 48 passed.
- `cargo test -p wavecrate --lib native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::tests` — 13 passed.
- `cargo test -p wavecrate --lib native_app::sample_library::folder_scan_actions::filesystem_refresh::tests` — 11 passed.
- `cargo test -p wavecrate --lib native_app::sample_library::source_watcher::journal::tests` — 32 passed.
- `cargo test -p wavecrate --lib native_app::tests::config_sources::scan_handoff::typed_replay_without_producer_lifecycle_generation_routes_to_audit` — 1 passed.
- `cargo check -p wavecrate --tests --bins` — passed.
- Touched-file Rust 2024 formatting and `git diff --check` — passed.
- Full watcher suite — 126 passed; `filesystem_event_after_initial_watcher_ready_is_not_suppressed` fails identically on the base commit.
- Full scan-handoff suite — 5 passed; two pre-existing baseline failures reproduce on the base commit.
- `bash scripts/ci.sh smoke` — could not start because the validation target could not identify lease owner process 12691.

## Known limitations

- The watcher and scan-handoff baseline failures are outside this lifecycle correction and reproduce against `bf7c4c962`.
- The smoke gate is currently blocked by the local validation lease-owner environment, before project checks execute.
- Typed `ExactEntry`/`Subtree` worker consumption is intentionally conservative in this prerequisite: until the current source-processing lifecycle token is transported, typed dispatch requests source audit rather than opening the database or using legacy paths.
- Workspace-wide formatting remains red on unrelated pre-existing files outside this diff; all changed Rust files pass the touched-file check.

## Next architecture task

Transport the current source-processing lifecycle generation atomically through watcher startup and source replacement, then enable the bounded/keyset scanner consumer for typed `ExactEntry` and `Subtree` scopes.

Merge requires explicit user approval. For this alignment task, approval is conditional on Terra providing its own terminal `APPROVE` verdict on the current exact head.