### PR TITLE
feat: transport source lifecycle registrations

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -97,10 +97,10 @@ pub(in crate::native_app) enum GuiMessage {
         source_root_available: bool,
         /// Root identity authority carried by a typed replay handoff.
         source_root_identity: Option<String>,
-        /// Producer-supplied current source-processing lifecycle authority. Typed replay may
-        /// intentionally carry `None` until current-token transport exists; consumers must not
-        /// substitute the GUI's current generation for `scopes: Some(_)`. Path-only legacy
-        /// messages may use `None` for the compatibility fallback.
+        /// Producer-supplied current source-processing lifecycle authority. Typed replay must
+        /// carry `Some` from the supervisor-owned registration pair; consumers must not substitute
+        /// the GUI's current generation for `scopes: Some(_)`. Path-only legacy messages may use
+        /// `None` for the compatibility fallback.
         lifecycle_generation: Option<u64>,
         /// A durable FSEvents cursor that may advance only after this targeted sync commits.
         journal_checkpoint_event_id: Option<u64>,

--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -28,7 +28,9 @@ use crate::native_app::sample_library::harvest_tracking::{
 use crate::native_app::sample_library::sample_ratings::{
     RatingPersistRequest, persist_rating_requests,
 };
-use crate::native_app::source_processing::SourceProcessingSupervisor;
+use crate::native_app::source_processing::{
+    SourceProcessingRegistration, SourceProcessingSupervisor,
+};
 use crate::native_app::waveform::WaveformPreservedMarks;
 
 pub(in crate::native_app) struct BackgroundTaskState {
@@ -398,44 +400,56 @@ mod rating_persist_owner_tests {
 }
 
 impl BackgroundTaskState {
-    pub(in crate::native_app) fn new(
+    pub(in crate::native_app) fn new_with_registrations(
         worker_sender: Sender<GuiMessage>,
         worker_receiver: Option<Receiver<GuiMessage>>,
         sources: Vec<wavecrate::sample_sources::SampleSource>,
-    ) -> Self {
+    ) -> (Self, Vec<SourceProcessingRegistration>) {
         #[cfg(test)]
         let recovery_root = sources.first().map(|source| source.root.join(".wavecrate"));
         #[cfg(not(test))]
         let recovery_root = None;
         #[cfg(not(test))]
-        let source_processing = Self::start_source_processing(&worker_sender, sources);
+        let (source_processing, registrations) =
+            Self::start_source_processing(&worker_sender, sources);
         #[cfg(test)]
-        let source_processing = {
-            drop(sources);
-            SourceProcessingSupervisor::dormant()
-        };
-        Self::with_source_processing(
+        let (source_processing, registrations) =
+            SourceProcessingSupervisor::dormant_with_sources(sources);
+        let state = Self::with_source_processing(
             worker_sender,
             worker_receiver,
             source_processing,
+            registrations.clone(),
             recovery_root,
-        )
+        );
+        (state, registrations)
     }
 
     #[cfg(any(test, feature = "legacy-controller"))]
-    pub(in crate::native_app) fn new_runtime(
+    pub(in crate::native_app) fn new_runtime_with_registrations(
         worker_sender: Sender<GuiMessage>,
         worker_receiver: Option<Receiver<GuiMessage>>,
         sources: Vec<wavecrate::sample_sources::SampleSource>,
-    ) -> Self {
-        let source_processing = Self::start_source_processing(&worker_sender, sources);
-        Self::with_source_processing(worker_sender, worker_receiver, source_processing, None)
+    ) -> (Self, Vec<SourceProcessingRegistration>) {
+        let (source_processing, registrations) =
+            Self::start_source_processing(&worker_sender, sources);
+        let state = Self::with_source_processing(
+            worker_sender,
+            worker_receiver,
+            source_processing,
+            registrations.clone(),
+            None,
+        );
+        (state, registrations)
     }
 
     fn start_source_processing(
         worker_sender: &Sender<GuiMessage>,
         sources: Vec<wavecrate::sample_sources::SampleSource>,
-    ) -> SourceProcessingSupervisor {
+    ) -> (
+        SourceProcessingSupervisor,
+        Vec<SourceProcessingRegistration>,
+    ) {
         SourceProcessingSupervisor::start_with_event_sink(
             sources,
             GuiSourceProcessingEventSink::new(worker_sender.clone()),
@@ -446,9 +460,18 @@ impl BackgroundTaskState {
         worker_sender: Sender<GuiMessage>,
         worker_receiver: Option<Receiver<GuiMessage>>,
         source_processing: SourceProcessingSupervisor,
+        registrations: Vec<SourceProcessingRegistration>,
         recovery_root: Option<PathBuf>,
     ) -> Self {
-        let source_lifecycle_generations = source_processing.lifecycle_generations();
+        let source_lifecycle_generations: BTreeMap<String, u64> = registrations
+            .iter()
+            .map(|registration| {
+                (
+                    registration.source.id.to_string(),
+                    registration.lifecycle_generation,
+                )
+            })
+            .collect();
         let waveform_recovery_root = recovery_root.map(|path| {
             let file = std::fs::File::open(&path).expect("test recovery root");
             let identity =
@@ -521,7 +544,7 @@ impl BackgroundTaskState {
 
     #[cfg(test)]
     pub(in crate::native_app) fn for_tests() -> Self {
-        Self::new(std::sync::mpsc::channel().0, None, Vec::new())
+        Self::new_with_registrations(std::sync::mpsc::channel().0, None, Vec::new()).0
     }
 
     pub(in crate::native_app) fn take_operation_journal_status(

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -20,6 +20,7 @@ use super::worker::{
 };
 use super::*;
 use crate::native_app::sample_library::source_watcher::GuiSourceWatcherHandle;
+use crate::native_app::source_processing::SourceProcessingRegistration;
 
 fn request(
     root: &Path,
@@ -480,7 +481,10 @@ fn stale_lifecycle_completion_has_no_committed_mutation_side_effects() {
         .select_file("before.wav".to_string());
 
     let (message_tx, message_rx) = mpsc::channel();
-    let watcher = GuiSourceWatcherHandle::spawn(vec![source.clone()], message_tx);
+    let watcher = GuiSourceWatcherHandle::spawn(
+        vec![SourceProcessingRegistration::new(source.clone(), 1)],
+        message_tx,
+    );
     watcher.wait_until_ready_for_tests();
     while message_rx.try_recv().is_ok() {}
     state.library.source_watcher = Some(watcher);

--- a/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
+++ b/src/native_app/sample_library/source_watcher/admission_lifecycle.rs
@@ -36,6 +36,8 @@ const NATIVE_ADMISSION_MAX_EVENTS_PER_LANE: usize = 512;
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(super) struct FseventsReplayEvidence {
+    /// Historical checkpoint generation; current source authority is transported separately by
+    /// `SourceProcessingRegistration` and must never be reconstructed from this evidence.
     pub(super) source_lifecycle_generation: WatcherGeneration,
     pub(super) replay_stream_generation: u64,
     pub(super) backend_device: u64,

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -40,6 +40,7 @@ use crate::native_app::sample_library::committed_file_mutations::{
 use crate::native_app::sample_library::source_watcher::{
     RevisionBoundCheckpoint, WatcherContinuityProof,
 };
+use crate::native_app::source_processing::SourceProcessingRegistration;
 
 struct ActiveSourceWatcher {
     _watcher: Box<dyn Watcher + Send>,
@@ -293,7 +294,7 @@ pub(in crate::native_app) struct GuiSourceWatcherHandle {
 
 impl GuiSourceWatcherHandle {
     pub(in crate::native_app) fn spawn(
-        sources: Vec<SampleSource>,
+        registrations: Vec<SourceProcessingRegistration>,
         message_tx: Sender<GuiMessage>,
     ) -> Self {
         let (command_tx, command_rx) = std::sync::mpsc::channel();
@@ -308,7 +309,9 @@ impl GuiSourceWatcherHandle {
         };
         let coordinator_lifecycle_tx = lifecycle_tx.clone();
         let handle = thread::spawn(move || match coordinator_lifecycle_tx {
-            Some(lifecycle_tx) => run_source_watcher(command_rx, message_tx, sources, lifecycle_tx),
+            Some(lifecycle_tx) => {
+                run_source_watcher(command_rx, message_tx, registrations, lifecycle_tx)
+            }
             None => run_source_watcher_without_lifecycle(command_rx),
         });
         Self {
@@ -318,10 +321,13 @@ impl GuiSourceWatcherHandle {
         }
     }
 
-    pub(in crate::native_app) fn replace_sources(&self, sources: Vec<SampleSource>) {
+    pub(in crate::native_app) fn replace_sources(
+        &self,
+        registrations: Vec<SourceProcessingRegistration>,
+    ) {
         let _ = self
             .command_tx
-            .send(GuiSourceWatchCommand::ReplaceSources(sources));
+            .send(GuiSourceWatchCommand::ReplaceSources(registrations));
     }
 
     pub(in crate::native_app) fn acknowledge_committed_paths(
@@ -453,7 +459,7 @@ impl Drop for GuiSourceWatcherHandle {
 
 #[derive(Debug)]
 enum GuiSourceWatchCommand {
-    ReplaceSources(Vec<SampleSource>),
+    ReplaceSources(Vec<SourceProcessingRegistration>),
     #[cfg(test)]
     ReconcileAllSources,
     AcknowledgeCommittedPaths {
@@ -491,7 +497,7 @@ enum GuiSourceWatchCommand {
 fn run_source_watcher(
     command_rx: Receiver<GuiSourceWatchCommand>,
     message_tx: Sender<GuiMessage>,
-    initial_sources: Vec<SampleSource>,
+    initial_registrations: Vec<SourceProcessingRegistration>,
     lifecycle_tx: Sender<SourceWatcherLifecycle>,
 ) {
     let (event_tx, event_rx) =
@@ -504,7 +510,7 @@ fn run_source_watcher(
         workers: Vec::new(),
     };
     let mut state = GuiSourceWatchState::default();
-    state.set_sources(initial_sources);
+    state.set_registrations(initial_registrations);
     let mut admission_lifecycle = AdmissionLifecycle::new();
     state.set_audit_request_capacity(admission_lifecycle.max_source_audit_request_entries());
     let mut pending_capture_contexts = HashMap::<DispatchTicket, PendingCaptureContext>::new();
@@ -522,11 +528,15 @@ fn run_source_watcher(
 
     loop {
         match command_rx.recv_timeout(WATCHER_POLL_INTERVAL) {
-            Ok(GuiSourceWatchCommand::ReplaceSources(sources)) => {
+            Ok(GuiSourceWatchCommand::ReplaceSources(registrations)) => {
                 let now = Instant::now();
+                let sources = registrations
+                    .iter()
+                    .map(|registration| registration.source.clone())
+                    .collect::<Vec<_>>();
                 let roots_changed =
                     desired_watched_roots(&sources) != desired_watched_roots(&state.sources);
-                state.set_sources(sources);
+                state.set_registrations(registrations);
                 if !reconcile_watcher_admission(
                     &mut state,
                     &mut admission_lifecycle,
@@ -1203,6 +1213,7 @@ struct PendingReplayHandoff {
     paths: Vec<PathBuf>,
     proof: WatcherContinuityProof,
     continuity_proven: bool,
+    source_processing_lifecycle_generation: u64,
 }
 
 #[derive(Clone)]
@@ -1211,7 +1222,23 @@ struct PendingReplayCheckpoint {
     source_root: PathBuf,
     root_identity: RootIdentity,
     owner_watcher_generation: WatcherGeneration,
+    source_processing_lifecycle_generation: u64,
     proof: WatcherContinuityProof,
+}
+
+fn replay_registration_matches_current(
+    state: &GuiSourceWatchState,
+    source_id: &SourceId,
+    source_root: &PathBuf,
+    lifecycle_generation: u64,
+) -> bool {
+    state
+        .registration_for_source(source_id.as_str())
+        .is_some_and(|registration| {
+            registration.source.id == *source_id
+                && registration.source.root == *source_root
+                && registration.lifecycle_generation == lifecycle_generation
+        })
 }
 
 fn capture_stream_id(capture: &SourceWatcherCapture) -> u64 {
@@ -1561,6 +1588,23 @@ fn handoff_dispatched_capture(
         state.mark_source_overflowed(context.source_id.as_str(), now);
         return (true, false);
     }
+    if let Some(replay) = context.replay.as_ref()
+        && !replay_registration_matches_current(
+            state,
+            &context.source_id,
+            &context.source_root,
+            replay.source_processing_lifecycle_generation,
+        )
+    {
+        tracing::warn!(
+            source_id = context.source_id.as_str(),
+            ticket = dispatched.ticket().id(),
+            lifecycle_generation = replay.source_processing_lifecycle_generation,
+            "Closed-application replay registration was replaced before typed handoff; retaining source audit fallback"
+        );
+        state.mark_source_overflowed(context.source_id.as_str(), now);
+        return (false, false);
+    }
     if source_audit && context.replay.is_none() {
         widen_source(state, &context.source_root, now);
         return (true, false);
@@ -1575,10 +1619,7 @@ fn handoff_dispatched_capture(
                 overflowed: false,
                 source_root_available: true,
                 source_root_identity: Some(replay.proof.root_identity.clone()),
-                // The replay/checkpoint generation is historical watcher authority, not the
-                // current source-processing lifecycle generation. This lane has no current-token
-                // transport yet; leave it unset so typed scopes fail closed at the GUI boundary.
-                lifecycle_generation: None,
+                lifecycle_generation: Some(replay.source_processing_lifecycle_generation),
                 journal_checkpoint_event_id: Some(replay.proof.acknowledged_end_event_id),
                 watcher_continuity_proof: Some(replay.proof.clone()),
             })
@@ -1705,6 +1746,8 @@ fn dispatch_pending_capture_contexts_with_replay(
                     source_root: context.source_root.clone(),
                     root_identity: context.root_identity.clone(),
                     owner_watcher_generation: context.watcher_generation,
+                    source_processing_lifecycle_generation: replay
+                        .source_processing_lifecycle_generation,
                     proof: replay.proof.clone(),
                 },
             );
@@ -2014,8 +2057,26 @@ fn publish_closed_app_journal_recovery(
             JournalRecovery::Changes {
                 paths,
                 proof,
-                source_lifecycle_generation,
+                historical_source_lifecycle_generation,
             } => {
+                let Some(registration) = state.registration_for_source(source.id.as_str()).cloned()
+                else {
+                    tracing::warn!(
+                        source_id = source.id.as_str(),
+                        "Closed-application replay has no current source-processing registration"
+                    );
+                    request_closed_app_journal_audit(
+                        message_tx,
+                        sources,
+                        audit_barriers,
+                        deferred_audit_barrier_sources,
+                        defer_audit_barriers,
+                        &source.id,
+                        "journal_replay_source_registration_unavailable",
+                    );
+                    continue;
+                };
+                let source = &registration.source;
                 tracing::info!(
                     source_id = source.id.as_str(),
                     path_count = paths.len(),
@@ -2120,7 +2181,7 @@ fn publish_closed_app_journal_recovery(
                     proof.watcher_generation,
                     FseventsReplayEvidence {
                         source_lifecycle_generation: WatcherGeneration::new(
-                            source_lifecycle_generation,
+                            historical_source_lifecycle_generation,
                         ),
                         replay_stream_generation: proof.watcher_generation,
                         backend_device: proof.backend_device,
@@ -2173,6 +2234,8 @@ fn publish_closed_app_journal_recovery(
                                 paths,
                                 proof,
                                 continuity_proven,
+                                source_processing_lifecycle_generation: registration
+                                    .lifecycle_generation,
                             }),
                         };
                         pending_contexts.insert(*ticket, context);
@@ -2218,7 +2281,7 @@ fn acknowledge_replay_checkpoint(
     state: &mut GuiSourceWatchState,
     admission: &mut AdmissionLifecycle,
     pending_replay_checkpoints: &mut HashMap<DispatchTicket, PendingReplayCheckpoint>,
-    sources: &[SampleSource],
+    _sources: &[SampleSource],
     request: RevisionBoundCheckpoint,
     now: Instant,
 ) {
@@ -2258,15 +2321,34 @@ fn acknowledge_replay_checkpoint(
         return;
     };
     let source_id = pending.source_id.clone();
-    let current_source_lifecycle_generation = WatcherGeneration::new(request.lifecycle_generation);
-    let Some(source) = sources.iter().find(|source| source.id == source_id) else {
+    let Some(registration) = state.registration_for_source(source_id.as_str()).cloned() else {
         tracing::warn!(
             source_id = source_id.as_str(),
-            "Replay checkpoint acknowledgement named a removed source"
+            "Replay checkpoint acknowledgement has no current source-processing registration"
         );
         pending_replay_checkpoints.remove(&ticket);
+        state.mark_source_overflowed(source_id.as_str(), now);
         return;
     };
+    if registration.source.root != pending.source_root
+        || registration.lifecycle_generation != pending.source_processing_lifecycle_generation
+        || request.lifecycle_generation != registration.lifecycle_generation
+    {
+        tracing::warn!(
+            source_id = source_id.as_str(),
+            ticket = ticket.id(),
+            captured_lifecycle_generation = pending.source_processing_lifecycle_generation,
+            current_lifecycle_generation = registration.lifecycle_generation,
+            requested_lifecycle_generation = request.lifecycle_generation,
+            "Replay checkpoint acknowledgement crossed a source-processing lifecycle boundary; retaining source audit fallback"
+        );
+        pending_replay_checkpoints.remove(&ticket);
+        state.mark_source_overflowed(source_id.as_str(), now);
+        return;
+    }
+    let source = &registration.source;
+    let current_source_lifecycle_generation =
+        WatcherGeneration::new(registration.lifecycle_generation);
     let database_root = match source.database_root() {
         Ok(root) => root,
         Err(error) => {
@@ -3183,10 +3265,54 @@ mod lifecycle_tests {
     }
 
     fn source_watcher_state(sources: Vec<SampleSource>) -> GuiSourceWatchState {
+        let registrations = sources
+            .iter()
+            .cloned()
+            .map(|source| SourceProcessingRegistration::new(source, 1))
+            .collect();
         GuiSourceWatchState {
+            registrations,
             sources,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn replay_registration_revalidation_rejects_replaced_source_generation() {
+        let first_root = tempfile::tempdir().expect("first source root");
+        let replacement_root = tempfile::tempdir().expect("replacement source root");
+        let first = source_with_root("replay-registration-race", first_root.path());
+        let replacement = source_with_root("replay-registration-race", replacement_root.path());
+        let mut state = source_watcher_state(vec![first.clone()]);
+
+        assert!(replay_registration_matches_current(
+            &state,
+            &first.id,
+            &first.root,
+            1,
+        ));
+        state.set_registrations(vec![SourceProcessingRegistration::new(
+            replacement.clone(),
+            2,
+        )]);
+        assert!(!replay_registration_matches_current(
+            &state,
+            &first.id,
+            &first.root,
+            1,
+        ));
+        assert!(!replay_registration_matches_current(
+            &state,
+            &replacement.id,
+            &replacement.root,
+            1,
+        ));
+        assert!(replay_registration_matches_current(
+            &state,
+            &replacement.id,
+            &replacement.root,
+            2,
+        ));
     }
 
     fn notify_capture(root: &Path, stream_id: u64, paths: &[&str]) -> SourceWatcherCapture {
@@ -4008,6 +4134,7 @@ mod lifecycle_tests {
                 source_root: first.root.clone(),
                 root_identity: first_lane.root_identity().clone(),
                 owner_watcher_generation: first_lane.generation(),
+                source_processing_lifecycle_generation: 1,
                 proof: journal::WatcherContinuityProof {
                     root_identity: "identity-0".to_string(),
                     backend: journal::WatcherBackend::Fsevents,
@@ -4085,6 +4212,7 @@ mod lifecycle_tests {
             source_root: replacement.root.clone(),
             root_identity: rebound_root_identity,
             owner_watcher_generation: stopped_generation,
+            source_processing_lifecycle_generation: 1,
             proof: stale_root_pending.proof.clone(),
         };
         pending_replay_checkpoints.insert(first_ticket, stale_lane_pending.clone());
@@ -4163,6 +4291,7 @@ mod lifecycle_tests {
         }
 
         let mut state = source_watcher_state(vec![source.clone()]);
+        state.set_registrations(vec![SourceProcessingRegistration::new(source.clone(), 2)]);
         let mut admission = configured_admission(&state.sources);
         let lane = admission
             .lane_for_capture(&source_id)
@@ -4221,6 +4350,7 @@ mod lifecycle_tests {
                 source_root: source.root.clone(),
                 root_identity: lane.root_identity().clone(),
                 owner_watcher_generation: lane.generation(),
+                source_processing_lifecycle_generation: 2,
                 proof: proof.clone(),
             },
         )]);
@@ -4265,6 +4395,10 @@ mod lifecycle_tests {
         let second = source_with_root("closed-replay-fallback-second", directory.path());
         let sources = vec![first.clone(), second.clone()];
         let mut state = source_watcher_state(sources.clone());
+        state.set_registrations(vec![
+            SourceProcessingRegistration::new(first.clone(), 1),
+            SourceProcessingRegistration::new(second.clone(), 2),
+        ]);
         state.watched_roots =
             HashMap::from([(first.root.clone(), Some(String::from("identity-1")))]);
         let mut admission = limited_admission(&sources, 1);
@@ -4389,6 +4523,7 @@ mod lifecycle_tests {
                 source_root: second.root.clone(),
                 root_identity: second_lane.root_identity().clone(),
                 owner_watcher_generation: second_lane.generation(),
+                source_processing_lifecycle_generation: 2,
                 proof: second_proof.clone(),
             },
         )]);
@@ -4483,6 +4618,10 @@ mod lifecycle_tests {
         let second = source_with_root("unproven-replay-second", directory.path());
         let sources = vec![first.clone(), second.clone()];
         let mut state = source_watcher_state(sources.clone());
+        state.set_registrations(vec![
+            SourceProcessingRegistration::new(first.clone(), 1),
+            SourceProcessingRegistration::new(second.clone(), 2),
+        ]);
         state.watched_roots =
             HashMap::from([(first.root.clone(), Some(String::from("identity-1")))]);
         let mut admission = configured_admission(&sources);
@@ -4645,6 +4784,7 @@ mod lifecycle_tests {
                         paths: vec![PathBuf::from("first.wav")],
                         proof: first_proof,
                         continuity_proven: false,
+                        source_processing_lifecycle_generation: 1,
                     }),
                 },
             ),
@@ -4665,6 +4805,7 @@ mod lifecycle_tests {
                         paths: vec![PathBuf::from("second.wav")],
                         proof: second_proof.clone(),
                         continuity_proven: true,
+                        source_processing_lifecycle_generation: 2,
                     }),
                 },
             ),
@@ -4730,7 +4871,7 @@ mod lifecycle_tests {
                     source_root_identity,
                     Some(second_proof.root_identity.clone())
                 );
-                assert_eq!(lifecycle_generation, None);
+                assert_eq!(lifecycle_generation, Some(2));
                 assert_eq!(journal_checkpoint_event_id, Some(21));
                 assert_eq!(watcher_continuity_proof, Some(second_proof.clone()));
             }
@@ -4773,6 +4914,10 @@ mod lifecycle_tests {
         let second = source_with_root("replay-failure-second", second_directory.path());
         let sources = vec![first.clone(), second.clone()];
         let mut state = source_watcher_state(sources.clone());
+        state.set_registrations(vec![
+            SourceProcessingRegistration::new(first.clone(), 2),
+            SourceProcessingRegistration::new(second.clone(), 2),
+        ]);
         state.watched_roots = HashMap::from([
             (first.root.clone(), Some(String::from("identity-0"))),
             (second.root.clone(), Some(String::from("identity-1"))),
@@ -4918,6 +5063,7 @@ mod lifecycle_tests {
                     source_root: first.root.clone(),
                     root_identity: first_lane.root_identity().clone(),
                     owner_watcher_generation: first_lane.generation(),
+                    source_processing_lifecycle_generation: 2,
                     proof: first_proof.clone(),
                 },
             ),
@@ -4928,6 +5074,7 @@ mod lifecycle_tests {
                     source_root: second.root.clone(),
                     root_identity: second_lane.root_identity().clone(),
                     owner_watcher_generation: second_lane.generation(),
+                    source_processing_lifecycle_generation: 2,
                     proof: second_proof.clone(),
                 },
             ),
@@ -4996,6 +5143,7 @@ mod lifecycle_tests {
             source_root: first.root.clone(),
             root_identity: restarted_first.root_identity().clone(),
             owner_watcher_generation: restarted_first.generation(),
+            source_processing_lifecycle_generation: 2,
             proof: first_proof.clone(),
         };
         pending_replay_checkpoints.insert(first_ticket, stopped_first_pending.clone());

--- a/src/native_app/sample_library/source_watcher/journal.rs
+++ b/src/native_app/sample_library/source_watcher/journal.rs
@@ -624,7 +624,7 @@ pub(super) enum JournalRecovery {
     Changes {
         paths: Vec<PathBuf>,
         proof: WatcherContinuityProof,
-        source_lifecycle_generation: u64,
+        historical_source_lifecycle_generation: u64,
     },
     FullAudit {
         reason: &'static str,
@@ -651,7 +651,7 @@ fn classify_replayed_paths(
     source: &SampleSource,
     paths: Vec<PathBuf>,
     proof: WatcherContinuityProof,
-    source_lifecycle_generation: u64,
+    historical_source_lifecycle_generation: u64,
 ) -> JournalRecovery {
     let paths = paths
         .into_iter()
@@ -669,7 +669,7 @@ fn classify_replayed_paths(
         JournalRecovery::Changes {
             paths,
             proof,
-            source_lifecycle_generation,
+            historical_source_lifecycle_generation,
         }
     }
 }
@@ -717,13 +717,16 @@ fn recover_source(source: &SampleSource, native_watcher: bool) -> JournalRecover
 
     #[cfg(target_os = "macos")]
     {
-        let source_lifecycle_generation = checkpoint
+        let historical_source_lifecycle_generation = checkpoint
             .revision_bound()
             .map_or(0, |checkpoint| checkpoint.lifecycle_generation);
         match replay_fsevents(&source.root, root_identity, checkpoint.event_id) {
-            Ok((paths, proof)) => {
-                classify_replayed_paths(source, paths, proof, source_lifecycle_generation)
-            }
+            Ok((paths, proof)) => classify_replayed_paths(
+                source,
+                paths,
+                proof,
+                historical_source_lifecycle_generation,
+            ),
             Err(reason) => JournalRecovery::FullAudit { reason },
         }
     }
@@ -1234,7 +1237,7 @@ mod tests {
             JournalRecovery::Changes {
                 paths: vec![PathBuf::from("kick.wav")],
                 proof,
-                source_lifecycle_generation: 4,
+                historical_source_lifecycle_generation: 4,
             }
         );
     }

--- a/src/native_app/sample_library/source_watcher/state.rs
+++ b/src/native_app/sample_library/source_watcher/state.rs
@@ -17,6 +17,7 @@ use super::roots::{
 use crate::native_app::sample_library::committed_file_mutations::{
     CommittedWatcherEcho, CommittedWatcherPathState, RevisionFirstCursor,
 };
+use crate::native_app::source_processing::SourceProcessingRegistration;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum AuditRequestQueueOutcome {
@@ -157,6 +158,7 @@ impl PendingSourceAuditRequests {
 #[derive(Default)]
 pub(super) struct GuiSourceWatchState {
     pub(super) watched_roots: WatchedRootIdentities,
+    pub(super) registrations: Vec<SourceProcessingRegistration>,
     pub(super) sources: Vec<SampleSource>,
     pub(super) pending: HashMap<String, PendingGuiSourceWatch>,
     pub(super) acknowledged_paths: HashMap<(String, PathBuf), (CommittedWatcherPathState, Instant)>,
@@ -164,7 +166,31 @@ pub(super) struct GuiSourceWatchState {
 }
 
 impl GuiSourceWatchState {
+    #[cfg(test)]
     pub(super) fn set_sources(&mut self, sources: Vec<SampleSource>) {
+        self.registrations.clear();
+        self.set_source_list(sources);
+    }
+
+    pub(super) fn set_registrations(&mut self, registrations: Vec<SourceProcessingRegistration>) {
+        let sources = registrations
+            .iter()
+            .map(|registration| registration.source.clone())
+            .collect();
+        self.registrations = registrations;
+        self.set_source_list(sources);
+    }
+
+    pub(super) fn registration_for_source(
+        &self,
+        source_id: &str,
+    ) -> Option<&SourceProcessingRegistration> {
+        self.registrations
+            .iter()
+            .find(|registration| registration.source.id.as_str() == source_id)
+    }
+
+    fn set_source_list(&mut self, sources: Vec<SampleSource>) {
         self.sources = sources;
         let allowed = self
             .sources
@@ -468,7 +494,44 @@ fn root_event_can_replace_identity(kind: notify::EventKind) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::native_app::source_processing::SourceProcessingRegistration;
     use wavecrate::sample_sources::{SampleSource, SourceId};
+
+    #[test]
+    fn registration_transport_replaces_descriptor_and_generation_as_one_pair() {
+        let first = SampleSource::new_with_id(
+            SourceId::from_string("registration-state"),
+            PathBuf::from("/first-root"),
+        );
+        let replacement =
+            SampleSource::new_with_id(first.id.clone(), PathBuf::from("/replacement-root"));
+        let mut state = GuiSourceWatchState::default();
+
+        state.set_registrations(vec![SourceProcessingRegistration::new(first, 7)]);
+        assert_eq!(
+            state
+                .registration_for_source("registration-state")
+                .expect("initial registration")
+                .lifecycle_generation,
+            7
+        );
+
+        state.set_registrations(vec![SourceProcessingRegistration::new(replacement, 8)]);
+        let registration = state
+            .registration_for_source("registration-state")
+            .expect("replacement registration");
+        assert_eq!(registration.lifecycle_generation, 8);
+        assert_eq!(registration.source.root, PathBuf::from("/replacement-root"));
+        assert_eq!(state.sources.len(), 1);
+
+        state.set_registrations(Vec::new());
+        assert!(
+            state
+                .registration_for_source("registration-state")
+                .is_none()
+        );
+        assert!(state.sources.is_empty());
+    }
 
     #[test]
     fn source_id_overflow_does_not_widen_shared_root_source() {

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -16,6 +16,7 @@ use wavecrate::sample_sources::{SampleSource, SourceDatabase, SourceId};
 use wavecrate_scan::sample_sources::scanner::{scan_once, sync_paths};
 
 use crate::native_app::app::GuiMessage;
+use crate::native_app::source_processing::SourceProcessingRegistration;
 
 #[path = "tests/committed_mutations.rs"]
 mod committed_mutations;
@@ -617,7 +618,13 @@ fn foreground_reconciliation_request_refreshes_every_configured_source() {
         second.id.as_str().to_string(),
     ];
     let (sender, receiver) = std::sync::mpsc::channel();
-    let watcher = GuiSourceWatcherHandle::spawn(vec![first, second], sender);
+    let watcher = GuiSourceWatcherHandle::spawn(
+        vec![
+            SourceProcessingRegistration::new(first, 1),
+            SourceProcessingRegistration::new(second, 1),
+        ],
+        sender,
+    );
     watcher.wait_until_ready_for_tests();
     while !matches!(
         receiver
@@ -675,9 +682,12 @@ fn idempotent_startup_source_sync_does_not_refresh_every_source() {
         root.path().to_path_buf(),
     );
     let (sender, receiver) = std::sync::mpsc::channel();
-    let watcher = GuiSourceWatcherHandle::spawn(vec![source.clone()], sender);
+    let watcher = GuiSourceWatcherHandle::spawn(
+        vec![SourceProcessingRegistration::new(source.clone(), 1)],
+        sender,
+    );
 
-    watcher.replace_sources(vec![source]);
+    watcher.replace_sources(vec![SourceProcessingRegistration::new(source, 1)]);
     watcher.wait_until_ready_for_tests();
     std::thread::sleep(
         super::SOURCE_CHANGE_DEBOUNCE + super::WATCHER_POLL_INTERVAL.saturating_mul(2),
@@ -724,7 +734,8 @@ fn filesystem_event_after_initial_watcher_ready_is_not_suppressed() {
     );
     let source_id = source.id.as_str().to_string();
     let (sender, receiver) = std::sync::mpsc::channel();
-    let watcher = GuiSourceWatcherHandle::spawn(vec![source], sender);
+    let watcher =
+        GuiSourceWatcherHandle::spawn(vec![SourceProcessingRegistration::new(source, 1)], sender);
     watcher.wait_until_ready_for_tests();
     while !matches!(
         receiver
@@ -772,7 +783,8 @@ fn stale_error_and_overflow_widen_without_retiring_current_watcher() {
     );
     let source_id = source.id.as_str().to_string();
     let (sender, receiver) = std::sync::mpsc::channel();
-    let watcher = GuiSourceWatcherHandle::spawn(vec![source], sender);
+    let watcher =
+        GuiSourceWatcherHandle::spawn(vec![SourceProcessingRegistration::new(source, 1)], sender);
     watcher.wait_until_ready_for_tests();
     while !matches!(
         receiver
@@ -844,7 +856,8 @@ fn watcher_restarts_and_overflows_when_a_live_root_is_replaced_at_the_same_path(
     );
     let expected_source_id = source.id.as_str().to_string();
     let (sender, receiver) = std::sync::mpsc::channel();
-    let watcher = GuiSourceWatcherHandle::spawn(vec![source], sender);
+    let watcher =
+        GuiSourceWatcherHandle::spawn(vec![SourceProcessingRegistration::new(source, 1)], sender);
     watcher.wait_until_ready_for_tests();
     while !matches!(
         receiver

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -44,27 +44,36 @@ impl NativeAppState {
         let startup_folder_verify_pending =
             has_configured_sources && folder_browser.selected_source_loaded();
         let (worker_sender, worker_receiver) = mpsc::channel();
-        let source_watcher = has_configured_sources.then(|| {
-            crate::native_app::sample_library::source_watcher::GuiSourceWatcherHandle::spawn(
-                config.sources.clone(),
-                worker_sender.clone(),
-            )
-        });
+        let watcher_message_sender = worker_sender.clone();
         #[cfg(any(test, feature = "legacy-controller"))]
-        let background = if start_runtime_background {
-            BackgroundTaskState::new_runtime(
+        let (background, source_registrations) = if start_runtime_background {
+            BackgroundTaskState::new_runtime_with_registrations(
                 worker_sender,
                 Some(worker_receiver),
                 config.sources.clone(),
             )
         } else {
-            BackgroundTaskState::new(worker_sender, Some(worker_receiver), config.sources.clone())
+            BackgroundTaskState::new_with_registrations(
+                worker_sender,
+                Some(worker_receiver),
+                config.sources.clone(),
+            )
         };
         #[cfg(not(any(test, feature = "legacy-controller")))]
-        let background = {
+        let (background, source_registrations) = {
             let _ = start_runtime_background;
-            BackgroundTaskState::new(worker_sender, Some(worker_receiver), config.sources.clone())
+            BackgroundTaskState::new_with_registrations(
+                worker_sender,
+                Some(worker_receiver),
+                config.sources.clone(),
+            )
         };
+        let source_watcher = has_configured_sources.then(|| {
+            crate::native_app::sample_library::source_watcher::GuiSourceWatcherHandle::spawn(
+                source_registrations,
+                watcher_message_sender,
+            )
+        });
         let audio = AudioAppState::from_settings(&config.core);
         let startup = StartupState::new(
             startup_source_scan_pending,
@@ -131,20 +140,30 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn sync_source_watcher(&mut self) {
         let sources = self.library.folder_browser.configured_sample_sources();
-        if let Err(error) = self
+        let registrations = match self
             .background
             .source_processing
             .replace_sources(sources.clone())
         {
-            tracing::error!(
+            Ok(registrations) => registrations,
+            Err(error) => {
+                tracing::error!(
                 target: "wavecrate::source_processing",
                 error,
                 "Configured sources remain unchanged because retirement fencing failed"
-            );
-            return;
-        }
-        self.background.source_lifecycle_generations =
-            self.background.source_processing.lifecycle_generations();
+                );
+                return;
+            }
+        };
+        self.background.source_lifecycle_generations = registrations
+            .iter()
+            .map(|registration| {
+                (
+                    registration.source.id.to_string(),
+                    registration.lifecycle_generation,
+                )
+            })
+            .collect();
         self.background
             .rating_persist
             .retain_current_lifecycles(&self.background.source_lifecycle_generations);
@@ -168,16 +187,16 @@ impl NativeAppState {
             self.background.source_processing_progress = None;
             self.ui.chrome.job_details_open = false;
         }
-        if sources.is_empty() {
+        if registrations.is_empty() {
             self.library.source_watcher = None;
             return;
         }
         match &self.library.source_watcher {
-            Some(watcher) => watcher.replace_sources(sources),
+            Some(watcher) => watcher.replace_sources(registrations),
             None => {
                 self.library.source_watcher = Some(
                     crate::native_app::sample_library::source_watcher::GuiSourceWatcherHandle::spawn(
-                        sources,
+                        registrations,
                         self.background.worker_sender.clone(),
                     ),
                 );

--- a/src/native_app/source_processing/mod.rs
+++ b/src/native_app/source_processing/mod.rs
@@ -12,7 +12,8 @@ pub(in crate::native_app) use events::{
 };
 pub(in crate::native_app) use supervisor::{
     ExternalScanHandoff, ProjectionHandoffTicket, SourceAuditLifecycleCause,
-    SourceProcessingBudgetHandle, SourceProcessingSupervisor, SourceScanAdmissionState,
+    SourceProcessingBudgetHandle, SourceProcessingRegistration, SourceProcessingSupervisor,
+    SourceScanAdmissionState,
 };
 pub(in crate::native_app) use worker::run_internal_source_analysis_from_args;
 #[cfg(not(test))]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -100,6 +100,7 @@ pub(in crate::native_app) use admission::{
 };
 use cache_ownership::*;
 pub(in crate::native_app) use commands::SourceAuditLifecycleCause;
+pub(in crate::native_app) use control::SourceProcessingRegistration;
 use control::*;
 use coordination::*;
 use coordinator::*;

--- a/src/native_app/source_processing/supervisor/control.rs
+++ b/src/native_app/source_processing/supervisor/control.rs
@@ -7,6 +7,25 @@ use crate::native_app::sample_library::source_watcher::RevisionBoundCheckpoint;
 use std::collections::VecDeque;
 use wavecrate_library::sample_sources::reconciliation::SourceAuditRequest;
 
+/// The supervisor-owned source descriptor and its current source-processing lifecycle epoch.
+///
+/// This pair is the only runtime transport for source lifecycle authority. Consumers may retain
+/// it, but they must not reconstruct it by pairing descriptors with a later generation snapshot.
+#[derive(Clone, Debug)]
+pub(in crate::native_app) struct SourceProcessingRegistration {
+    pub(in crate::native_app) source: SampleSource,
+    pub(in crate::native_app) lifecycle_generation: u64,
+}
+
+impl SourceProcessingRegistration {
+    pub(in crate::native_app) fn new(source: SampleSource, lifecycle_generation: u64) -> Self {
+        Self {
+            source,
+            lifecycle_generation,
+        }
+    }
+}
+
 pub(super) struct ControlState {
     pub(super) sources: BTreeMap<String, SampleSource>,
     pub(super) source_work_cancels: BTreeMap<String, Arc<AtomicBool>>,
@@ -44,6 +63,20 @@ pub(super) struct ControlState {
 }
 
 impl ControlState {
+    pub(super) fn source_registrations(&self) -> Vec<SourceProcessingRegistration> {
+        self.sources
+            .iter()
+            .filter_map(|(source_id, source)| {
+                self.source_lifecycle_generations
+                    .get(source_id)
+                    .copied()
+                    .map(|lifecycle_generation| {
+                        SourceProcessingRegistration::new(source.clone(), lifecycle_generation)
+                    })
+            })
+            .collect()
+    }
+
     pub(super) fn source_is_configured(&self, source_id: &str) -> bool {
         self.sources.contains_key(source_id) && !self.quarantined_sources.contains(source_id)
     }

--- a/src/native_app/source_processing/supervisor/lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/lifecycle.rs
@@ -8,7 +8,7 @@ impl SourceProcessingSupervisor {
     pub(in crate::native_app) fn replace_sources(
         &self,
         sources: Vec<SampleSource>,
-    ) -> Result<(), String> {
+    ) -> Result<Vec<super::SourceProcessingRegistration>, String> {
         let _replacement = self
             .shared
             .source_replacement
@@ -27,11 +27,13 @@ impl SourceProcessingSupervisor {
                 control.quarantined_sources.clear();
                 control.reset_source_work_tokens();
                 control.mark_all_sources_dirty("configured_sources_reactivated");
+                let registrations = control.source_registrations();
                 drop(control);
                 self.shared.budget_wake.notify_all();
                 self.shared.wake.notify_all();
+                return Ok(registrations);
             }
-            return Ok(());
+            return Ok(control.source_registrations());
         }
         let changed_source_ids = control
             .sources
@@ -231,10 +233,11 @@ impl SourceProcessingSupervisor {
                     == Some(&health.lifecycle.generation)
             });
         control.notify("configured_sources_changed");
+        let registrations = control.source_registrations();
         drop(control);
         self.shared.budget_wake.notify_all();
         self.shared.wake.notify_all();
         self.shared.retirement_wake.notify_all();
-        Ok(())
+        Ok(registrations)
     }
 }

--- a/src/native_app/source_processing/supervisor/startup.rs
+++ b/src/native_app/source_processing/supervisor/startup.rs
@@ -12,7 +12,7 @@ impl SourceProcessingSupervisor {
     pub(in crate::native_app) fn start_with_event_sink(
         sources: Vec<SampleSource>,
         event_sink: impl SourceProcessingEventSink + 'static,
-    ) -> Self {
+    ) -> (Self, Vec<super::SourceProcessingRegistration>) {
         Self::start_with_options(sources, false, Some(Arc::new(event_sink)), false)
     }
 
@@ -30,7 +30,8 @@ impl SourceProcessingSupervisor {
         playback_active: bool,
         event_sink: Option<Arc<dyn SourceProcessingEventSink>>,
     ) -> Self {
-        Self::start_with_options(sources, playback_active, event_sink, false)
+        let (supervisor, _) = Self::start_with_options(sources, playback_active, event_sink, false);
+        supervisor
     }
 
     fn start_with_options(
@@ -38,11 +39,15 @@ impl SourceProcessingSupervisor {
         playback_active: bool,
         event_sink: Option<Arc<dyn SourceProcessingEventSink>>,
         synthetic_test_execution: bool,
-    ) -> Self {
+    ) -> (Self, Vec<super::SourceProcessingRegistration>) {
         let app_root = wavecrate::app_dirs::app_root_dir()
             .expect("source-processing supervisor should resolve its persistence root");
         let shared = Arc::new(Shared::new(sources, event_sink));
-        shared.control().playback_active = playback_active;
+        let registrations = {
+            let mut control = shared.control();
+            control.playback_active = playback_active;
+            control.source_registrations()
+        };
         shared
             .synthetic_test_execution
             .store(synthetic_test_execution, Ordering::Release);
@@ -64,11 +69,14 @@ impl SourceProcessingSupervisor {
                 run_retirement_worker(retirement_shared);
             })
             .expect("spawn source retirement worker");
-        Self {
-            shared,
-            coordinator: Some(coordinator),
-            retirement_worker: Some(retirement_worker),
-        }
+        (
+            Self {
+                shared,
+                coordinator: Some(coordinator),
+                retirement_worker: Some(retirement_worker),
+            },
+            registrations,
+        )
     }
 
     #[cfg(test)]
@@ -78,6 +86,22 @@ impl SourceProcessingSupervisor {
             coordinator: None,
             retirement_worker: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn dormant_with_sources(
+        sources: Vec<SampleSource>,
+    ) -> (Self, Vec<super::SourceProcessingRegistration>) {
+        let shared = Arc::new(Shared::new(sources, None));
+        let registrations = shared.control().source_registrations();
+        (
+            Self {
+                shared,
+                coordinator: None,
+                retirement_worker: None,
+            },
+            registrations,
+        )
     }
 
     #[cfg(any(test, feature = "legacy-controller"))]
@@ -90,7 +114,15 @@ impl SourceProcessingSupervisor {
         sources: Vec<SampleSource>,
         playback_active: bool,
     ) -> Self {
-        Self::start_with_options(sources, playback_active, None, true)
+        let (supervisor, _) = Self::start_with_options(sources, playback_active, None, true);
+        supervisor
+    }
+
+    #[cfg(test)]
+    pub(super) fn start_with_registrations(
+        sources: Vec<SampleSource>,
+    ) -> (Self, Vec<super::SourceProcessingRegistration>) {
+        Self::start_with_options(sources, false, None, true)
     }
 
     #[cfg(test)]

--- a/src/native_app/source_processing/supervisor/tests/lifecycle_retirement.rs
+++ b/src/native_app/source_processing/supervisor/tests/lifecycle_retirement.rs
@@ -1,4 +1,42 @@
 #[test]
+fn source_registrations_remain_supervisor_owned_across_startup_and_replacement() {
+    let first_root = tempfile::tempdir().expect("first source root");
+    let replacement_root = tempfile::tempdir().expect("replacement source root");
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("registration-owner"),
+        first_root.path().to_path_buf(),
+    );
+    let replacement =
+        SampleSource::new_with_id(source.id.clone(), replacement_root.path().to_path_buf());
+
+    let (mut supervisor, startup_registrations) =
+        SourceProcessingSupervisor::start_with_registrations(vec![source.clone()]);
+    assert_eq!(startup_registrations.len(), 1);
+    assert_eq!(startup_registrations[0].source.root, source.root);
+    let startup_generation = startup_registrations[0].lifecycle_generation;
+
+    let unchanged = supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("unchanged source registration");
+    assert_eq!(unchanged[0].lifecycle_generation, startup_generation);
+    assert_eq!(unchanged[0].source.root, source.root);
+
+    let replaced = supervisor
+        .replace_sources(vec![replacement.clone()])
+        .expect("changed source registration");
+    assert_eq!(replaced[0].source.root, replacement.root);
+    assert_ne!(replaced[0].lifecycle_generation, startup_generation);
+
+    assert!(
+        supervisor
+            .replace_sources(Vec::new())
+            .expect("removed source registration")
+            .is_empty()
+    );
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
 fn playback_active_does_not_block_hash_backlog_and_shutdown_joins() {
     let (_directory, source) = unhashed_source("playing");
     let mut supervisor =
@@ -89,7 +127,10 @@ fn retirement_logging_is_bounded_at_info_and_detailed_at_debug() {
     assert!(info.contains("offline=2"));
     assert!(!info.contains("source_processing.retirement.started"));
     assert!(!info.contains("source_processing.retirement.offline"));
-    assert_eq!(info.matches("source_processing.retirement.sweep").count(), 1);
+    assert_eq!(
+        info.matches("source_processing.retirement.sweep").count(),
+        1
+    );
     assert_eq!(info_supervisor.shutdown()["joined"], true);
 
     let mut debug_supervisor = offline_retirement_supervisor("debug-retirement");
@@ -423,10 +464,12 @@ fn busy_source_discovery_is_rescheduled_after_retry_deadline() {
                     SourceProcessingHealthState::Processing | SourceProcessingHealthState::Ready
                 )
             {
-                assert!(!health
-                    .failure_codes
-                    .iter()
-                    .any(|code| code == "discovery_retry_pending"));
+                assert!(
+                    !health
+                        .failure_codes
+                        .iter()
+                        .any(|code| code == "discovery_retry_pending")
+                );
                 saw_recovered_health = true;
             }
         }

--- a/src/native_app/tests/config_sources/scan_handoff.rs
+++ b/src/native_app/tests/config_sources/scan_handoff.rs
@@ -212,6 +212,56 @@ fn typed_replay_without_producer_lifecycle_generation_routes_to_audit() {
 }
 
 #[test]
+fn typed_replay_with_current_generation_reaches_audit_only_scanner_boundary() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 107)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let mut context = ui::UiUpdateContext::default();
+    let source = state
+        .library
+        .folder_browser
+        .configured_sample_sources()
+        .into_iter()
+        .find(|source| source.id.as_str() == source_id)
+        .expect("configured typed replay source");
+    let current_generation = state
+        .background
+        .source_processing
+        .register_source_for_scan(source)
+        .expect("register typed replay source");
+    state
+        .background
+        .source_lifecycle_generations
+        .insert(source_id.clone(), current_generation);
+    let proof = replay_proof(source_root.path(), 12);
+
+    state.refresh_source_after_filesystem_change(
+        source_id.clone(),
+        Some(typed_scopes()),
+        vec![PathBuf::from("typed-replay.wav")],
+        false,
+        true,
+        Some(proof.root_identity.clone()),
+        Some(current_generation),
+        Some(12),
+        Some(proof),
+        &mut context,
+    );
+
+    assert!(
+        state
+            .library
+            .targeted_source_sync_active_for_tests(&source_id),
+        "matching producer lifecycle authority must reach the typed worker boundary"
+    );
+}
+
+#[test]
 fn mismatched_folder_scan_registration_cannot_adopt_existing_source_generation() {
     let requested_root = tempfile::tempdir().expect("requested source root");
     let authoritative_root = tempfile::tempdir().expect("authoritative source root");

--- a/src/test_support/source_processing_liveness/harness.rs
+++ b/src/test_support/source_processing_liveness/harness.rs
@@ -23,7 +23,10 @@ impl LivenessHarness {
                 .protected();
         source.open_db().expect("create liveness source database");
         let (watcher_tx, watcher_rx) = std::sync::mpsc::channel();
-        let watcher = GuiSourceWatcherHandle::spawn(vec![source.clone()], watcher_tx);
+        let watcher = GuiSourceWatcherHandle::spawn(
+            vec![SourceProcessingRegistration::new(source.clone(), 1)],
+            watcher_tx,
+        );
         watcher.wait_until_ready_for_tests();
         let supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
         Self {
@@ -181,7 +184,7 @@ impl LivenessHarness {
     pub(super) fn restart_runtime(&mut self) {
         let (watcher_tx, watcher_rx) = std::sync::mpsc::channel();
         self.watcher = Some(GuiSourceWatcherHandle::spawn(
-            vec![self.source.clone()],
+            vec![SourceProcessingRegistration::new(self.source.clone(), 1)],
             watcher_tx,
         ));
         self.watcher

--- a/src/test_support/source_processing_liveness/mod.rs
+++ b/src/test_support/source_processing_liveness/mod.rs
@@ -26,6 +26,7 @@ use crate::native_app::sample_library::committed_file_mutations::{
 };
 use crate::native_app::sample_library::folder_scan_actions::sync_source_database_paths;
 use crate::native_app::sample_library::source_watcher::GuiSourceWatcherHandle;
+use crate::native_app::source_processing::SourceProcessingRegistration;
 
 mod artifacts;
 mod diagnostics;

--- a/src/test_support/source_processing_liveness/scenarios.rs
+++ b/src/test_support/source_processing_liveness/scenarios.rs
@@ -249,7 +249,10 @@ fn source_processing_liveness_harness_converges_restart_churn_and_root_recovery(
         .watcher
         .as_ref()
         .expect("active watcher")
-        .replace_sources(vec![harness.source.clone()]);
+        .replace_sources(vec![SourceProcessingRegistration::new(
+            harness.source.clone(),
+            1,
+        )]);
     harness.force_watcher_restart();
     harness.await_fully_ready();
 

--- a/src/test_support/source_processing_state_machine/harness.rs
+++ b/src/test_support/source_processing_state_machine/harness.rs
@@ -381,8 +381,7 @@ pub(super) fn start_observed_supervisor(
     source: &SampleSource,
 ) -> (SourceProcessingSupervisor, Receiver<SourceProcessingEvent>) {
     let (event_sender, event_receiver) = mpsc::channel();
-    (
-        SourceProcessingSupervisor::start_with_event_sink(vec![source.clone()], event_sender),
-        event_receiver,
-    )
+    let (supervisor, _) =
+        SourceProcessingSupervisor::start_with_event_sink(vec![source.clone()], event_sender);
+    (supervisor, event_receiver)
 }


### PR DESCRIPTION
## Goal

Transport the supervisor-owned source descriptor and current source-processing lifecycle generation atomically through watcher startup, configured-source replacement, closed-application replay admission, and GUI handoff.

## Scope and non-goals

This PR:
- adds a supervisor-owned `SourceProcessingRegistration` pair;
- returns registration pairs from startup and serialized source replacement;
- starts the watcher only after the supervisor registration snapshot exists;
- installs registration pairs atomically in watcher state and revalidates pending replay/checkpoint work against the current pair;
- keeps historical checkpoint lifecycle generations separate from current source-processing authority;
- preserves the typed scanner's fail-closed `TypedScopeDispatchUnavailable` boundary.

Non-goals:
- scanner execution or projection changes;
- changes to scope limits, readiness, checkpoint persistence schema, or database migrations;
- GUI-side fallback for typed replay generations;
- adding `docs/IO_ALIGNMENT_ESTIMATE.md` to this PR (it remains a separate untracked estimate document).

## Definition of Done

- Startup and replacement transport descriptor/generation pairs from the supervisor's serialized state.
- Unchanged registrations retain their generation; changed or re-added source identities receive a fresh generation; removed sources are absent.
- A continuity-proven replay emits `Some(current_source_processing_generation)` only when its captured registration still matches the current watcher registration.
- Historical checkpoint generation is used only as historical replay evidence.
- Stale or missing registration authority fails closed to bounded audit behavior.
- Matching typed replay reaches the existing scanner boundary without enabling scanner consumption.

## Validation

- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests` — 119 passed, 1 ignored.
- `cargo test -p wavecrate --lib native_app::sample_library::source_watcher` — 128 passed, 1 known baseline failure in `filesystem_event_after_initial_watcher_ready_is_not_suppressed`; the same failure reproduces on the base.
- `cargo test -p wavecrate --lib native_app::tests::config_sources::scan_handoff` — 6 passed, 2 known baseline failures; the new typed-generation test passes and both failures reproduce on the base.
- `cargo check -p wavecrate --tests --bins` — passed.
- Rust 2024 touched-file rustfmt check — passed.
- `git diff --check` — passed.

## Known limitations

The full repository smoke script was not rerun for this slice. Native live-app acceptance remains a separate runtime lane; no persistence schema or migration changes are included.

User approval is required before merge.