### PR TITLE
feat: consume bounded exact watcher scopes

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params, types::Value};
 
 use super::schema;
 use super::util::{
@@ -11,6 +11,7 @@ use super::{
     META_SOURCE_INDEX_REVISION, SourceDatabase, SourceDbError, SourceIndexClassification,
     SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot, SourceWriteBatch,
 };
+use crate::sample_sources::reconciliation::RootRelativePath;
 
 const REQUIRED_COLUMNS: [&str; 7] = [
     "path",
@@ -23,6 +24,22 @@ const REQUIRED_COLUMNS: [&str; 7] = [
 ];
 
 impl SourceDatabase {
+    /// Read index-only entries at exact validated paths and their current index revision.
+    ///
+    /// The row query remains equality-only and bounded by the supplied paths; the revision is
+    /// read separately so callers can reject a concurrent index write before publishing facts.
+    pub fn source_index_entries_for_exact_paths(
+        &self,
+        paths: &[RootRelativePath],
+    ) -> Result<SourceIndexSnapshot, SourceDbError> {
+        let expected_revision = if source_index_schema_available(&self.connection)? {
+            read_index_revision(&self.connection)?
+        } else {
+            0
+        };
+        self.source_index_entries_for_exact_paths_at_revision(expected_revision, paths)
+    }
+
     /// Read the complete index-only file set and its independent revision atomically.
     ///
     /// Legacy read-only databases without the table project revision zero and
@@ -207,6 +224,87 @@ impl SourceDatabase {
                     collect_entries(&transaction, &sql, rusqlite::params![path])?
                 }
             });
+        }
+        entries.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        entries.dedup_by(|left, right| left.relative_path == right.relative_path);
+        transaction.rollback().map_err(map_sql_error)?;
+        Ok(SourceIndexSnapshot { revision, entries })
+    }
+
+    /// Read a bounded set of index-only entries at one exact typed path set.
+    ///
+    /// Each query is equality-only and the validated typed paths are never
+    /// widened into subtree predicates.
+    pub fn source_index_entries_for_exact_paths_at_revision(
+        &self,
+        expected_revision: u64,
+        paths: &[RootRelativePath],
+    ) -> Result<SourceIndexSnapshot, SourceDbError> {
+        if !source_index_schema_available(&self.connection)? {
+            if expected_revision != 0 {
+                return Err(SourceDbError::Unexpected);
+            }
+            return Ok(SourceIndexSnapshot {
+                revision: 0,
+                entries: Vec::new(),
+            });
+        }
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(map_sql_error)?;
+        let revision = read_index_revision(&transaction)?;
+        if revision != expected_revision {
+            return Err(SourceDbError::Unexpected);
+        }
+        let path_encoding_available = source_index_path_encoding_available(&transaction)?;
+        let normalized = paths
+            .iter()
+            .map(|path| normalize_source_index_path(path.as_path()))
+            .collect::<Result<Vec<_>, _>>()?;
+        const PATHS_PER_QUERY: usize = 128;
+        let mut entries = Vec::new();
+        for chunk in normalized.chunks(PATHS_PER_QUERY) {
+            let mut parameters = Vec::with_capacity(chunk.len() * 2);
+            let predicates = chunk
+                .iter()
+                .enumerate()
+                .map(|(index, (path, encoding))| {
+                    if path_encoding_available {
+                        let path_parameter = index * 2 + 1;
+                        let encoding_parameter = path_parameter + 1;
+                        parameters.push(Value::Text(path.clone()));
+                        parameters.push(Value::Integer(*encoding));
+                        Ok(format!(
+                            "(path = ?{path_parameter} COLLATE BINARY AND path_encoding = ?{encoding_parameter})"
+                        ))
+                    } else {
+                        if *encoding != INDEX_PATH_ENCODING_PLAIN {
+                            return Err(SourceDbError::NonUnicodeRelativePath(PathBuf::from(path)));
+                        }
+                        parameters.push(Value::Text(path.clone()));
+                        Ok(format!("path = ?{} COLLATE BINARY", index + 1))
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let sql = format!(
+                "SELECT path, {}, classification, file_size, modified_ns, file_identity,
+                        diagnostic, format_policy_version
+                 FROM source_index_entries
+                 WHERE {}
+                 ORDER BY path ASC",
+                if path_encoding_available {
+                    "path_encoding"
+                } else {
+                    "0 AS path_encoding"
+                },
+                predicates.join(" OR ")
+            );
+            entries.extend(collect_entries(
+                &transaction,
+                &sql,
+                rusqlite::params_from_iter(parameters),
+            )?);
         }
         entries.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
         entries.dedup_by(|left, right| left.relative_path == right.relative_path);
@@ -574,6 +672,95 @@ mod tests {
                 .expect("read literal subtree"),
             vec![entries[0].clone(), entries[1].clone()]
         );
+    }
+
+    #[test]
+    fn typed_exact_index_reads_exclude_descendants_and_siblings() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        let entries = [
+            SourceIndexEntry {
+                relative_path: PathBuf::from("target/inside.txt"),
+                classification: SourceIndexClassification::UnsupportedNonAudio,
+                file_size: Some(5),
+                modified_ns: Some(10),
+                file_identity: None,
+                diagnostic: None,
+                format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+            },
+            SourceIndexEntry {
+                relative_path: PathBuf::from("target/inside/deep.txt"),
+                classification: SourceIndexClassification::UnsupportedNonAudio,
+                file_size: Some(6),
+                modified_ns: Some(11),
+                file_identity: None,
+                diagnostic: None,
+                format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+            },
+            SourceIndexEntry {
+                relative_path: PathBuf::from("target/other.txt"),
+                classification: SourceIndexClassification::UnsupportedNonAudio,
+                file_size: Some(7),
+                modified_ns: Some(12),
+                file_identity: None,
+                diagnostic: None,
+                format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+            },
+        ];
+        let mut batch = database.write_batch().expect("index batch");
+        for entry in &entries {
+            batch
+                .upsert_source_index_entry(entry)
+                .expect("upsert index entry");
+        }
+        batch.commit_auxiliary_state().expect("commit index rows");
+
+        let exact = crate::sample_sources::reconciliation::RootRelativePath::try_from_path(
+            PathBuf::from("target/inside.txt"),
+        )
+        .expect("valid exact path");
+        let snapshot = database
+            .source_index_entries_for_exact_paths(std::slice::from_ref(&exact))
+            .expect("exact index snapshot");
+
+        assert_eq!(snapshot.revision, 1);
+        assert_eq!(snapshot.entries, vec![entries[0].clone()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn typed_exact_index_reads_round_trip_non_unicode_paths() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        let relative_path = PathBuf::from(OsString::from_vec(b"raw-\xFF.txt".to_vec()));
+        let entry = SourceIndexEntry {
+            relative_path: relative_path.clone(),
+            classification: SourceIndexClassification::UnsupportedNonAudio,
+            file_size: Some(5),
+            modified_ns: Some(10),
+            file_identity: Some(String::from("raw-file")),
+            diagnostic: None,
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+        };
+        let mut batch = database.write_batch().expect("index batch");
+        batch
+            .upsert_source_index_entry(&entry)
+            .expect("upsert raw index entry");
+        batch.commit_auxiliary_state().expect("commit index row");
+
+        let exact =
+            crate::sample_sources::reconciliation::RootRelativePath::try_from_path(relative_path)
+                .expect("valid raw exact path");
+        let snapshot = database
+            .source_index_entries_for_exact_paths(std::slice::from_ref(&exact))
+            .expect("exact raw index snapshot");
+
+        assert_eq!(snapshot.entries, vec![entry]);
     }
 
     #[cfg(unix)]

--- a/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
@@ -10,6 +10,7 @@ use super::super::decode::{
     decode_path_row, decode_wav_entry_row, wav_file_has_column, wav_file_select_columns,
     wav_file_supported_audio_filter,
 };
+use crate::sample_sources::reconciliation::RootRelativePath;
 
 fn collect_wav_entries(
     db: &SourceDatabase,
@@ -174,6 +175,85 @@ impl SourceDatabase {
             let mut statement = transaction.prepare(&sql).map_err(map_sql_error)?;
             let rows = statement
                 .query_map(params_from_iter(parameters.iter()), |row| {
+                    let Some(relative_path) = decode_path_row(
+                        row,
+                        "Skipping source manifest row with invalid relative path",
+                    )?
+                    else {
+                        return Ok(None);
+                    };
+                    Ok(Some(SourceManifestEntry {
+                        relative_path,
+                        file_identity: row.get(1)?,
+                        content_hash: row.get(2)?,
+                        file_size: row.get::<_, i64>(3)?.max(0) as u64,
+                        modified_ns: row.get(4)?,
+                    }))
+                })
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?;
+            entries.extend(rows.into_iter().flatten());
+        }
+        entries.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        entries.dedup_by(|left, right| left.relative_path == right.relative_path);
+        transaction.rollback().map_err(map_sql_error)?;
+        Ok((revision, entries))
+    }
+
+    /// Fetch the committed live source manifest for exact validated entries.
+    ///
+    /// Unlike the subtree snapshot above, every predicate is an exact path
+    /// equality. The validated typed path is retained through the query seam;
+    /// no legacy targeted-path normalization or descendant expansion occurs.
+    pub fn manifest_snapshot_with_revision_for_exact_paths(
+        &self,
+        paths: &[RootRelativePath],
+    ) -> Result<(u64, Vec<SourceManifestEntry>), SourceDbError> {
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(map_sql_error)?;
+        let revision = transaction
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'revision'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+            .transpose()?
+            .unwrap_or_default();
+        if paths.is_empty() {
+            transaction.rollback().map_err(map_sql_error)?;
+            return Ok((revision, Vec::new()));
+        }
+
+        let mut normalized_paths = paths
+            .iter()
+            .map(|path| super::super::super::normalize_relative_path(path.as_path()))
+            .collect::<Result<Vec<_>, _>>()?;
+        normalized_paths.sort();
+        normalized_paths.dedup();
+        let filter = wav_file_supported_audio_filter(self)?;
+        const PATHS_PER_QUERY: usize = 128;
+        let mut entries = Vec::new();
+        for chunk in normalized_paths.chunks(PATHS_PER_QUERY) {
+            let parameters = chunk.iter().map(String::as_str).collect::<Vec<_>>();
+            let predicates = (1..=chunk.len())
+                .map(|index| format!("path = ?{index} COLLATE BINARY"))
+                .collect::<Vec<_>>();
+            let sql = format!(
+                "SELECT path, file_identity, content_hash, file_size, modified_ns
+                 FROM wav_files
+                 WHERE {filter} AND missing = 0 AND ({})
+                 ORDER BY path ASC",
+                predicates.join(" OR ")
+            );
+            let mut statement = transaction.prepare(&sql).map_err(map_sql_error)?;
+            let rows = statement
+                .query_map(rusqlite::params_from_iter(parameters), |row| {
                     let Some(relative_path) = decode_path_row(
                         row,
                         "Skipping source manifest row with invalid relative path",

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -525,6 +525,37 @@ fn scoped_manifest_snapshot_reads_only_requested_exact_subtrees() {
 }
 
 #[test]
+fn exact_manifest_snapshot_reads_only_requested_entries() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+    for path in [
+        "target/inside.wav",
+        "target/inside/deep.wav",
+        "target/other.wav",
+        "targetX/inside.wav",
+    ] {
+        db.upsert_file(Path::new(path), 10, 5).unwrap();
+    }
+    let exact = crate::sample_sources::reconciliation::RootRelativePath::try_from_path(
+        PathBuf::from("target/./inside.wav"),
+    )
+    .unwrap();
+
+    let (revision, entries) = db
+        .manifest_snapshot_with_revision_for_exact_paths(std::slice::from_ref(&exact))
+        .unwrap();
+
+    assert_eq!(revision, db.get_revision().unwrap());
+    assert_eq!(
+        entries
+            .into_iter()
+            .map(|entry| entry.relative_path)
+            .collect::<Vec<_>>(),
+        vec![PathBuf::from("target/inside.wav")]
+    );
+}
+
+#[test]
 fn recent_unretained_rename_destinations_report_bounded_overflow() {
     let dir = tempdir().unwrap();
     let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -28,5 +28,8 @@ pub use scan::{
     scan_in_background, scan_once, scan_with_progress, scan_with_progress_and_writer,
     scan_with_progress_and_writer_and_committed_batch,
 };
-pub use scan_paths::{sync_paths, sync_paths_with_progress, sync_paths_with_progress_and_writer};
+pub use scan_paths::{
+    sync_exact_paths_with_progress_and_writer, sync_paths, sync_paths_with_progress,
+    sync_paths_with_progress_and_writer, validate_exact_regular_paths,
+};
 pub use scan_writer::{ScanWritePhase, ScanWriter, UncoordinatedScanWriter};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -14,6 +14,7 @@ pub(crate) struct ScanContext {
     pub(crate) stats: ScanStats,
     pub(crate) mode: ScanMode,
     pub(crate) rename_candidate_generation: Option<u64>,
+    allow_rename_candidates: bool,
     existing_index_entries: BTreeMap<PathBuf, SourceIndexEntry>,
     observed_index_entries: BTreeMap<PathBuf, SourceIndexEntry>,
     committed_manifest: BTreeMap<PathBuf, SourceManifestEntry>,
@@ -62,6 +63,7 @@ impl ScanContext {
             stats: ScanStats::default(),
             mode,
             rename_candidate_generation: None,
+            allow_rename_candidates: true,
             existing_index_entries: BTreeMap::new(),
             observed_index_entries: BTreeMap::new(),
             committed_manifest: manifest
@@ -354,6 +356,9 @@ impl ScanContext {
         &mut self,
         batch: &mut SourceWriteBatch<'_>,
     ) -> Result<(), ScanError> {
+        if !self.allow_rename_candidates {
+            return Ok(());
+        }
         if self.rename_candidate_generation.is_some() {
             return Ok(());
         }
@@ -367,6 +372,10 @@ impl ScanContext {
         };
         self.rename_candidate_generation = Some(generation);
         Ok(())
+    }
+
+    pub(in crate::sample_sources::scanner) fn disable_rename_candidates(&mut self) {
+        self.allow_rename_candidates = false;
     }
 
     pub(in crate::sample_sources::scanner) fn committed_file_identity(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -1,10 +1,18 @@
 use super::*;
-use crate::sample_sources::scanner::scan_fs::force_directory_identity;
-use crate::sample_sources::scanner::scan_fs::force_directory_read_failure;
-use crate::sample_sources::scanner::{DirectoryRepeatKind, SourceTreeDiagnostic};
-use crate::sample_sources::scanner::{sync_paths, sync_paths_with_progress};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::sample_sources::scanner::scan_fs::force_directory_identity;
+use crate::sample_sources::scanner::scan_fs::force_directory_read_failure;
+use crate::sample_sources::scanner::{
+    DirectoryRepeatKind, SourceTreeDiagnostic, UncoordinatedScanWriter,
+    sync_exact_paths_with_progress_and_writer, sync_paths, sync_paths_with_progress,
+};
+use wavecrate_library::sample_sources::reconciliation::RootRelativePath;
+
+fn exact_path(path: &str) -> RootRelativePath {
+    RootRelativePath::try_from_path(PathBuf::from(path)).expect("valid exact path")
+}
 
 #[test]
 fn targeted_sync_updates_only_requested_file() {
@@ -23,6 +31,111 @@ fn targeted_sync_updates_only_requested_file() {
     assert_eq!(db.list_files().unwrap().len(), 2);
     assert_eq!(stats.committed_delta.changed.len(), 1);
     assert!(stats.committed_delta.revision > 0);
+}
+
+#[test]
+fn exact_sync_updates_one_live_entry_with_an_exact_manifest_snapshot() {
+    let dir = tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("target/inside")).unwrap();
+    std::fs::write(dir.path().join("target/inside.wav"), b"before").unwrap();
+    std::fs::write(dir.path().join("target/inside/deep.wav"), b"deep").unwrap();
+    std::fs::write(dir.path().join("unrelated.wav"), b"unrelated").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+
+    std::fs::write(dir.path().join("target/inside.wav"), b"after").unwrap();
+    let target = exact_path("target/inside.wav");
+    let stats = sync_exact_paths_with_progress_and_writer(
+        &db,
+        std::slice::from_ref(&target),
+        None,
+        &mut |_, _| {},
+        &UncoordinatedScanWriter,
+    )
+    .unwrap();
+
+    assert_eq!(stats.total_files, 1);
+    assert_eq!(stats.updated, 1);
+    assert_eq!(stats.committed_delta.changed.len(), 1);
+    assert_eq!(stats.manifest_before.len(), 1);
+    assert_eq!(stats.manifest_after.len(), 1);
+    assert_eq!(
+        stats.manifest_after[0].relative_path,
+        PathBuf::from("target/inside.wav")
+    );
+    assert_eq!(db.list_files().unwrap().len(), 3);
+}
+
+#[test]
+fn exact_sync_indexes_one_live_unsupported_entry_without_subtree_rows() {
+    let dir = tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("target/inside")).unwrap();
+    std::fs::write(dir.path().join("target/inside.txt"), b"inside").unwrap();
+    std::fs::write(dir.path().join("target/inside/deep.txt"), b"deep").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+
+    let target = exact_path("target/inside.txt");
+    let stats = sync_exact_paths_with_progress_and_writer(
+        &db,
+        std::slice::from_ref(&target),
+        None,
+        &mut |_, _| {},
+        &UncoordinatedScanWriter,
+    )
+    .unwrap();
+
+    assert_eq!(stats.total_files, 1);
+    assert_eq!(db.list_files().unwrap().len(), 0);
+    assert_eq!(
+        db.list_source_index_entries()
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.relative_path)
+            .collect::<Vec<_>>(),
+        vec![PathBuf::from("target/inside.txt")]
+    );
+}
+
+#[test]
+fn exact_sync_rejects_missing_or_directory_entries_without_retirement() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("tracked.wav"), b"tracked").unwrap();
+    std::fs::create_dir_all(dir.path().join("folder/child")).unwrap();
+    std::fs::write(dir.path().join("folder/child.wav"), b"child").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let before = db
+        .entry_for_path(Path::new("tracked.wav"))
+        .unwrap()
+        .unwrap();
+    let revision = db.get_revision().unwrap();
+
+    std::fs::remove_file(dir.path().join("tracked.wav")).unwrap();
+    let missing = sync_exact_paths_with_progress_and_writer(
+        &db,
+        &[exact_path("tracked.wav")],
+        None,
+        &mut |_, _| {},
+        &UncoordinatedScanWriter,
+    );
+    assert!(missing.is_err());
+
+    let directory = sync_exact_paths_with_progress_and_writer(
+        &db,
+        &[exact_path("folder")],
+        None,
+        &mut |_, _| {},
+        &UncoordinatedScanWriter,
+    );
+    assert!(directory.is_err());
+    let after = db
+        .entry_for_path(Path::new("tracked.wav"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(after.file_size, before.file_size);
+    assert_eq!(after.modified_ns, before.modified_ns);
+    assert_eq!(after.content_hash, before.content_hash);
+    assert_eq!(db.get_revision().unwrap(), revision);
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -8,6 +8,7 @@ use std::{
 
 use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::fs::{Dir, OpenOptions};
+use wavecrate_library::sample_sources::reconciliation::RootRelativePath;
 use wavecrate_library::sample_sources::{
     SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
     SourceIndexDiagnostic, SourceIndexEntry, SourceTraversalPolicy,
@@ -17,11 +18,11 @@ use wavecrate_library::sample_sources::{
 use crate::sample_sources::{SourceDatabase, WavEntry};
 
 use super::{
-    scan::{ScanContext, ScanError, ScanMode, ScanStats},
+    scan::{ScanContext, ScanError, ScanMode, ScanStats, finish_scan_result},
     scan_capability::SourceRootCapability,
     scan_db_sync::{complete_scan_generation, db_sync_phase},
     scan_diff_phase::prepare_diff_from_facts,
-    scan_fs::{DirectoryVisit, VisitedDirectories, ensure_root_dir},
+    scan_fs::{DirectoryVisit, VisitedDirectories, ensure_root_dir, read_facts_from_open_file},
     scan_index::{inaccessible_index_entry, index_entry_from_file_facts, non_unicode_index_entry},
     scan_walk::apply_prepared_chunk,
     scan_writer::{ScanWriter, UncoordinatedScanWriter},
@@ -36,6 +37,213 @@ const TARGET_PREPARE_BATCH_SIZE: usize = 64;
 /// pending-rename rules used by a normal quick scan.
 pub fn sync_paths(db: &SourceDatabase, paths: &[PathBuf]) -> Result<ScanStats, ScanError> {
     sync_paths_with_progress(db, paths, None, &mut |_, _| {})
+}
+
+/// Validate exact-entry paths without following any path component.
+///
+/// This is the admission preflight for typed filesystem refreshes. A missing entry, directory,
+/// link, or unavailable path is deliberately indistinguishable from an invalid exact scope to
+/// callers: the whole batch must widen to authoritative recovery before database work starts.
+pub fn validate_exact_regular_paths(
+    root: &Path,
+    paths: &[RootRelativePath],
+    cancel: Option<&AtomicBool>,
+) -> Result<(), ScanError> {
+    let source_root = SourceRootCapability::open(root)?;
+    source_root.ensure_current_generation()?;
+    for path in paths {
+        if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
+            return Err(ScanError::Canceled);
+        }
+        if source_root.open_regular_file(path.as_path())?.is_none() {
+            return Err(exact_entry_unavailable(root, path.as_path()));
+        }
+    }
+    source_root.ensure_current_generation()
+}
+
+/// Reconcile a fully validated set of live regular files without widening to a subtree.
+///
+/// Unlike [`sync_paths_with_progress_and_writer`], this path never enumerates a directory and
+/// never performs rename reconciliation. Manifest and source-index reads are exact-path bounded;
+/// any missing, changed, or uncertain entry fails the complete operation closed.
+pub fn sync_exact_paths_with_progress_and_writer(
+    db: &SourceDatabase,
+    paths: &[RootRelativePath],
+    cancel: Option<&AtomicBool>,
+    on_progress: &mut impl FnMut(usize, &Path),
+    writer: &impl ScanWriter,
+) -> Result<ScanStats, ScanError> {
+    let started = Instant::now();
+    if paths.is_empty() {
+        return Err(ScanError::Io {
+            path: db.root().to_path_buf(),
+            source: io::Error::new(io::ErrorKind::InvalidInput, "exact scope batch is empty"),
+        });
+    }
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
+        return Err(ScanError::Canceled);
+    }
+
+    let root = ensure_root_dir(db)?;
+    validate_exact_regular_paths(&root, paths, cancel)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    source_root.ensure_current_generation()?;
+    let policy = db.source_traversal_policy()?;
+    let exact_paths = paths
+        .iter()
+        .map(|path| path.as_path().to_path_buf())
+        .collect::<Vec<_>>();
+    let (manifest_revision, manifest_before) =
+        db.manifest_snapshot_with_revision_for_exact_paths(paths)?;
+    let source_index_before = db.source_index_entries_for_exact_paths(paths)?;
+    let mut existing = HashMap::new();
+    for path in paths {
+        if path.as_path().to_str().is_some()
+            && let Some(entry) = db.entry_for_path(path.as_path())?
+        {
+            existing.insert(entry.relative_path.clone(), entry);
+        }
+    }
+    let mut context = ScanContext::from_existing(
+        existing,
+        ScanMode::Targeted,
+        manifest_revision,
+        manifest_before.clone(),
+    );
+    context.set_traversal_policy(policy);
+    context.set_targeted_manifest_scope(exact_paths.clone());
+    context.stats.targeted_manifest_rows_read = manifest_before.len();
+    context.stats.targeted_manifest_query_count = 1;
+    context.stats.targeted_manifest_scope_count = exact_paths.len();
+    context.disable_rename_candidates();
+
+    let mut prepared = Vec::with_capacity(paths.len());
+    let mut observed_index_entries = BTreeMap::new();
+    let mut observed_index_facts = BTreeMap::new();
+    for path in paths {
+        if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
+            return Err(ScanError::Canceled);
+        }
+        let relative_path = path.as_path();
+        let Some(file) = source_root.open_regular_file(relative_path)? else {
+            return Err(exact_entry_unavailable(&root, relative_path));
+        };
+        let absolute_path = root.join(relative_path);
+        let facts = read_facts_from_open_file(&root, &absolute_path, &file)?;
+        let classification =
+            classify_source_entry_with_policy(relative_path, SourceEntryFileType::File, policy);
+        let Some(file_classification) = classification.file_classification() else {
+            return Err(exact_entry_unavailable(&root, relative_path));
+        };
+        if classification.indexes_audio() {
+            let mut prepared_file = prepare_diff_from_facts(facts, &context);
+            prepared_file.source_file = Some(file);
+            prepared_file.source_handle_verified = true;
+            prepared.push(prepared_file);
+        } else if !classification.has_supported_audio() {
+            let Some(index_entry) = index_entry_from_file_facts(
+                relative_path.to_path_buf(),
+                file_classification,
+                facts.size,
+                facts.modified_ns,
+                facts.file_identity.clone(),
+            ) else {
+                return Err(exact_entry_unavailable(&root, relative_path));
+            };
+            observed_index_facts.insert(relative_path.to_path_buf(), facts);
+            observed_index_entries.insert(relative_path.to_path_buf(), index_entry);
+        } else {
+            // A supported format excluded by the current traversal policy is not a complete exact
+            // observation. The next authoritative source audit owns that policy boundary.
+            return Err(exact_entry_unavailable(&root, relative_path));
+        }
+        context.stats.total_files = context.stats.total_files.saturating_add(1);
+        on_progress(context.stats.total_files, &absolute_path);
+    }
+    context.set_targeted_index_entries(
+        source_index_before.entries,
+        observed_index_entries.into_values(),
+    );
+    source_root.ensure_current_generation()?;
+    revalidate_exact_index_facts(&root, &source_root, &observed_index_facts, cancel)?;
+
+    let result = (|| {
+        if !prepared.is_empty() {
+            let _ = apply_prepared_chunk(
+                db,
+                &root,
+                &source_root,
+                cancel,
+                &mut context,
+                prepared,
+                false,
+                writer,
+            )?;
+        }
+        if context.has_uncertain_prefixes() {
+            return Err(ScanError::Io {
+                path: root.clone(),
+                source: io::Error::other("exact entry changed during preparation"),
+            });
+        }
+        revalidate_exact_index_facts(&root, &source_root, &observed_index_facts, cancel)?;
+        reconcile_exact_index_entries(db, &source_root, &mut context, cancel, writer)?;
+        source_root.ensure_current_generation()?;
+        complete_scan_generation(db, &source_root, &mut context, cancel, writer)
+    })();
+    context.stats.targeted_sync_elapsed_us =
+        started.elapsed().as_micros().min(u64::MAX as u128) as u64;
+    finish_scan_result(manifest_before, context, result)
+}
+
+fn revalidate_exact_index_facts(
+    root: &Path,
+    source_root: &SourceRootCapability,
+    expected_facts: &BTreeMap<PathBuf, super::scan_fs::FileFacts>,
+    cancel: Option<&AtomicBool>,
+) -> Result<(), ScanError> {
+    for (relative_path, expected) in expected_facts {
+        if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
+            return Err(ScanError::Canceled);
+        }
+        let Some(file) = source_root.open_regular_file(relative_path)? else {
+            return Err(exact_entry_unavailable(root, relative_path));
+        };
+        let observed =
+            super::scan_fs::read_facts_from_open_file(root, &root.join(relative_path), &file)?;
+        if !expected.same_file_facts(&observed) {
+            return Err(exact_entry_unavailable(root, relative_path));
+        }
+    }
+    source_root.ensure_current_generation()
+}
+
+fn reconcile_exact_index_entries(
+    db: &SourceDatabase,
+    source_root: &SourceRootCapability,
+    context: &mut ScanContext,
+    cancel: Option<&AtomicBool>,
+    writer: &impl ScanWriter,
+) -> Result<(), ScanError> {
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
+        return Err(ScanError::Canceled);
+    }
+    super::scan_index::reconcile_index_entries(db, source_root, context, writer)?;
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
+        return Err(ScanError::Canceled);
+    }
+    Ok(())
+}
+
+fn exact_entry_unavailable(root: &Path, relative_path: &Path) -> ScanError {
+    ScanError::Io {
+        path: root.join(relative_path),
+        source: io::Error::new(
+            io::ErrorKind::NotFound,
+            "exact entry is unavailable or changed",
+        ),
+    }
 }
 
 /// Reconcile changed paths with a progress callback and optional cancellation.

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -909,6 +909,7 @@ impl NativeAppState {
                                 Some(scopes) => sync_source_database_scopes_with_writer(
                                     source_id,
                                     root,
+                                    database_root,
                                     scopes,
                                     changed_count,
                                     source_root_identity,

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -9,7 +9,7 @@ use std::{
 use wavecrate::sample_sources::{Rating, SourceDatabase, SourceIndexClassification};
 use wavecrate_library::filesystem_identity::stable_filesystem_identity;
 use wavecrate_library::sample_sources::reconciliation::{
-    ReconciliationScope, ReconciliationScopeKind,
+    ReconciliationScope, ReconciliationScopeKind, RootRelativePath,
 };
 use wavecrate_scan::sample_sources::scanner::{
     self, ScanWritePhase, ScanWriter, UncoordinatedScanWriter,
@@ -205,30 +205,28 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
     }
 }
 
-/// Admit typed scopes at the refresh-worker boundary without narrowing them into compatibility
-/// paths. The scanner collection contract is deliberately deferred to the next slice, so every
-/// typed scope is conservatively routed to the existing source-audit owner before any DB work.
 pub(in crate::native_app) fn sync_source_database_scopes_with_writer(
     source_id: String,
     root: PathBuf,
+    database_root: PathBuf,
     scopes: Vec<ReconciliationScope>,
     changed_count: usize,
     source_root_identity: Option<String>,
     cancel: &AtomicBool,
     watcher_continuity_proof: Option<WatcherContinuityProof>,
-    _writer: &impl ScanWriter,
+    writer: &impl ScanWriter,
 ) -> SourceFilesystemSyncResult {
     let root_identity = capture_source_root_identity(&root);
     let cancelled = cancel.load(Ordering::Acquire);
     let audit_required = if cancelled {
-        SourceFilesystemSyncAuditReason::Cancelled
+        Some(SourceFilesystemSyncAuditReason::Cancelled)
     } else if scopes.is_empty() {
-        SourceFilesystemSyncAuditReason::ScopeLost
+        Some(SourceFilesystemSyncAuditReason::ScopeLost)
     } else if scopes
         .iter()
         .any(|scope| scope.kind() == ReconciliationScopeKind::SourceAudit)
     {
-        SourceFilesystemSyncAuditReason::SourceAuditScope
+        Some(SourceFilesystemSyncAuditReason::SourceAuditScope)
     } else if !root_identity_matches_watcher_proof(
         root_identity.as_deref(),
         watcher_continuity_proof.as_ref(),
@@ -237,23 +235,76 @@ pub(in crate::native_app) fn sync_source_database_scopes_with_writer(
             .as_ref()
             .map(|proof| proof.root_identity.as_str())
     {
-        SourceFilesystemSyncAuditReason::RootIdentityUncertain
+        Some(SourceFilesystemSyncAuditReason::RootIdentityUncertain)
+    } else if !scopes
+        .iter()
+        .all(|scope| scope.kind() == ReconciliationScopeKind::ExactEntry && scope.path().is_some())
+    {
+        Some(SourceFilesystemSyncAuditReason::TypedScopeDispatchUnavailable)
     } else {
-        SourceFilesystemSyncAuditReason::TypedScopeDispatchUnavailable
+        None
     };
+    if let Some(audit_required) = audit_required {
+        return SourceFilesystemSyncResult {
+            source_id,
+            lifecycle_generation: 0,
+            changed_count,
+            root_identity,
+            journal_checkpoint_event_id: None,
+            watcher_continuity_proof,
+            cancelled,
+            audit_required: Some(audit_required),
+            result: Err(format!(
+                "Typed reconciliation scope dispatch requires source audit: {}",
+                audit_required.label()
+            )),
+        };
+    }
+
+    let exact_paths = scopes
+        .iter()
+        .map(|scope| {
+            scope
+                .path()
+                .expect("validated exact scope must carry a path")
+                .clone()
+        })
+        .collect::<Vec<_>>();
+    if let Err(error) = scanner::validate_exact_regular_paths(&root, &exact_paths, Some(cancel)) {
+        let audit_required = exact_scope_preflight_audit_reason(&root, &error, cancel);
+        return SourceFilesystemSyncResult {
+            source_id,
+            lifecycle_generation: 0,
+            changed_count,
+            root_identity: capture_source_root_identity(&root),
+            journal_checkpoint_event_id: None,
+            watcher_continuity_proof,
+            cancelled: cancel.load(Ordering::Acquire),
+            audit_required: Some(audit_required),
+            result: Err(format!("Exact scope preflight failed: {error}")),
+        };
+    }
+
+    let attempt = sync_source_database_target_once(
+        &source_id,
+        &root,
+        &database_root,
+        SourceDatabaseSyncTarget::ExactEntries(&exact_paths),
+        cancel,
+        watcher_continuity_proof.as_ref(),
+        writer,
+    );
+    let cancelled = cancel.load(Ordering::Acquire);
     SourceFilesystemSyncResult {
         source_id,
         lifecycle_generation: 0,
         changed_count,
-        root_identity,
+        root_identity: attempt.root_identity,
         journal_checkpoint_event_id: None,
         watcher_continuity_proof,
         cancelled,
-        audit_required: Some(audit_required),
-        result: Err(format!(
-            "Typed reconciliation scope dispatch requires source audit: {}",
-            audit_required.label()
-        )),
+        audit_required: cancelled.then_some(SourceFilesystemSyncAuditReason::Cancelled),
+        result: attempt.result,
     }
 }
 
@@ -272,9 +323,44 @@ fn sync_source_database_paths_once(
     watcher_continuity_proof: Option<&WatcherContinuityProof>,
     writer: &impl ScanWriter,
 ) -> SourceDatabaseSyncAttempt {
+    sync_source_database_target_once(
+        source_id,
+        root,
+        database_root,
+        SourceDatabaseSyncTarget::CompatibilityPaths(paths),
+        cancel,
+        watcher_continuity_proof,
+        writer,
+    )
+}
+
+#[derive(Clone, Copy)]
+enum SourceDatabaseSyncTarget<'a> {
+    CompatibilityPaths(&'a [PathBuf]),
+    ExactEntries(&'a [RootRelativePath]),
+}
+
+impl SourceDatabaseSyncTarget<'_> {
+    fn browser_delta_eligible(self) -> bool {
+        match self {
+            Self::CompatibilityPaths(paths) => paths.iter().all(|path| path.to_str().is_some()),
+            Self::ExactEntries(paths) => paths.iter().all(|path| path.as_path().to_str().is_some()),
+        }
+    }
+}
+
+fn sync_source_database_target_once(
+    source_id: &str,
+    root: &std::path::Path,
+    database_root: &std::path::Path,
+    target: SourceDatabaseSyncTarget<'_>,
+    cancel: &AtomicBool,
+    watcher_continuity_proof: Option<&WatcherContinuityProof>,
+    writer: &impl ScanWriter,
+) -> SourceDatabaseSyncAttempt {
     // Browser IDs are UTF-8 paths. A raw path is still reconciled in the database, but it must
     // take the existing full-recovery path rather than enter a lossy incremental projection.
-    let browser_delta_eligible = paths.iter().all(|path| path.to_str().is_some());
+    let browser_delta_eligible = target.browser_delta_eligible();
     let _writer = writer.lock(ScanWritePhase::Open);
     let root_identity = capture_source_root_identity(root);
     if cancel.load(Ordering::Acquire) {
@@ -302,13 +388,27 @@ fn sync_source_database_paths_once(
     let result = database
         .map_err(|err| format!("open source index: {err}"))
         .and_then(|db| {
-            let (stats, mut incomplete_error) = match scanner::sync_paths_with_progress_and_writer(
-                &db,
-                paths,
-                Some(cancel),
-                &mut |_, _| {},
-                writer,
-            ) {
+            let scan_result = match target {
+                SourceDatabaseSyncTarget::CompatibilityPaths(paths) => {
+                    scanner::sync_paths_with_progress_and_writer(
+                        &db,
+                        paths,
+                        Some(cancel),
+                        &mut |_, _| {},
+                        writer,
+                    )
+                }
+                SourceDatabaseSyncTarget::ExactEntries(paths) => {
+                    scanner::sync_exact_paths_with_progress_and_writer(
+                        &db,
+                        paths,
+                        Some(cancel),
+                        &mut |_, _| {},
+                        writer,
+                    )
+                }
+            };
+            let (stats, mut incomplete_error) = match scan_result {
                 Ok(stats) => (stats, None),
                 Err(scanner::ScanError::Incomplete { committed, error }) => {
                     (*committed, Some(error))
@@ -316,7 +416,9 @@ fn sync_source_database_paths_once(
                 Err(error) => return Err(format!("sync source index: {error}")),
             };
             let committed = stats.clone();
-            let completed = if incomplete_error.is_some() {
+            let completed = if incomplete_error.is_some()
+                || matches!(target, SourceDatabaseSyncTarget::ExactEntries(_))
+            {
                 committed
             } else {
                 match scanner::complete_deferred_rename_candidates_with_cancel_and_writer(
@@ -385,6 +487,25 @@ fn sync_source_database_paths_once(
         root_identity,
         result,
         retryable: true,
+    }
+}
+
+fn exact_scope_preflight_audit_reason(
+    root: &Path,
+    error: &scanner::ScanError,
+    cancel: &AtomicBool,
+) -> SourceFilesystemSyncAuditReason {
+    if cancel.load(Ordering::Acquire) || matches!(error, scanner::ScanError::Canceled) {
+        return SourceFilesystemSyncAuditReason::Cancelled;
+    }
+    let root_loss = matches!(
+        error,
+        scanner::ScanError::InvalidRoot(_) | scanner::ScanError::StaleRootGeneration { .. }
+    ) || matches!(error, scanner::ScanError::Io { path, .. } if path == root);
+    if root_loss {
+        SourceFilesystemSyncAuditReason::RootIdentityUncertain
+    } else {
+        SourceFilesystemSyncAuditReason::ScopeLost
     }
 }
 
@@ -618,7 +739,9 @@ mod tests {
         RawObservationEnvelope, RawObservationLimits, RawObservationProvenance, RawObservedPath,
         RawPathRole, RootIdentity, WatcherGeneration, normalize_observation,
     };
-    use wavecrate_scan::sample_sources::scanner::{ScanWritePhase, ScanWriter};
+    use wavecrate_scan::sample_sources::scanner::{
+        ScanWritePhase, ScanWriter, UncoordinatedScanWriter,
+    };
 
     use crate::native_app::sample_library::source_watcher::{
         WatcherBackend, WatcherContinuityProof,
@@ -721,7 +844,7 @@ mod tests {
     }
 
     #[test]
-    fn typed_scope_dispatch_routes_to_audit_without_opening_database_or_using_paths() {
+    fn typed_scope_preflight_falls_back_without_opening_database() {
         let root = tempfile::tempdir().expect("source root");
         let root_identity = capture_source_root_identity(root.path()).expect("root identity");
         let proof = watcher_proof(&root_identity, 73);
@@ -731,6 +854,7 @@ mod tests {
 
         let result = sync_source_database_scopes_with_writer(
             String::from("source-a"),
+            root.path().to_path_buf(),
             root.path().to_path_buf(),
             vec![exact_scope()],
             1,
@@ -742,12 +866,43 @@ mod tests {
 
         assert_eq!(
             result.audit_required,
-            Some(
-                crate::native_app::app::SourceFilesystemSyncAuditReason::TypedScopeDispatchUnavailable
-            )
+            Some(crate::native_app::app::SourceFilesystemSyncAuditReason::ScopeLost)
         );
         assert!(result.result.is_err());
         assert!(!writer.database_open_started.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn typed_scope_dispatch_uses_exact_scanner_and_committed_projection() {
+        let root = tempfile::tempdir().expect("source root");
+        std::fs::write(root.path().join("exact.wav"), b"exact").expect("exact file");
+        let database_parent = tempfile::tempdir().expect("database parent");
+        let database_root = database_parent.path().join("source-db");
+        let database_path = database_root.join(".wavecrate.db");
+        let root_identity = capture_source_root_identity(root.path()).expect("root identity");
+        let proof = watcher_proof(&root_identity, 73);
+
+        let result = sync_source_database_scopes_with_writer(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            database_root,
+            vec![exact_scope()],
+            1,
+            Some(root_identity),
+            &AtomicBool::new(false),
+            Some(proof),
+            &UncoordinatedScanWriter,
+        );
+
+        assert!(result.audit_required.is_none());
+        let success = result.result.expect("exact scope sync");
+        assert_eq!(success.renames_reconciled, 0);
+        assert_eq!(success.committed_delta.created.len(), 1);
+        assert!(success.incomplete_error.is_none());
+        assert!(success.browser_projection_delta.is_some());
+        assert!(success.projection_handoff_ticket.is_none());
+        assert!(database_path.is_file());
+        assert!(!root.path().join(".wavecrate.db").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Goal

Enable the first production consumer for typed watcher scopes: bounded `ExactEntry` reconciliation for live regular-file creates, modifications, copies, and supported/unsupported classification transitions.

## Scope and non-goals

This PR:
- adds exact-path, no-follow regular-file preflight;
- adds bounded exact manifest and source-index snapshot reads;
- adds an exact-only scanner path that never recursively traverses and disables rename-candidate reconciliation;
- dispatches all-`ExactEntry` batches through that scanner while preserving the existing committed-delta, browser-projection, permit, readiness, and checkpoint gates;
- preserves committed partial results from `ScanError::Incomplete`;
- plumbs the configured separate database root through typed dispatch.

Non-goals:
- `Subtree` traversal or continuation;
- `SourceAudit` or mixed/broader typed batches;
- deletion, rename-source retirement, directory truth, or empty-folder handling;
- schema/migration, watcher, lifecycle, readiness, checkpoint, or UI-thread I/O redesign;
- legacy `sync_paths` behavior changes;
- adding `docs/IO_ALIGNMENT_ESTIMATE.md` to this PR (it remains a separate untracked estimate document).

## Definition of Done

- An all-`ExactEntry` batch reaches the bounded exact scanner only after every path is proven to be a live regular file.
- Exact scans read only requested manifest/index rows, never descendants or siblings.
- Exact scans use the configured database root, produce committed revisioned deltas, and reuse exact browser projection hydration.
- Exact scans never run deferred rename completion.
- Subtree, source-audit, mixed, missing, directory, link, stale-root, cancelled, uncertain, incomplete, or projection-mismatch cases fail closed to audit/full reconciliation without checkpoint advancement.
- Existing compatibility-path behavior remains unchanged.

## Validation

- `cargo test -p wavecrate-library --lib` — 413 passed.
- `cargo test -p wavecrate-scan --lib` — 200 passed.
- `cargo test -p wavecrate --lib native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::tests` — 14 passed.
- `cargo test -p wavecrate --lib native_app::sample_library::folder_scan_actions::filesystem_refresh::tests` — 11 passed.
- `cargo test -p wavecrate --lib native_app::app::state::source_scan_workflow::tests` — 48 passed.
- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::watcher_checkpoint` — 8 passed.
- `cargo check -p wavecrate --tests --bins` — passed.
- Rust 2024 touched-file rustfmt check — passed.
- `git diff --check` — passed.
- `cargo test -p wavecrate --lib native_app::tests::config_sources::scan_handoff` — 6 passed; 2 existing baseline failures reproduce from the base (`foreground_scan_terminal_release_admits_coalesced_watcher_paths`, `foreground_scan_hands_exact_committed_identities_to_readiness`).
- Clippy was attempted with `-D warnings` but remains blocked by seven unrelated pre-existing warnings outside this diff.

## Known limitations

Native live-app/FSEvents acceptance remains a separate runtime lane. Non-Unicode exact paths and all disappearance/retirement cases intentionally remain on conservative recovery.

User approval is required before merge.