### PR TITLE
feat: add atomic directory truth handoff

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -542,8 +542,9 @@ mod tests {
     use std::path::Path;
 
     use super::super::{
-        SourceDatabase, SourceDbError, SourceDirectoryEntry, SourceDirectoryTruthError,
-        SourceDirectoryTruthState, SourceDirectoryTruthUnavailableReason,
+        META_LAST_SCAN_COMPLETED_AT, SourceDatabase, SourceDbError, SourceDirectoryEntry,
+        SourceDirectoryTruthError, SourceDirectoryTruthState,
+        SourceDirectoryTruthUnavailableReason, SourceManifestEntry,
     };
 
     fn directory(path: &str, identity: &str) -> SourceDirectoryEntry {
@@ -599,6 +600,193 @@ mod tests {
             .unwrap();
         assert_eq!(second.entries.len(), 1);
         assert!(second.next_cursor.is_none());
+    }
+
+    #[test]
+    fn full_scan_handoff_publishes_directory_truth_and_exact_manifest_snapshot() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let mut manifest_batch = db.write_batch().unwrap();
+        manifest_batch
+            .upsert_file_with_hash(Path::new("kick.wav"), 128, 42, "kick-hash")
+            .unwrap();
+        manifest_batch.commit().unwrap();
+        db.begin_source_directory_truth_generation(1, 1).unwrap();
+        db.stage_source_directory_truth_entries(1, &[directory("drums", "dir-1")])
+            .unwrap();
+
+        let batch = db.write_batch().unwrap();
+        let result = batch
+            .commit_full_scan_with_directory_truth(1, 1, 1234)
+            .unwrap();
+
+        assert_eq!(result.publication.generation, 1);
+        assert_eq!(result.publication.source_revision, 2);
+        assert!(!result.publication.idempotent);
+        assert_eq!(
+            result.manifest_snapshot,
+            (
+                2,
+                vec![SourceManifestEntry {
+                    relative_path: Path::new("kick.wav").to_path_buf(),
+                    file_identity: None,
+                    content_hash: Some("kick-hash".to_owned()),
+                    file_size: 128,
+                    modified_ns: 42,
+                }]
+            )
+        );
+        assert_eq!(db.get_revision().unwrap(), 2);
+        assert_eq!(
+            db.get_metadata(META_LAST_SCAN_COMPLETED_AT).unwrap(),
+            Some("1234".to_owned())
+        );
+        assert_eq!(
+            db.source_directory_truth_state().unwrap(),
+            SourceDirectoryTruthState::Active {
+                generation: 1,
+                published_source_revision: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn full_scan_handoff_rejects_incomplete_stale_and_active_generations_without_changes() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        db.begin_source_directory_truth_generation(1, 1).unwrap();
+        db.stage_source_directory_truth_entries(1, &[directory("one", "dir-1")])
+            .unwrap();
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+        let mut timestamp_batch = db.write_batch().unwrap();
+        timestamp_batch
+            .set_metadata(META_LAST_SCAN_COMPLETED_AT, "old")
+            .unwrap();
+        timestamp_batch.commit_auxiliary_state().unwrap();
+
+        db.begin_source_directory_truth_generation(2, 2).unwrap();
+        db.stage_source_directory_truth_entries(2, &[directory("two", "dir-2")])
+            .unwrap();
+        let error = db
+            .write_batch()
+            .unwrap()
+            .commit_full_scan_with_directory_truth(2, 1, 200)
+            .unwrap_err();
+        assert_eq!(
+            directory_error(error),
+            SourceDirectoryTruthError::Incomplete {
+                generation: 2,
+                expected: 2,
+                staged: 1,
+            }
+        );
+
+        db.stage_source_directory_truth_entries(2, &[directory("three", "dir-3")])
+            .unwrap();
+        let error = db
+            .write_batch()
+            .unwrap()
+            .commit_full_scan_with_directory_truth(2, 0, 201)
+            .unwrap_err();
+        assert_eq!(
+            directory_error(error),
+            SourceDirectoryTruthError::StaleRevision {
+                expected: 0,
+                actual: 1,
+            }
+        );
+
+        let error = db
+            .write_batch()
+            .unwrap()
+            .commit_full_scan_with_directory_truth(1, 1, 202)
+            .unwrap_err();
+        assert_eq!(
+            directory_error(error),
+            SourceDirectoryTruthError::GenerationCollision { generation: 1 }
+        );
+        assert_eq!(db.get_revision().unwrap(), 1);
+        assert_eq!(
+            db.get_metadata(META_LAST_SCAN_COMPLETED_AT).unwrap(),
+            Some("old".to_owned())
+        );
+        assert_eq!(
+            db.source_directory_truth_state().unwrap(),
+            SourceDirectoryTruthState::Active {
+                generation: 1,
+                published_source_revision: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn full_scan_handoff_rejects_dirty_manifest_batch_and_rolls_it_back() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        db.begin_source_directory_truth_generation(1, 0).unwrap();
+
+        let mut batch = db.write_batch().unwrap();
+        batch.upsert_file(Path::new("dirty.wav"), 1, 1).unwrap();
+        assert!(matches!(
+            batch.commit_full_scan_with_directory_truth(1, 0, 300),
+            Err(SourceDbError::Unexpected)
+        ));
+
+        assert_eq!(db.get_revision().unwrap(), 0);
+        assert!(db.entry_for_path(Path::new("dirty.wav")).unwrap().is_none());
+        assert_eq!(db.get_metadata(META_LAST_SCAN_COMPLETED_AT).unwrap(), None);
+        assert_eq!(
+            db.source_directory_truth_state().unwrap(),
+            SourceDirectoryTruthState::Uninitialized
+        );
+    }
+
+    #[test]
+    fn full_scan_handoff_rolls_back_on_injected_activation_failure() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        db.begin_source_directory_truth_generation(1, 1).unwrap();
+        db.stage_source_directory_truth_entries(1, &[directory("one", "dir-1")])
+            .unwrap();
+        db.finalize_source_directory_truth_generation(1, 0).unwrap();
+        let mut timestamp_batch = db.write_batch().unwrap();
+        timestamp_batch
+            .set_metadata(META_LAST_SCAN_COMPLETED_AT, "old")
+            .unwrap();
+        timestamp_batch.commit_auxiliary_state().unwrap();
+
+        db.begin_source_directory_truth_generation(2, 1).unwrap();
+        db.stage_source_directory_truth_entries(2, &[directory("two", "dir-2")])
+            .unwrap();
+        db.connection
+            .execute_batch(
+                "CREATE TRIGGER fail_directory_truth_activation
+                 BEFORE UPDATE OF status ON source_directory_generations
+                 WHEN OLD.status = 'staging' AND NEW.status = 'active'
+                 BEGIN
+                     SELECT RAISE(ABORT, 'injected directory activation failure');
+                 END;",
+            )
+            .unwrap();
+
+        let error = db
+            .write_batch()
+            .unwrap()
+            .commit_full_scan_with_directory_truth(2, 1, 400)
+            .unwrap_err();
+        assert!(matches!(error, SourceDbError::Sql(_)));
+        assert_eq!(db.get_revision().unwrap(), 1);
+        assert_eq!(
+            db.get_metadata(META_LAST_SCAN_COMPLETED_AT).unwrap(),
+            Some("old".to_owned())
+        );
+        assert_eq!(
+            db.source_directory_truth_state().unwrap(),
+            SourceDirectoryTruthState::Active {
+                generation: 1,
+                published_source_revision: 1,
+            }
+        );
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -69,8 +69,9 @@ pub use types::{
 };
 pub use util::normalize_relative_path;
 pub use write::{
-    ManifestCommitResult, SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite,
-    SourceIndexCommitResult, SourceTagWrite, SourceWriteCommand,
+    ManifestCommitResult, SourceCollectionWrite, SourceContentHashWrite,
+    SourceDirectoryTruthCommitResult, SourceFileWrite, SourceIndexCommitResult, SourceTagWrite,
+    SourceWriteCommand,
 };
 
 /// Hidden filename used for per-source databases.

--- a/crates/wavecrate-library/src/sample_sources/db/write.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write.rs
@@ -14,7 +14,9 @@ pub use command::{
     SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite, SourceTagWrite,
     SourceWriteCommand,
 };
-pub use transaction::{ManifestCommitResult, SourceIndexCommitResult};
+pub use transaction::{
+    ManifestCommitResult, SourceDirectoryTruthCommitResult, SourceIndexCommitResult,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -8,9 +8,9 @@ use super::super::util::{
     map_sql_error, normalize_relative_path, parse_canonical_directory_path_from_db,
 };
 use super::super::{
-    META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError, SourceDirectoryEntry,
-    SourceDirectoryTruthError, SourceDirectoryTruthPublication, SourceIndexEntry,
-    SourceManifestEntry, SourceTraversalPolicy, SourceWriteBatch,
+    META_LAST_SCAN_COMPLETED_AT, META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError,
+    SourceDirectoryEntry, SourceDirectoryTruthError, SourceDirectoryTruthPublication,
+    SourceIndexEntry, SourceManifestEntry, SourceTraversalPolicy, SourceWriteBatch,
 };
 use crate::sample_sources::reconciliation::{RootIdentity, SourceAuditCommit, SourceAuditRequest};
 
@@ -36,6 +36,21 @@ pub struct SourceIndexCommitResult {
     pub upserted_entries: Vec<SourceIndexEntry>,
     /// Index rows removed by the transaction.
     pub removed_paths: Vec<PathBuf>,
+}
+
+/// Result of atomically publishing a complete directory generation with a full-scan handoff.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SourceDirectoryTruthCommitResult {
+    /// Directory generation publication committed by the handoff.
+    pub publication: SourceDirectoryTruthPublication,
+    /// Complete manifest snapshot captured at the publication's committed source revision.
+    pub manifest_snapshot: (u64, Vec<SourceManifestEntry>),
+}
+
+#[derive(Clone, Copy)]
+enum DirectoryTruthActivationMode {
+    AllowIdempotent,
+    RequireStaging,
 }
 
 impl SourceWriteBatch<'_> {
@@ -223,6 +238,62 @@ impl SourceWriteBatch<'_> {
         generation: u64,
         expected_source_revision: u64,
     ) -> Result<SourceDirectoryTruthPublication, SourceDbError> {
+        let mut batch = self;
+        let publication = batch.activate_source_directory_truth_generation(
+            generation,
+            expected_source_revision,
+            DirectoryTruthActivationMode::AllowIdempotent,
+        )?;
+        let db_path = batch.db_path.clone();
+        let telemetry_label = batch.telemetry_label;
+        batch.tx.commit().map_err(map_sql_error)?;
+        checkpoint_source_database(&db_path, telemetry_label);
+        Ok(publication)
+    }
+
+    /// Commit a complete full-scan directory handoff and its exact manifest snapshot atomically.
+    pub fn commit_full_scan_with_directory_truth(
+        mut self,
+        generation: u64,
+        expected_source_revision: u64,
+        completed_at: i64,
+    ) -> Result<SourceDirectoryTruthCommitResult, SourceDbError> {
+        if self.paths_revision_dirty
+            || self.identities_revision_dirty
+            || self.index_revision_dirty
+            || !self.manifest_touched_paths.is_empty()
+            || !self.source_index_changes.is_empty()
+        {
+            return Err(SourceDbError::Unexpected);
+        }
+
+        let publication = self.activate_source_directory_truth_generation(
+            generation,
+            expected_source_revision,
+            DirectoryTruthActivationMode::RequireStaging,
+        )?;
+        self.set_metadata(META_LAST_SCAN_COMPLETED_AT, &completed_at.to_string())?;
+        let manifest_snapshot = manifest_snapshot(&self.tx)?;
+        if manifest_snapshot.0 != publication.source_revision {
+            return Err(SourceDbError::Unexpected);
+        }
+
+        let db_path = self.db_path.clone();
+        let telemetry_label = self.telemetry_label;
+        self.tx.commit().map_err(map_sql_error)?;
+        checkpoint_source_database(&db_path, telemetry_label);
+        Ok(SourceDirectoryTruthCommitResult {
+            publication,
+            manifest_snapshot,
+        })
+    }
+
+    fn activate_source_directory_truth_generation(
+        &mut self,
+        generation: u64,
+        expected_source_revision: u64,
+        activation_mode: DirectoryTruthActivationMode,
+    ) -> Result<SourceDirectoryTruthPublication, SourceDbError> {
         let generation_sql = directory_generation_sql_value(generation)?;
         let Some((status, expected_entry_count, staged_entry_count, complete, published_revision)) =
             self.tx
@@ -262,10 +333,12 @@ impl SourceWriteBatch<'_> {
                 staged_entry_count,
                 complete,
             )?;
-            let db_path = self.db_path.clone();
-            let telemetry_label = self.telemetry_label;
-            self.tx.commit().map_err(map_sql_error)?;
-            checkpoint_source_database(&db_path, telemetry_label);
+            if matches!(
+                activation_mode,
+                DirectoryTruthActivationMode::RequireStaging
+            ) {
+                return Err(SourceDirectoryTruthError::GenerationCollision { generation }.into());
+            }
             return Ok(SourceDirectoryTruthPublication {
                 generation,
                 source_revision: published_revision,
@@ -370,10 +443,6 @@ impl SourceWriteBatch<'_> {
         if changed != 1 {
             return Err(SourceDirectoryTruthError::GenerationMissing { generation }.into());
         }
-        let db_path = self.db_path.clone();
-        let telemetry_label = self.telemetry_label;
-        self.tx.commit().map_err(map_sql_error)?;
-        checkpoint_source_database(&db_path, telemetry_label);
         Ok(SourceDirectoryTruthPublication {
             generation,
             source_revision: committed_source_revision,


### PR DESCRIPTION
## Goal

Add the atomic source-database handoff needed for the next directory-truth implementation step: activate an already-staged full-scan directory generation, record completion metadata, advance the source revision once, and return the exact manifest snapshot from that same committed revision.

## Scope and non-goals

This PR:
- adds `SourceDirectoryTruthCommitResult`;
- adds `SourceWriteBatch::commit_full_scan_with_directory_truth`;
- refactors directory-generation activation into a reusable non-committing validation/activation helper;
- preserves the standalone idempotent directory finalizer;
- adds atomic success, stale/incomplete/active rejection, dirty-batch rejection, and injected-failure rollback coverage.

Non-goals:
- scanner traversal or directory-identity transport;
- production full-scan wiring to this seam;
- generation allocation or abandoned-staging recovery;
- typed `Subtree`, watcher, browser projection, readiness, lifecycle, or checkpoint changes;
- schema or migration changes;
- changes to `docs/IO_ALIGNMENT_ESTIMATE.md`, which remains a separate untracked estimate document.

## Definition of Done

- A complete staged generation can atomically switch active directory truth, write `META_LAST_SCAN_COMPLETED_AT`, increment source revision exactly once, and return a manifest snapshot at that new revision.
- Stale, incomplete, malformed, colliding, dirty, or injected-failure cases roll back without changing the prior active generation, revision, or completion timestamp.
- Existing standalone finalization, staging limits, paging, cleanup, reopen, and read-only behavior remain intact.
- No scanner/runtime behavior changes are included.

## Validation

- `cargo test -p wavecrate-library --lib` — 417 passed.
- `cargo test -p wavecrate-scan --lib` — 200 passed.
- `cargo check -p wavecrate --tests --bins` — passed.
- Rust 2024 rustfmt check on touched files — passed.
- `git diff --check` and staged diff check — passed.
- `cargo clippy -p wavecrate-library --lib -- -D warnings` — blocked by four pre-existing warnings in untouched `file_ops_journal/reconcile.rs`, `open/paths.rs`, `write/manifest_audit.rs`, and `db/util.rs`.
- `bash scripts/ci.sh smoke` — environment-blocked: the validation lease was not identifiable in the sandbox; an escalated retry reached the gate but the configured Radiant sibling origin was a local path rather than the expected GitHub origin. No failure was attributed to this diff.

## Known limitations

This PR intentionally provides the atomic seam only. A later bounded slice must carry scanner-owned directory identities and invoke this handoff at full-scan completion before production directory truth is enabled.

User approval is required before merge.