### PR TITLE
feat: carry directory identities through full scans

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -1,6 +1,8 @@
 use std::{fmt, path::PathBuf};
 
-use wavecrate_library::sample_sources::db::{ContentAuditReport, PendingRenameDiagnostics};
+use wavecrate_library::sample_sources::db::{
+    ContentAuditReport, PendingRenameDiagnostics, SourceDirectoryEntry,
+};
 use wavecrate_library::sample_sources::{SourceIndexEntry, SourceManifestEntry};
 
 /// One bounded group of source-manifest rows after its database transaction commits.
@@ -132,6 +134,9 @@ pub struct SourceTreeFile {
 pub struct SourceTreeSnapshot {
     /// All visible directories, relative to the source root, including the empty root path.
     pub directories: Vec<PathBuf>,
+    /// Identity-bearing descendant directories prepared for a later bounded persistence handoff.
+    #[doc(hidden)]
+    pub(crate) directory_entries: Option<Vec<SourceDirectoryEntry>>,
     /// Visible regular files that are not authoritative supported-audio manifest rows.
     pub other_files: Vec<SourceTreeFile>,
     /// Typed index-only file facts captured by this traversal.
@@ -153,6 +158,15 @@ impl SourceTreeSnapshot {
     /// A projection is safe to publish only when every encountered entry was classified.
     pub fn is_complete(&self) -> bool {
         self.diagnostics.is_empty()
+    }
+
+    /// Borrow persistence-ready directory entries only from a complete traversal snapshot.
+    #[allow(dead_code)]
+    pub(crate) fn complete_directory_entries(&self) -> Option<&[SourceDirectoryEntry]> {
+        if !self.is_complete() {
+            return None;
+        }
+        self.directory_entries.as_deref()
     }
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
@@ -106,6 +106,7 @@ fn full_scan_stops_an_injected_directory_identity_cycle() {
 
     assert_eq!(stats.total_files, 1);
     assert!(!snapshot.is_complete());
+    assert!(snapshot.complete_directory_entries().is_none());
     assert!(!snapshot.directories.contains(&PathBuf::from("cycle")));
     assert!(snapshot.diagnostics.iter().any(|diagnostic| matches!(
         diagnostic,
@@ -125,9 +126,15 @@ fn full_scan_preserves_manifest_when_root_identity_is_unavailable() {
     scan_once(&db).unwrap();
 
     let _root_identity = force_directory_identity(dir.path(), None);
-    let ScanError::Incomplete { .. } = scan_once(&db).unwrap_err() else {
+    let ScanError::Incomplete { committed, .. } = scan_once(&db).unwrap_err() else {
         panic!("an unavailable root identity must return an incomplete scan");
     };
+    let snapshot = committed
+        .source_tree_snapshot
+        .as_ref()
+        .expect("source tree snapshot");
+    assert!(!snapshot.is_complete());
+    assert!(snapshot.complete_directory_entries().is_none());
     assert_eq!(db.count_files().unwrap(), 1);
 }
 
@@ -200,6 +207,71 @@ fn full_scan_captures_browser_layout_in_the_authoritative_traversal() {
         .find(|file| file.relative_path == Path::new("nested/notes.txt"))
         .expect("notes layout entry");
     assert_eq!(notes.file_size, 5);
+}
+
+#[test]
+fn full_scan_transports_directory_identities_in_relative_path_order() {
+    let dir = tempdir().unwrap();
+    let alpha = dir.path().join("alpha");
+    let nested = alpha.join("nested");
+    let zeta = dir.path().join("zeta");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::create_dir(&zeta).unwrap();
+
+    let _root_identity = force_directory_identity(dir.path(), Some("identity-root"));
+    let _alpha_identity = force_directory_identity(&alpha, Some("identity-alpha"));
+    let _nested_identity = force_directory_identity(&nested, Some("identity-nested"));
+    let _zeta_identity = force_directory_identity(&zeta, Some("identity-zeta"));
+
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    let snapshot = scan_once(&db)
+        .unwrap()
+        .source_tree_snapshot
+        .expect("source tree snapshot");
+
+    assert!(snapshot.is_complete());
+    assert_eq!(
+        snapshot.directories,
+        vec![
+            PathBuf::new(),
+            PathBuf::from("alpha"),
+            PathBuf::from("alpha/nested"),
+            PathBuf::from("zeta"),
+        ]
+    );
+    let entries = snapshot
+        .complete_directory_entries()
+        .expect("complete directory entries");
+    let pairs = entries
+        .iter()
+        .map(|entry| {
+            (
+                entry.relative_path.clone(),
+                entry.directory_identity.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        pairs,
+        vec![
+            (PathBuf::from("alpha"), String::from("identity-alpha")),
+            (
+                PathBuf::from("alpha/nested"),
+                String::from("identity-nested")
+            ),
+            (PathBuf::from("zeta"), String::from("identity-zeta")),
+        ]
+    );
+    assert_eq!(entries.len(), snapshot.directories.len() - 1);
+    assert!(entries.windows(2).all(|pair| {
+        pair[0].relative_path < pair[1].relative_path
+            && pair[0].directory_identity != pair[1].directory_identity
+    }));
+    assert!(
+        entries
+            .iter()
+            .all(|entry| !entry.relative_path.as_os_str().is_empty())
+    );
 }
 
 #[test]
@@ -279,6 +351,14 @@ fn browser_layout_snapshot_does_not_include_symlink_entries() {
             .directories
             .iter()
             .all(|path| path != Path::new("outside-link"))
+    );
+    let entries = snapshot
+        .complete_directory_entries()
+        .expect("complete directory entries");
+    assert!(
+        entries
+            .iter()
+            .all(|entry| entry.relative_path != Path::new("outside-link"))
     );
     assert!(
         snapshot

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs,
     io::Read,
     path::{Path, PathBuf},
@@ -7,7 +7,7 @@ use std::{
 };
 
 #[cfg(test)]
-use std::{cell::RefCell, collections::BTreeSet};
+use std::cell::RefCell;
 
 use cap_fs_ext::{DirExt, OpenOptionsFollowExt};
 use cap_std::fs::{Dir, OpenOptions};
@@ -17,6 +17,7 @@ use wavecrate_library::filesystem_identity::filesystem_change_marker;
 use wavecrate_library::filesystem_identity::{
     stable_filesystem_identity, stable_filesystem_identity_from_open_file,
 };
+use wavecrate_library::sample_sources::db::SourceDirectoryEntry;
 use wavecrate_library::sample_sources::{
     SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
     SourceIndexDiagnostic, SourceIndexEntry, SourceTraversalPolicy,
@@ -44,9 +45,10 @@ thread_local! {
     static FORCED_DIRECTORY_IDENTITIES: RefCell<BTreeMap<PathBuf, Option<String>>> = const { RefCell::new(BTreeMap::new()) };
 }
 
-/// A per-traversal directory identity set shared by full and targeted scans.
+/// A per-traversal directory identity map shared by full and targeted scans.
 #[derive(Default)]
 pub(super) struct VisitedDirectories {
+    /// Stable identity captured from an opened directory descriptor and its first accepted path.
     identities: BTreeMap<String, PathBuf>,
     diagnostics: Vec<SourceTreeDiagnostic>,
 }
@@ -112,6 +114,27 @@ impl VisitedDirectories {
 
     pub(super) fn diagnostics(&self) -> &[SourceTreeDiagnostic] {
         &self.diagnostics
+    }
+
+    /// Assemble persistence-ready descendant entries from the accepted identity map.
+    pub(super) fn directory_entries(&self) -> Option<Vec<SourceDirectoryEntry>> {
+        let mut identities = BTreeSet::new();
+        let mut paths = BTreeSet::new();
+        let mut entries = Vec::with_capacity(self.identities.len().saturating_sub(1));
+        for (identity, relative_path) in &self.identities {
+            if relative_path.as_os_str().is_empty() {
+                continue;
+            }
+            if !identities.insert(identity) || !paths.insert(relative_path) {
+                return None;
+            }
+            entries.push(SourceDirectoryEntry {
+                relative_path: relative_path.clone(),
+                directory_identity: identity.clone(),
+            });
+        }
+        entries.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        Some(entries)
     }
 }
 
@@ -498,6 +521,7 @@ pub(super) fn visit_dir_with_cancel_check(
     snapshot
         .index_entries
         .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    snapshot.directory_entries = visited.directory_entries();
     snapshot
         .diagnostics
         .extend_from_slice(visited.diagnostics());


### PR DESCRIPTION
## Goal

Carry descriptor-derived stable directory identities through authoritative full scans into a complete-only, persistence-ready scanner snapshot for the next bounded directory-truth staging step.

## Scope and non-goals

This PR:
- retains the exact stable identity captured from each already-opened no-follow directory descriptor;
- adds crate-private `SourceDirectoryEntry` transport on `SourceTreeSnapshot`;
- excludes the implicit source root and sorts descendant entries by relative path;
- gates the persistence-ready accessor on a complete snapshot;
- adds identity ordering, root exclusion, repeated/unavailable, and symlink regression coverage.

Non-goals:
- directory generation allocation, staging, activation, cleanup, or recovery;
- invoking the merged atomic handoff from PR #1049;
- scan completion metadata, revisions, committed deltas, browser projection, readiness, checkpoints, watchers, lifecycle, or UI changes;
- typed `Subtree`, targeted directory publication, schema/migration, or arbitrary new limits;
- changes to `docs/IO_ALIGNMENT_ESTIMATE.md`, which remains a separate untracked estimate document.

## Definition of Done

- A complete full traversal exposes exact descendant path/identity pairs from the accepted no-follow descriptors.
- The root remains in the existing browser-layout directory list but is absent from persistence-ready entries.
- Complete entries are unique and deterministically ordered; incomplete, repeated-identity, unavailable-identity, and symlink cases cannot be exposed as publishable complete truth.
- Existing browser layout and scan behavior remain unchanged.
- No directory-truth persistence API is called by production code.

## Validation

- `cargo test -p wavecrate-scan --lib filesystem_edges` — 12 passed.
- `cargo test -p wavecrate-scan --lib` — 201 passed.
- `cargo check -p wavecrate --tests --bins` — passed.
- Rust 2024 rustfmt check on touched files — passed.
- `git diff --check` and staged diff check — passed.
- `cargo clippy -p wavecrate-scan --lib -- -D warnings` — blocked by four pre-existing warnings in the untouched library dependency.
- `cargo fmt --all -- --check` — reports existing formatting differences in untouched native-app/test files outside this diff.

## Known limitations

This PR only transports scanner facts. Bounded generation allocation/staging and production full-scan invocation of the atomic handoff remain later slices.

User approval is required before merge.