### PR TITLE
feat: allocate directory truth generations

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/directories.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/directories.rs
@@ -260,6 +260,21 @@ impl SourceDatabase {
         batch.commit_auxiliary_state()
     }
 
+    /// Allocate and start the next revision-neutral source-directory generation.
+    ///
+    /// The allocation and staging-row insert share the immediate writer reservation, so a
+    /// concurrent source writer cannot observe and reuse the same generation.
+    pub fn begin_next_source_directory_truth_generation(
+        &self,
+        expected_entry_count: u64,
+    ) -> Result<u64, SourceDbError> {
+        let mut batch = self.write_batch()?;
+        let generation =
+            batch.begin_next_source_directory_truth_generation(expected_entry_count)?;
+        batch.commit_auxiliary_state()?;
+        Ok(generation)
+    }
+
     /// Stage one bounded batch of validated descendant directories.
     pub fn stage_source_directory_truth_entries(
         &self,
@@ -600,6 +615,194 @@ mod tests {
             .unwrap();
         assert_eq!(second.entries.len(), 1);
         assert!(second.next_cursor.is_none());
+    }
+
+    #[test]
+    fn allocator_starts_at_one_for_an_empty_directory_truth_table() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+
+        assert_eq!(
+            db.begin_next_source_directory_truth_generation(0).unwrap(),
+            1
+        );
+        assert_eq!(db.get_revision().unwrap(), 0);
+        assert_eq!(
+            db.connection
+                .query_row(
+                    "SELECT status, expected_entry_count, staged_entry_count, complete
+                     FROM source_directory_generations
+                     WHERE generation = 1",
+                    [],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, i64>(3)?,
+                        ))
+                    },
+                )
+                .unwrap(),
+            ("staging".to_owned(), 0, 0, 1)
+        );
+    }
+
+    #[test]
+    fn allocator_includes_staging_and_finalized_generations() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+
+        assert_eq!(
+            db.begin_next_source_directory_truth_generation(0).unwrap(),
+            1
+        );
+        let finalized = db.begin_next_source_directory_truth_generation(0).unwrap();
+        assert_eq!(finalized, 2);
+        db.finalize_source_directory_truth_generation(finalized, 0)
+            .unwrap();
+
+        let staged_after_finalization = db.begin_next_source_directory_truth_generation(0).unwrap();
+        assert_eq!(staged_after_finalization, 3);
+        db.finalize_source_directory_truth_generation(staged_after_finalization, 1)
+            .unwrap();
+
+        assert_eq!(
+            db.begin_next_source_directory_truth_generation(0).unwrap(),
+            4
+        );
+    }
+
+    #[test]
+    fn allocator_rejects_unrepresentable_entry_count_without_a_row() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let count = i64::MAX as u64 + 1;
+
+        let error = db
+            .begin_next_source_directory_truth_generation(count)
+            .unwrap_err();
+        assert_eq!(
+            directory_error(error),
+            SourceDirectoryTruthError::InvalidEntryCount { count }
+        );
+        assert_eq!(
+            db.connection
+                .query_row(
+                    "SELECT COUNT(*) FROM source_directory_generations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn allocator_rejects_malformed_generation_state_without_allocating() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        db.connection
+            .execute_batch("PRAGMA ignore_check_constraints = ON;")
+            .unwrap();
+        db.connection
+            .execute(
+                "INSERT INTO source_directory_generations (
+                    generation, status, expected_entry_count, staged_entry_count, complete,
+                    published_source_revision, created_at
+                 ) VALUES (0, 'staging', 0, 0, 1, NULL, 0)",
+                [],
+            )
+            .unwrap();
+
+        let error = db
+            .begin_next_source_directory_truth_generation(0)
+            .unwrap_err();
+        assert_eq!(
+            directory_error(error),
+            SourceDirectoryTruthError::RequiresAudit {
+                reason: SourceDirectoryTruthUnavailableReason::Malformed,
+            }
+        );
+        assert_eq!(
+            db.connection
+                .query_row(
+                    "SELECT COUNT(*) FROM source_directory_generations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn allocator_rejects_generation_after_sql_integer_limit_without_allocating() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        db.connection
+            .execute(
+                "INSERT INTO source_directory_generations (
+                    generation, status, expected_entry_count, staged_entry_count, complete,
+                    published_source_revision, created_at
+                 ) VALUES (?1, 'staging', 0, 0, 1, NULL, 0)",
+                [i64::MAX],
+            )
+            .unwrap();
+        let next_generation = i64::MAX as u64 + 1;
+
+        let error = db
+            .begin_next_source_directory_truth_generation(0)
+            .unwrap_err();
+        assert_eq!(
+            directory_error(error),
+            SourceDirectoryTruthError::InvalidGeneration {
+                generation: next_generation,
+            }
+        );
+        assert_eq!(
+            db.connection
+                .query_row(
+                    "SELECT COUNT(*) FROM source_directory_generations",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn allocator_waits_for_an_existing_writer_reservation() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open_for_source_write(root.path()).unwrap();
+        let mut writer = db.write_batch().unwrap();
+        writer
+            .begin_source_directory_truth_generation(1, 0)
+            .unwrap();
+
+        let source_path = root.path().to_path_buf();
+        let (done_tx, done_rx) = mpsc::channel();
+        let allocator_thread = std::thread::spawn(move || {
+            let db = SourceDatabase::open_for_source_write(source_path).unwrap();
+            done_tx
+                .send(db.begin_next_source_directory_truth_generation(0))
+                .unwrap();
+        });
+
+        assert!(done_rx.recv_timeout(Duration::from_millis(50)).is_err());
+        writer.commit_auxiliary_state().unwrap();
+        assert_eq!(
+            done_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("allocator completion")
+                .unwrap(),
+            2
+        );
+        allocator_thread.join().unwrap();
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::OptionalExtension;
+use rusqlite::types::ValueRef;
 
 use super::super::util::{
     map_sql_error, normalize_relative_path, parse_canonical_directory_path_from_db,
@@ -54,6 +55,16 @@ enum DirectoryTruthActivationMode {
 }
 
 impl SourceWriteBatch<'_> {
+    pub(crate) fn begin_next_source_directory_truth_generation(
+        &mut self,
+        expected_entry_count: u64,
+    ) -> Result<u64, SourceDbError> {
+        directory_entry_count_sql_value(expected_entry_count)?;
+        let generation = next_source_directory_truth_generation(&self.tx)?;
+        self.begin_source_directory_truth_generation(generation, expected_entry_count)?;
+        Ok(generation)
+    }
+
     pub(crate) fn begin_source_directory_truth_generation(
         &mut self,
         generation: u64,
@@ -719,6 +730,54 @@ fn directory_generation_sql_value(generation: u64) -> Result<i64, SourceDbError>
     }
     i64::try_from(generation)
         .map_err(|_| SourceDirectoryTruthError::InvalidGeneration { generation }.into())
+}
+
+fn next_source_directory_truth_generation(
+    connection: &rusqlite::Transaction<'_>,
+) -> Result<u64, SourceDbError> {
+    let nonpositive_generation = connection
+        .query_row(
+            "SELECT generation
+             FROM source_directory_generations
+             WHERE generation <= 0
+             LIMIT 1",
+            [],
+            |_| Ok(()),
+        )
+        .optional()
+        .map_err(map_sql_error)?;
+    if nonpositive_generation.is_some() {
+        return Err(directory_requires_audit());
+    }
+
+    let highest_generation = match connection
+        .query_row(
+            "SELECT generation
+             FROM source_directory_generations
+             ORDER BY generation DESC
+             LIMIT 1",
+            [],
+            |row| {
+                Ok(match row.get_ref(0)? {
+                    ValueRef::Integer(value) if value > 0 => Some(value),
+                    _ => None,
+                })
+            },
+        )
+        .optional()
+        .map_err(map_sql_error)?
+    {
+        None => 0,
+        Some(Some(value)) => u64::try_from(value).map_err(|_| directory_requires_audit())?,
+        Some(None) => return Err(directory_requires_audit()),
+    };
+    let next_generation =
+        highest_generation
+            .checked_add(1)
+            .ok_or(SourceDirectoryTruthError::InvalidGeneration {
+                generation: u64::MAX,
+            })?;
+    directory_generation_sql_value(next_generation).map(|_| next_generation)
 }
 
 fn directory_entry_count_sql_value(count: u64) -> Result<i64, SourceDbError> {


### PR DESCRIPTION
## Goal

Advance the Phase 4 source-database implementation toward the I/O architecture target by giving the writer a durable, monotonic directory-truth generation allocator.

## Scope and non-goals

- Add a public writer-owned allocator that reserves the next positive directory-truth generation in one auxiliary-state transaction.
- Inspect only bounded generation rows (LIMIT 1) and fail closed on malformed or unrepresentable state.
- Preserve the existing explicit begin-generation API and all existing staging/finalization/read/cleanup behavior.
- Add coverage for empty, staged/finalized, malformed, overflow, invalid entry-count, and writer-reservation cases.
- No payload staging, activation, scanner wiring, recovery, schema migration, runtime/UI behavior, or production caller is included in this slice.
- The estimate-only document remains untracked locally and is intentionally excluded from this PR.

## Definition of Done

- A caller can obtain the next writer-reserved positive generation without advancing the source revision.
- Existing staging and finalized generations participate in monotonic allocation.
- Invalid generation state and SQL-integer overflow fail without allocating a row.
- The allocator waits for an existing writer reservation under SQLite transaction semantics.
- Focused regression coverage protects the above behavior.

## Validation

- cargo test -p wavecrate-library --lib: 423 passed.
- cargo test -p wavecrate-scan --lib: 201 passed.
- cargo test -p wavecrate-library allocator_ --lib: 6 passed after the final lint correction.
- cargo check -p wavecrate --tests --bins: passed with the repository's temporary Radiant validation link.
- rustfmt check on touched files: passed.
- git diff --check: passed.
- cargo clippy -p wavecrate-library --lib -- -D warnings: blocked only by four pre-existing warnings in untouched files; the new allocator warning was corrected.

## Known limitations

- No production caller consumes the allocator yet; later slices must connect it to bounded payload staging and safe activation.
- The workspace-wide formatter and the full smoke gate retain unrelated repository/environment baseline limitations documented in prior PR validation.

## Review and merge gate

Please review the current complete diff independently. User approval is required before merge; the standing approval condition is to merge only after Terra's independent review returns the terminal verdict APPROVE.