### PR TITLE
feat: type durable operation identities

### DIFF
--- a/docs/IO_ALIGNMENT_ESTIMATE.md
+++ b/docs/IO_ALIGNMENT_ESTIMATE.md
@@ -6,7 +6,7 @@ These are approximate total architecture-alignment estimates for dependency-orde
 
 | Implementation phase | Estimated alignment |
 | --- | ---: |
-| 1. Authority and contracts | 75% |
+| 1. Authority and contracts | 100% |
 | 2. Lifecycle registration and watcher/journal transport | 50% |
 | 3. Coordinator admission and bounded scanner execution | 25% |
 | 4. Source database writes and committed deltas | 60% |
@@ -17,4 +17,8 @@ These are approximate total architecture-alignment estimates for dependency-orde
 
 ## Overall estimate
 
-**Approximately 45% aligned with the design target.**
+**Approximately 48% aligned with the design target.**
+
+This cycle completes the remaining reasonable Authority/contracts work by carrying the opaque
+`OperationId` through durable journal, file-owner, recovery, and pending-history boundaries while
+preserving the UUID-on-disk representation. Later phases remain intentionally unchanged.

--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -10,10 +10,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
-use uuid::Uuid;
 
 use crate::native_app::transaction_history::operation_journal::{
-    BoundedAdmissionError, FilesystemStageOutcome, JournalError, OperationDisposition,
+    BoundedAdmissionError, FilesystemStageOutcome, JournalError, OperationDisposition, OperationId,
     OperationIntent, OperationJournalCoordinator, OperationPhase, PreparedOperationOutcome,
     RecoveryRootCapability,
 };
@@ -143,7 +142,7 @@ enum JournalCommand {
         payload: Value,
         direction: HistoryFileIoDirection,
         actions: Vec<HistoryFileAction>,
-        result: SyncSender<Result<Uuid, JournalOperationError>>,
+        result: SyncSender<Result<OperationId, JournalOperationError>>,
     },
     PrepareBoundedWaveformRestore {
         intent: OperationIntent,
@@ -163,10 +162,10 @@ enum JournalCommand {
     Admit {
         intent: OperationIntent,
         payload: Value,
-        result: SyncSender<Result<Uuid, JournalOperationError>>,
+        result: SyncSender<Result<OperationId, JournalOperationError>>,
     },
     Update {
-        operation_id: Uuid,
+        operation_id: OperationId,
         phase: OperationPhase,
         disposition: OperationDisposition,
         result: SyncSender<Result<(), JournalOperationError>>,
@@ -302,7 +301,7 @@ impl OperationJournalOwner {
         &self,
         intent: OperationIntent,
         payload: Value,
-    ) -> Result<Receiver<Result<Uuid, JournalOperationError>>, JournalOwnerQueueError> {
+    ) -> Result<Receiver<Result<OperationId, JournalOperationError>>, JournalOwnerQueueError> {
         self.ensure_available()?;
         let (result_tx, result_rx) = mpsc::sync_channel(1);
         self.commands
@@ -329,7 +328,7 @@ impl OperationJournalOwner {
         payload: Value,
         direction: HistoryFileIoDirection,
         actions: Vec<HistoryFileAction>,
-    ) -> Result<Receiver<Result<Uuid, JournalOperationError>>, JournalOwnerQueueError> {
+    ) -> Result<Receiver<Result<OperationId, JournalOperationError>>, JournalOwnerQueueError> {
         self.ensure_available()?;
         let (result_tx, result_rx) = mpsc::sync_channel(1);
         self.commands
@@ -416,7 +415,7 @@ impl OperationJournalOwner {
     #[allow(dead_code)]
     pub(in crate::native_app) fn update(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         phase: OperationPhase,
         disposition: OperationDisposition,
     ) -> Result<Receiver<Result<(), JournalOperationError>>, JournalOwnerQueueError> {

--- a/src/native_app/app/state/transactions.rs
+++ b/src/native_app/app/state/transactions.rs
@@ -2,9 +2,10 @@ use crate::native_app::sample_library::committed_file_mutations::ProcessLocalMut
 use crate::native_app::sample_library::committed_file_mutations::RevisionFirstCursor;
 use crate::native_app::transaction_history::HistoryFileIoDirection;
 use crate::native_app::transaction_history::NativeTransactionHistory;
-use crate::native_app::transaction_history::operation_journal::FilesystemStageOutcome;
+use crate::native_app::transaction_history::operation_journal::{
+    FilesystemStageOutcome, OperationId,
+};
 use std::path::PathBuf;
-use uuid::Uuid;
 
 pub(in crate::native_app) struct PendingHistoryCommit {
     pub(in crate::native_app) execution_id: u64,
@@ -22,7 +23,7 @@ pub(in crate::native_app) struct PendingHistoryOwnerStaging {
     pub(in crate::native_app) direction: HistoryFileIoDirection,
     pub(in crate::native_app) through_target: Option<u64>,
     pub(in crate::native_app) label: String,
-    pub(in crate::native_app) operation_id: Uuid,
+    pub(in crate::native_app) operation_id: OperationId,
     pub(in crate::native_app) outcome: FilesystemStageOutcome,
 }
 

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -2,10 +2,10 @@ use super::gui_state_for_span_tests;
 use crate::native_app::app::{OperationJournalRestoreCompletion, OperationJournalRestoreError};
 use crate::native_app::sample_library::committed_file_mutations::PreparedCommittedFileMutationChange;
 use crate::native_app::transaction_history::operation_journal::{
-    FilesystemStageOutcome, ObservedFilesystemClassification, ReplacementCandidateAssessment,
-    ReplacementCandidatePrimitive, ReplacementMissingInvariant, ReplacementPlatformFamily,
-    ReplacementQualificationAssessment, ReplacementQualificationDecision,
-    ReplacementQualificationRetryCondition, VolumeIdentity,
+    FilesystemStageOutcome, ObservedFilesystemClassification, OperationId,
+    ReplacementCandidateAssessment, ReplacementCandidatePrimitive, ReplacementMissingInvariant,
+    ReplacementPlatformFamily, ReplacementQualificationAssessment,
+    ReplacementQualificationDecision, ReplacementQualificationRetryCondition, VolumeIdentity,
 };
 use crate::native_app::transaction_history::{
     HistoryFileAction, HistoryFileIoDirection, HistoryFileIoOutput, HistoryFileIoResult,
@@ -19,7 +19,6 @@ use crate::native_app::{
     },
 };
 use radiant::prelude::{self as ui, IntoView};
-use uuid::Uuid;
 use wavecrate::selection::SelectionRange;
 
 #[test]
@@ -96,22 +95,22 @@ fn platform_qualification_assessment_for_tests() -> ReplacementQualificationAsse
 #[test]
 fn owner_staging_outcomes_retain_history_and_operation_identity() {
     let outcomes = [
-        FilesystemStageOutcome::FilesystemStaged(Uuid::new_v4()),
-        FilesystemStageOutcome::FilesystemPublished(Uuid::new_v4()),
+        FilesystemStageOutcome::FilesystemStaged(OperationId::for_test()),
+        FilesystemStageOutcome::FilesystemPublished(OperationId::for_test()),
         FilesystemStageOutcome::PlatformQualificationRequired {
-            operation_id: Uuid::new_v4(),
+            operation_id: OperationId::for_test(),
             assessment: platform_qualification_assessment_for_tests(),
         },
         FilesystemStageOutcome::RetryPending {
-            operation_id: Uuid::new_v4(),
+            operation_id: OperationId::for_test(),
             reason: String::from("staging collision"),
         },
         FilesystemStageOutcome::AuditRequired {
-            operation_id: Uuid::new_v4(),
+            operation_id: OperationId::for_test(),
             reason: String::from("checkpoint mismatch"),
         },
         FilesystemStageOutcome::JournalWriteFailed {
-            operation_id: Uuid::new_v4(),
+            operation_id: OperationId::for_test(),
             reason: String::from("journal sync failed"),
         },
     ];
@@ -153,16 +152,20 @@ fn owner_staging_outcomes_retain_history_and_operation_identity() {
         assert_eq!(state.transactions.history_through_count, 0);
         assert!(state.ui.status.sample.contains(&operation_id.to_string()));
         if is_platform_qualification {
-            assert!(state
-                .ui
-                .status
-                .sample
-                .contains("safe replacement unavailable on the current platform/build"));
-            assert!(state
-                .ui
-                .status
-                .sample
-                .contains("staged recovery data preserved"));
+            assert!(
+                state
+                    .ui
+                    .status
+                    .sample
+                    .contains("safe replacement unavailable on the current platform/build")
+            );
+            assert!(
+                state
+                    .ui
+                    .status
+                    .sample
+                    .contains("staged recovery data preserved")
+            );
         }
     }
 }
@@ -226,7 +229,7 @@ fn owner_staging_ambiguous_journal_error_retains_history_for_recovery() {
 fn duplicate_owner_staging_completion_does_not_replace_pending_outcome() {
     let mut state = gui_state_for_span_tests();
     let command = begin_owner_restore_for_tests(&mut state);
-    let first_operation_id = Uuid::new_v4();
+    let first_operation_id = OperationId::for_test();
     state.finish_operation_journal_restore(OperationJournalRestoreCompletion {
         execution_id: command.execution_id,
         transaction_id: command.transaction_id,
@@ -236,7 +239,7 @@ fn duplicate_owner_staging_completion_does_not_replace_pending_outcome() {
         result: Ok(FilesystemStageOutcome::FilesystemStaged(first_operation_id)),
     });
     let first_status = state.ui.status.sample.clone();
-    let replacement_operation_id = Uuid::new_v4();
+    let replacement_operation_id = OperationId::for_test();
     state.finish_operation_journal_restore(OperationJournalRestoreCompletion {
         execution_id: command.execution_id,
         transaction_id: command.transaction_id,
@@ -314,7 +317,7 @@ fn stale_owner_staging_completion_preserves_in_flight_transaction() {
         direction: command.direction,
         through_target: command.through_target,
         label: command.label,
-        result: Ok(FilesystemStageOutcome::FilesystemStaged(Uuid::new_v4())),
+        result: Ok(FilesystemStageOutcome::FilesystemStaged(OperationId::for_test())),
     });
     assert!(state.transactions.history.file_io_in_flight());
     assert!(state.transactions.pending_history_owner_staging.is_none());

--- a/src/native_app/transaction_history/absent_final_no_replace.rs
+++ b/src/native_app/transaction_history/absent_final_no_replace.rs
@@ -10,10 +10,9 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use super::operation_journal::{
-    AbsentFinalAdoptionGuardRequest, PreparedFileEvidence, PreparedObjectIdentity,
+    AbsentFinalAdoptionGuardRequest, OperationId, PreparedFileEvidence, PreparedObjectIdentity,
 };
 use super::publication::{PublicationSynchronization, PublicationVisibility};
 
@@ -60,7 +59,7 @@ pub(super) struct AbsentFinalAdoptionRequest<'a> {
 /// this request carries no borrowed descriptor.
 #[cfg(test)]
 pub(super) struct AbsentFinalAdoptionQualificationRequest {
-    pub(super) operation_id: Uuid,
+    pub(super) operation_id: OperationId,
     pub(super) target_parent_path: PathBuf,
     pub(super) final_leaf: PathBuf,
     pub(super) expected_target_parent_stable_id: String,
@@ -81,7 +80,7 @@ pub(super) enum AbsentFinalAdoptionQualificationRequestError {
 #[cfg(test)]
 impl AbsentFinalAdoptionQualificationRequest {
     pub(super) fn try_new(
-        operation_id: Uuid,
+        operation_id: OperationId,
         target_parent_path: PathBuf,
         final_leaf: PathBuf,
         expected_target_parent_stable_id: String,
@@ -143,7 +142,7 @@ impl<'a> AbsentFinalAdoptionRequest<'a> {
 
 impl AbsentFinalAdoptionGuardRequest {
     pub(super) fn try_new(
-        operation_id: Uuid,
+        operation_id: OperationId,
         target_parent_path: PathBuf,
         final_leaf: PathBuf,
         expected_target_parent_stable_id: String,
@@ -168,7 +167,7 @@ impl AbsentFinalAdoptionGuardRequest {
         })
     }
 
-    pub(super) fn operation_id(&self) -> Uuid {
+    pub(super) fn operation_id(&self) -> OperationId {
         self.operation_id
     }
 }
@@ -201,13 +200,13 @@ pub(crate) struct QualifiedAbsentFinalAdoption {
 #[cfg(test)]
 #[derive(Debug, Eq, PartialEq)]
 pub(super) struct AbsentFinalAdoptionQualificationResult {
-    pub(super) operation_id: Uuid,
+    pub(super) operation_id: OperationId,
     pub(super) outcome: AbsentFinalAdoptionOutcome,
 }
 
 #[cfg(test)]
 impl AbsentFinalAdoptionQualificationResult {
-    pub(super) fn operation_id(&self) -> Uuid {
+    pub(super) fn operation_id(&self) -> OperationId {
         self.operation_id
     }
 }
@@ -218,7 +217,7 @@ impl AbsentFinalAdoptionQualificationResult {
 /// descriptors, clean leaf, and exact content hash are the authority for a later binding check;
 /// the configured root pathname is not retained or consulted.
 pub(super) struct QualifiedAbsentFinalAdoptionGuard {
-    operation_id: Uuid,
+    operation_id: OperationId,
     target_parent: File,
     final_object: File,
     final_leaf: PathBuf,
@@ -230,7 +229,7 @@ pub(super) struct QualifiedAbsentFinalAdoptionGuard {
 impl QualifiedAbsentFinalAdoptionGuard {
     pub(super) fn revalidate_binding(
         &self,
-        current_operation_id: Uuid,
+        current_operation_id: OperationId,
     ) -> Result<(), AbsentFinalAdoptionOutcome> {
         #[cfg(unix)]
         {
@@ -246,13 +245,13 @@ impl QualifiedAbsentFinalAdoptionGuard {
         }
     }
 
-    pub(super) fn operation_id(&self) -> Uuid {
+    pub(super) fn operation_id(&self) -> OperationId {
         self.operation_id
     }
 
     fn into_operation_bound_publication(
         self,
-        expected_operation_id: Uuid,
+        expected_operation_id: OperationId,
     ) -> Result<OperationBoundQualifiedAbsentFinalNoReplace, AbsentFinalAdoptionOutcome> {
         // Keep the guard alive until the last possible moment.  This rechecks the retained
         // parent descriptor, retained final descriptor, and the freshly reopened final through
@@ -349,7 +348,7 @@ impl ProductionAbsentFinalAdoptionAdapter {
     pub(super) fn consume_guard_for_publication(
         &self,
         guard: QualifiedAbsentFinalAdoptionGuard,
-        expected_operation_id: Uuid,
+        expected_operation_id: OperationId,
     ) -> Result<OperationBoundQualifiedAbsentFinalNoReplace, AbsentFinalAdoptionOutcome> {
         guard.into_operation_bound_publication(expected_operation_id)
     }
@@ -363,7 +362,7 @@ impl ProductionAbsentFinalAdoptionAdapter {
 /// evidence.
 pub(in crate::native_app) fn acquire_absent_final_publication_guard(
     request: AbsentFinalAdoptionGuardRequest,
-    expected_operation_id: Uuid,
+    expected_operation_id: OperationId,
 ) -> Result<OperationBoundQualifiedAbsentFinalNoReplace, AbsentFinalAdoptionOutcome> {
     let adapter = ProductionAbsentFinalAdoptionAdapter;
     let guard = adapter.acquire_guard(request)?;
@@ -687,18 +686,18 @@ pub(super) struct QualifiedAbsentFinalNoReplace {
 /// boundary.  The journal may only obtain the typed publication evidence by consuming it with the
 /// expected operation ID after its exact record snapshot has been checked.
 pub(in crate::native_app) struct OperationBoundQualifiedAbsentFinalNoReplace {
-    operation_id: Uuid,
+    operation_id: OperationId,
     qualified: QualifiedAbsentFinalNoReplace,
 }
 
 impl OperationBoundQualifiedAbsentFinalNoReplace {
-    pub(super) fn operation_id(&self) -> Uuid {
+    pub(super) fn operation_id(&self) -> OperationId {
         self.operation_id
     }
 
     pub(super) fn into_qualified(
         self,
-        expected_operation_id: Uuid,
+        expected_operation_id: OperationId,
     ) -> Result<QualifiedAbsentFinalNoReplace, AbsentFinalAdoptionOutcome> {
         if self.operation_id != expected_operation_id {
             return Err(AbsentFinalAdoptionOutcome::OperationIdDrift);
@@ -1461,7 +1460,7 @@ mod tests {
             PreparedFileEvidence::ContentHash(hash) => *hash,
             _ => panic!("fixture must have exact content"),
         };
-        let operation_id = Uuid::new_v4();
+        let operation_id = OperationId::for_test();
         let request = AbsentFinalAdoptionQualificationRequest::try_new(
             operation_id,
             fixture.target_parent_path.clone(),
@@ -1493,7 +1492,7 @@ mod tests {
             PreparedFileEvidence::ContentHash(hash) => *hash,
             _ => panic!("fixture must have exact content"),
         };
-        let operation_id = Uuid::new_v4();
+        let operation_id = OperationId::for_test();
         let request = AbsentFinalAdoptionGuardRequest::try_new(
             operation_id,
             fixture.target_parent_path.clone(),
@@ -1524,7 +1523,7 @@ mod tests {
             PreparedFileEvidence::ContentHash(hash) => *hash,
             _ => panic!("fixture must have exact content"),
         };
-        let operation_id = Uuid::new_v4();
+        let operation_id = OperationId::for_test();
         let request = AbsentFinalAdoptionQualificationRequest::try_new(
             operation_id,
             fixture.target_parent_path.clone(),

--- a/src/native_app/transaction_history/absent_final_recovery.rs
+++ b/src/native_app/transaction_history/absent_final_recovery.rs
@@ -13,14 +13,13 @@
 use std::fs::File;
 use std::path::Path;
 use std::path::PathBuf;
-use uuid::Uuid;
 
 use super::absent_final_no_replace::{
     exact_content_evidence_matches, stable_id_and_length_matches,
 };
 use super::operation_journal::{
     AbsentFinalRecoveryObservation, FilesystemStagedParticipant, FilesystemStagedWaveformRestore,
-    PreparedAbsentFinalNoReplace, PreparedFileEvidence, PreparedObjectIdentity,
+    OperationId, PreparedAbsentFinalNoReplace, PreparedFileEvidence, PreparedObjectIdentity,
 };
 #[cfg(unix)]
 use super::operation_journal::{descriptor_identity, open_root, prepared_file_evidence};
@@ -35,7 +34,7 @@ mod sealed {
 /// descriptor, filesystem capability, or mutation authority; the production adapter reacquires
 /// those capabilities before interpreting the locators.
 pub(super) struct AbsentFinalRecoveryRequest {
-    pub(super) operation_id: Uuid,
+    pub(super) operation_id: OperationId,
     pub(super) target_parent_path: PathBuf,
     pub(super) expected_target_parent: PreparedObjectIdentity,
     pub(super) staging_leaf: PathBuf,
@@ -58,7 +57,7 @@ pub(super) enum AbsentFinalRecoveryRequestError {
 impl AbsentFinalRecoveryRequest {
     /// Construct an owned recovery request without touching the filesystem.
     pub(super) fn try_new(
-        operation_id: Uuid,
+        operation_id: OperationId,
         target_parent_path: PathBuf,
         expected_target_parent: PreparedObjectIdentity,
         staging_leaf: PathBuf,
@@ -149,13 +148,13 @@ pub(super) struct AbsentFinalRecoveryInspection {
 /// operation ID before interpreting or persisting the evidence.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct AbsentFinalRecoveryResult {
-    pub(super) operation_id: Uuid,
+    pub(super) operation_id: OperationId,
     pub(super) classification: AbsentFinalRecoveryClassification,
     pub(super) observation: Option<AbsentFinalRecoveryObservation>,
 }
 
 impl AbsentFinalRecoveryResult {
-    pub(super) fn operation_id(&self) -> Uuid {
+    pub(super) fn operation_id(&self) -> OperationId {
         self.operation_id
     }
 }
@@ -222,14 +221,15 @@ pub(super) fn inspect_absent_final_recovery(
     prepared: &PreparedAbsentFinalNoReplace,
     staged: &FilesystemStagedWaveformRestore,
 ) -> AbsentFinalRecoveryInspection {
-    let request = match request_from_prepared(Uuid::nil(), prepared, staged) {
-        Ok(request) => request,
-        Err(_) => {
-            return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
-                AbsentFinalRecoveryAmbiguity::StagingInspectionRaceOrFailure,
-            ));
-        }
-    };
+    let request =
+        match request_from_prepared(OperationId::for_test(), prepared, staged) {
+            Ok(request) => request,
+            Err(_) => {
+                return inspection(AbsentFinalRecoveryClassification::IdentityAmbiguous(
+                    AbsentFinalRecoveryAmbiguity::StagingInspectionRaceOrFailure,
+                ));
+            }
+        };
     let result = ProductionAbsentFinalRecoveryAdapter.inspect(request);
     AbsentFinalRecoveryInspection {
         classification: result.classification,
@@ -436,7 +436,7 @@ fn final_ambiguity(error: LeafInspectionError) -> AbsentFinalRecoveryAmbiguity {
 }
 
 fn request_from_prepared(
-    operation_id: Uuid,
+    operation_id: OperationId,
     prepared: &PreparedAbsentFinalNoReplace,
     staged: &FilesystemStagedWaveformRestore,
 ) -> Result<AbsentFinalRecoveryRequest, AbsentFinalRecoveryRequestError> {
@@ -633,7 +633,7 @@ mod tests {
     #[test]
     fn owned_recovery_request_is_filesystem_free_before_adapter_inspection() {
         let fixture = Fixture::new();
-        let operation_id = Uuid::new_v4();
+        let operation_id = OperationId::for_test();
         let request = request_from_prepared(operation_id, &fixture.prepared, &fixture.staged)
             .expect("durable recovery request");
 

--- a/src/native_app/transaction_history/app_state.rs
+++ b/src/native_app/transaction_history/app_state.rs
@@ -3,15 +3,13 @@ use crate::native_app::app::{
     PendingHistoryCommit, PendingHistoryOwnerStaging,
 };
 use crate::native_app::transaction_history::operation_journal::{
-    FilesystemStageOutcome, OperationActor, OperationIntent, OperationKind,
+    FilesystemStageOutcome, OperationActor, OperationId, OperationIntent, OperationKind,
 };
 use crate::native_app::transaction_history::{
     HistoryFileIoCommand, HistoryFileIoDirection, HistoryFileIoResult, HistoryFileIoRoute,
     TransactionContext, TransactionResult,
 };
 use radiant::prelude as ui;
-use uuid::Uuid;
-
 impl NativeAppState {
     pub(in crate::native_app) fn begin_transaction(&mut self, label: impl Into<String>) {
         if !self.transactions.restoring {
@@ -555,7 +553,7 @@ impl NativeAppState {
     }
 }
 
-fn operation_id_for_stage_outcome(outcome: &FilesystemStageOutcome) -> Uuid {
+fn operation_id_for_stage_outcome(outcome: &FilesystemStageOutcome) -> OperationId {
     match outcome {
         FilesystemStageOutcome::FilesystemStaged(operation_id)
         | FilesystemStageOutcome::FilesystemPublished(operation_id)

--- a/src/native_app/transaction_history/expected_identity_replacement.rs
+++ b/src/native_app/transaction_history/expected_identity_replacement.rs
@@ -7,10 +7,9 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use super::capacity_gate::VolumeIdentity;
-use super::operation_journal::{PreparedFileEvidence, PreparedObjectIdentity};
+use super::operation_journal::{OperationId, PreparedFileEvidence, PreparedObjectIdentity};
 use super::publication::{
     PublicationSynchronization, PublicationVisibility, WholePublicationAtomicity,
 };
@@ -144,7 +143,7 @@ fn classify_candidate(
 /// Filesystem-free durable expectations handed from the journal owner to the physical file
 /// owner. The request contains no descriptor, store, or mutation authority.
 pub(in crate::native_app) struct ExpectedIdentityReplacementOwnerRequest {
-    operation_id: Uuid,
+    operation_id: OperationId,
     target_root_path: PathBuf,
     target_leaf: PathBuf,
     staging_leaf: PathBuf,
@@ -159,7 +158,7 @@ pub(in crate::native_app) struct ExpectedIdentityReplacementOwnerRequest {
 impl ExpectedIdentityReplacementOwnerRequest {
     /// Construct an owned request only from a complete, already-validated durable snapshot.
     pub(super) fn try_new(
-        operation_id: Uuid,
+        operation_id: OperationId,
         target_root_path: PathBuf,
         target_leaf: PathBuf,
         staging_leaf: PathBuf,
@@ -297,7 +296,7 @@ pub(super) enum ExpectedIdentityReplacementOutcome {
 /// Opaque result returned by the physical file owner. It is deliberately neither cloneable nor
 /// serializable; only the operation-bound coordinator may consume it.
 pub(in crate::native_app) struct OperationBoundExpectedIdentityReplacementResult {
-    operation_id: Uuid,
+    operation_id: OperationId,
     outcome: ExpectedIdentityReplacementOutcome,
 }
 
@@ -307,13 +306,13 @@ pub(super) enum ExpectedIdentityReplacementResultError {
 }
 
 impl OperationBoundExpectedIdentityReplacementResult {
-    pub(super) fn operation_id(&self) -> Uuid {
+    pub(super) fn operation_id(&self) -> OperationId {
         self.operation_id
     }
 
     pub(super) fn into_outcome(
         self,
-        expected_operation_id: Uuid,
+        expected_operation_id: OperationId,
     ) -> Result<ExpectedIdentityReplacementOutcome, ExpectedIdentityReplacementResultError> {
         if self.operation_id != expected_operation_id {
             return Err(ExpectedIdentityReplacementResultError::OperationIdDrift);
@@ -322,7 +321,7 @@ impl OperationBoundExpectedIdentityReplacementResult {
     }
 
     #[cfg(test)]
-    pub(super) fn replace_operation_id_for_test(mut self, operation_id: Uuid) -> Self {
+    pub(super) fn replace_operation_id_for_test(mut self, operation_id: OperationId) -> Self {
         self.operation_id = operation_id;
         self
     }

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -59,6 +59,38 @@ const MAX_RECORD_BYTES: usize = 1024 * 1024;
 const RECORD_SUFFIX: &str = ".json";
 const LOCK_FILE_NAME: &str = "owner.lock";
 
+/// Opaque identity for one admitted durable operation.
+///
+/// The UUID representation is an on-disk compatibility detail. Callers must carry this type
+/// across journal and file-owner boundaries instead of manufacturing or comparing raw UUIDs.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct OperationId(Uuid);
+
+impl OperationId {
+    fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    fn from_uuid(value: Uuid) -> Self {
+        Self(value)
+    }
+
+    fn as_uuid(self) -> Uuid {
+        self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for OperationId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
 /// Typed actor that admitted an operation to the journal.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) enum OperationActor {
@@ -329,7 +361,7 @@ pub(crate) struct AbsentFinalAdoptionEvidence {
 /// It owns no descriptor, does not inspect the filesystem, and cannot establish that the locator
 /// currently names the expected objects.
 pub(crate) struct AbsentFinalAdoptionGuardRequest {
-    pub(super) operation_id: Uuid,
+    pub(super) operation_id: OperationId,
     pub(super) target_parent_path: PathBuf,
     pub(super) final_leaf: PathBuf,
     pub(super) expected_target_parent_stable_id: String,
@@ -447,7 +479,7 @@ pub(crate) struct OperationRecord {
     /// Record schema version.
     pub(crate) schema_version: u32,
     /// Stable operation identity.
-    pub(crate) operation_id: Uuid,
+    pub(crate) operation_id: OperationId,
     /// Durable intent.
     pub(crate) intent: OperationIntent,
     /// Last durable coordinator phase.
@@ -594,7 +626,7 @@ impl From<PersistedOperationRecordV1> for OperationRecord {
     fn from(record: PersistedOperationRecordV1) -> Self {
         Self {
             schema_version: record.schema_version,
-            operation_id: record.operation_id,
+            operation_id: OperationId::from_uuid(record.operation_id),
             intent: record.intent,
             phase: record.phase,
             disposition: record.disposition,
@@ -658,7 +690,7 @@ fn persisted_v1_from_record(
     }
     Ok(PersistedOperationRecordV1 {
         schema_version: record.schema_version,
-        operation_id: record.operation_id,
+        operation_id: record.operation_id.as_uuid(),
         intent: record.intent.clone(),
         phase: record.phase,
         disposition: record.disposition,
@@ -740,7 +772,7 @@ impl From<PersistedOperationRecordV2> for OperationRecord {
     fn from(record: PersistedOperationRecordV2) -> Self {
         Self {
             schema_version: record.schema_version,
-            operation_id: record.operation_id,
+            operation_id: OperationId::from_uuid(record.operation_id),
             intent: record.intent,
             phase: record.phase,
             disposition: record.disposition,
@@ -764,7 +796,7 @@ fn persisted_v2_from_record(
 ) -> Result<PersistedOperationRecordV2, io::Error> {
     Ok(PersistedOperationRecordV2 {
         schema_version: record.schema_version,
-        operation_id: record.operation_id,
+        operation_id: record.operation_id.as_uuid(),
         intent: record.intent.clone(),
         phase: record.phase,
         disposition: record.disposition,
@@ -1390,7 +1422,7 @@ fn encode_record(record: &OperationRecord) -> io::Result<Vec<u8>> {
 
 impl OperationRecord {
     /// Construct a new intent record in the durable `IntentDurable` phase.
-    pub(crate) fn new(intent: OperationIntent, payload: Value) -> Self {
+    fn new(intent: OperationIntent, payload: Value) -> Self {
         Self::new_with_capacity_plan(intent, payload, None)
     }
 
@@ -1402,7 +1434,7 @@ impl OperationRecord {
         let now = unix_millis();
         Self {
             schema_version: SCHEMA_V1,
-            operation_id: Uuid::new_v4(),
+            operation_id: OperationId::new(),
             intent,
             phase: OperationPhase::IntentDurable,
             disposition: OperationDisposition::None,
@@ -1941,27 +1973,33 @@ pub(crate) enum JournalError {
     AppDirectory(String),
     /// A requested update did not refer to an admitted operation.
     #[error("operation journal record not found: {0}")]
-    NotFound(Uuid),
+    NotFound(OperationId),
     /// A legacy record remains visible for recovery but cannot be rewritten without losing its
     /// attention-required evidence.
     #[error("operation journal record is retained as non-writable recovery evidence: {0}")]
-    NotWritable(Uuid),
+    NotWritable(OperationId),
     /// A phase transition did not follow the bounded journal state machine.
     #[error("illegal operation journal transition for {operation_id}: {from:?} -> {to:?}")]
     IllegalTransition {
-        operation_id: Uuid,
+        operation_id: OperationId,
         from: OperationPhase,
         to: OperationPhase,
     },
     /// Preparation was requested without a typed descriptor.
     #[error("prepared operation {0} is missing typed evidence")]
-    MissingPreparedEvidence(Uuid),
+    MissingPreparedEvidence(OperationId),
     /// Publication evidence did not prove the complete guarded boundary.
     #[error("invalid publication evidence for operation {operation_id}: {reason}")]
-    InvalidPublicationEvidence { operation_id: Uuid, reason: String },
+    InvalidPublicationEvidence {
+        operation_id: OperationId,
+        reason: String,
+    },
     /// Recovery observation did not match the live or durable absent-final contract.
     #[error("invalid absent-final recovery observation for operation {operation_id}: {reason}")]
-    InvalidRecoveryObservation { operation_id: Uuid, reason: String },
+    InvalidRecoveryObservation {
+        operation_id: OperationId,
+        reason: String,
+    },
 }
 
 /// Result boundary for the bounded pre-intent capacity gate.
@@ -1979,30 +2017,36 @@ pub(crate) enum BoundedAdmissionError {
 /// Outcome after an admitted restore was freshly prepared on the journal owner thread.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum PreparedOperationOutcome {
-    Prepared(Uuid),
-    RetryPending { operation_id: Uuid, reason: String },
-    JournalWriteFailed { operation_id: Uuid, reason: String },
+    Prepared(OperationId),
+    RetryPending {
+        operation_id: OperationId,
+        reason: String,
+    },
+    JournalWriteFailed {
+        operation_id: OperationId,
+        reason: String,
+    },
 }
 
 /// Result after the prepared restore has attempted destination-local staging.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum FilesystemStageOutcome {
-    FilesystemStaged(Uuid),
-    FilesystemPublished(Uuid),
+    FilesystemStaged(OperationId),
+    FilesystemPublished(OperationId),
     PlatformQualificationRequired {
-        operation_id: Uuid,
+        operation_id: OperationId,
         assessment: ReplacementQualificationAssessment,
     },
     RetryPending {
-        operation_id: Uuid,
+        operation_id: OperationId,
         reason: String,
     },
     AuditRequired {
-        operation_id: Uuid,
+        operation_id: OperationId,
         reason: String,
     },
     JournalWriteFailed {
-        operation_id: Uuid,
+        operation_id: OperationId,
         reason: String,
     },
 }
@@ -2028,8 +2072,8 @@ enum RetainedRecord {
 pub(crate) struct OperationJournalStore {
     directory: PathBuf,
     _ownership: OwnershipLock,
-    records: BTreeMap<Uuid, OperationRecord>,
-    non_writable: BTreeSet<Uuid>,
+    records: BTreeMap<OperationId, OperationRecord>,
+    non_writable: BTreeSet<OperationId>,
     retained: Vec<RetainedRecord>,
     recovery: RecoverySummary,
     capacity_claims: BTreeMap<VolumeIdentity, u64>,
@@ -2064,11 +2108,11 @@ impl OperationJournalStore {
     }
 
     /// Return a typed record currently retained by the store.
-    pub(crate) fn record(&self, operation_id: Uuid) -> Option<&OperationRecord> {
+    pub(crate) fn record(&self, operation_id: OperationId) -> Option<&OperationRecord> {
         self.records.get(&operation_id)
     }
 
-    fn ensure_writable(&self, operation_id: Uuid) -> Result<(), JournalError> {
+    fn ensure_writable(&self, operation_id: OperationId) -> Result<(), JournalError> {
         if self.non_writable.contains(&operation_id) {
             Err(JournalError::NotWritable(operation_id))
         } else {
@@ -2144,7 +2188,7 @@ impl OperationJournalStore {
     /// Durably replace one existing record as an atomic update.
     pub(crate) fn update(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         phase: OperationPhase,
         disposition: OperationDisposition,
     ) -> Result<(), JournalError> {
@@ -2154,7 +2198,7 @@ impl OperationJournalStore {
     /// Durably replace one staged record with its latest platform qualification assessment.
     fn update_with_replacement_qualification(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         assessment: ReplacementQualificationAssessment,
     ) -> Result<(), JournalError> {
         self.update_with_optional_replacement_qualification(
@@ -2167,7 +2211,7 @@ impl OperationJournalStore {
 
     fn update_with_optional_replacement_qualification(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         phase: OperationPhase,
         disposition: OperationDisposition,
         replacement_qualification: Option<ReplacementQualificationAssessment>,
@@ -2262,7 +2306,7 @@ impl OperationJournalStore {
 
     fn guarded_prepare(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         prepared: PreparedWaveformRestore,
     ) -> Result<(), JournalError> {
         let current = self
@@ -2298,7 +2342,7 @@ impl OperationJournalStore {
 
     fn guarded_stage(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         staged: FilesystemStagedWaveformRestore,
     ) -> Result<(), JournalError> {
         let current = self
@@ -2350,7 +2394,7 @@ impl OperationJournalStore {
     #[cfg(test)]
     fn record_absent_final_recovery_observation(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         observation: AbsentFinalRecoveryObservation,
     ) -> Result<(), JournalError> {
         let current = self
@@ -2392,7 +2436,7 @@ impl OperationJournalStore {
     #[cfg(test)]
     fn record_absent_final_transaction_owned_proof(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         proof: AbsentFinalTransactionOwnedProof,
     ) -> Result<(), JournalError> {
         let current = self
@@ -2434,7 +2478,7 @@ impl OperationJournalStore {
     #[cfg(test)]
     fn record_absent_final_adoption_evidence(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         evidence: AbsentFinalAdoptionEvidence,
     ) -> Result<(), JournalError> {
         let current = self
@@ -2475,7 +2519,7 @@ impl OperationJournalStore {
 
     fn guarded_publish(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         published: FilesystemPublishedWaveformRestore,
     ) -> Result<(), JournalError> {
         let current = self
@@ -2580,7 +2624,7 @@ impl OperationJournalStore {
         }
     }
 
-    fn record_path(&self, operation_id: Uuid) -> PathBuf {
+    fn record_path(&self, operation_id: OperationId) -> PathBuf {
         self.directory
             .join(format!("{operation_id}{RECORD_SUFFIX}"))
     }
@@ -2664,7 +2708,8 @@ impl OperationJournalStore {
             let filename_id = path
                 .file_stem()
                 .and_then(|stem| stem.to_str())
-                .and_then(|stem| Uuid::parse_str(stem).ok());
+                .and_then(|stem| Uuid::parse_str(stem).ok())
+                .map(OperationId::from_uuid);
             if filename_id != Some(record.operation_id)
                 || self.records.contains_key(&record.operation_id)
             {
@@ -2869,7 +2914,7 @@ impl ExpectedIdentityPublicationAttemptContext {
 
 #[cfg(test)]
 fn validate_absent_final_recovery_result_operation_id(
-    operation_id: Uuid,
+    operation_id: OperationId,
     result: AbsentFinalRecoveryResult,
 ) -> Result<AbsentFinalRecoveryResult, JournalError> {
     if result.operation_id() != operation_id {
@@ -2885,7 +2930,7 @@ fn validate_absent_final_recovery_result_operation_id(
 
 #[cfg(test)]
 fn validate_absent_final_adoption_result_operation_id(
-    operation_id: Uuid,
+    operation_id: OperationId,
     result: AbsentFinalAdoptionQualificationResult,
 ) -> Result<AbsentFinalAdoptionOutcome, JournalError> {
     if result.operation_id() != operation_id {
@@ -3432,7 +3477,7 @@ pub(super) fn prepared_file_evidence(file: &File) -> PreparedFileEvidence {
 }
 
 fn prepare_descriptor(
-    operation_id: Uuid,
+    operation_id: OperationId,
     direction: super::file_io::HistoryFileIoDirection,
     actions: &[super::file_io::HistoryFileAction],
     capacity_plan: &DurableCapacityPlan,
@@ -3572,7 +3617,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     pub(crate) fn classify_schema_v2_absent_final_recovery(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<AbsentFinalRecoveryClassification, JournalError> {
         Ok(self
             .run_schema_v2_absent_final_recovery(operation_id)?
@@ -3583,7 +3628,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     fn prepare_schema_v2_absent_final_recovery_request(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<AbsentFinalRecoveryRequest, JournalError> {
         let record = self
             .store
@@ -3661,7 +3706,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     fn run_schema_v2_absent_final_recovery(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<AbsentFinalRecoveryResult, JournalError> {
         let request = self.prepare_schema_v2_absent_final_recovery_request(operation_id)?;
         let result = ProductionAbsentFinalRecoveryAdapter.inspect(request);
@@ -3674,7 +3719,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     pub(crate) fn record_schema_v2_absent_final_recovery_observation(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<AbsentFinalRecoveryClassification, JournalError> {
         let result = self.run_schema_v2_absent_final_recovery(operation_id)?;
         let existing = self
@@ -3726,7 +3771,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     pub(crate) fn record_schema_v2_absent_final_transaction_owned_proof(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<AbsentFinalRecoveryClassification, JournalError> {
         let result = self.run_schema_v2_absent_final_recovery(operation_id)?;
         let AbsentFinalRecoveryClassification::StagingMissingFinalMatches = result.classification
@@ -3794,7 +3839,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     pub(crate) fn qualify_schema_v2_absent_final_adoption(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<AbsentFinalAdoptionOutcome, JournalError> {
         let recovery = self
             .run_schema_v2_absent_final_recovery(operation_id)
@@ -3906,7 +3951,7 @@ impl OperationJournalCoordinator {
     /// phase/timestamps or capacity, or exposes a handle.
     fn prepare_absent_final_publication_attempt(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<AbsentFinalPublicationAttemptContext, JournalError> {
         let authorizing_record = self
             .store
@@ -3928,7 +3973,7 @@ impl OperationJournalCoordinator {
     /// result is committed or rejected.
     pub(crate) fn prepare_absent_final_publication_attempt_if_needed(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<Option<AbsentFinalPublicationAttemptContext>, JournalError> {
         let record = self
             .store
@@ -3948,7 +3993,7 @@ impl OperationJournalCoordinator {
 
     fn prepare_absent_final_adoption_guard_request_from_record(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         record: &OperationRecord,
     ) -> Result<AbsentFinalAdoptionGuardRequest, JournalError> {
         if record.operation_id != operation_id {
@@ -4082,7 +4127,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     pub(crate) fn prepare_schema_v2_absent_final_adoption_guard_request(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<AbsentFinalAdoptionGuardRequest, JournalError> {
         let mut context = self.prepare_absent_final_publication_attempt(operation_id)?;
         context.take_guard_request()
@@ -4093,7 +4138,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     pub(crate) fn record_schema_v2_absent_final_adoption_evidence(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<AbsentFinalRecoveryClassification, JournalError> {
         let outcome = self.qualify_schema_v2_absent_final_adoption(operation_id)?;
         let AbsentFinalAdoptionOutcome::Qualified(qualified) = outcome else {
@@ -4151,7 +4196,7 @@ impl OperationJournalCoordinator {
         &mut self,
         intent: OperationIntent,
         payload: Value,
-    ) -> Result<Uuid, JournalError> {
+    ) -> Result<OperationId, JournalError> {
         let record = OperationRecord::new(intent, payload);
         let operation_id = record.operation_id;
         self.store.admit(record)?;
@@ -4168,7 +4213,7 @@ impl OperationJournalCoordinator {
         prepared: PreparedAbsentFinalNoReplace,
         staged: FilesystemStagedWaveformRestore,
         capacity_plan: DurableCapacityPlan,
-    ) -> Result<Uuid, JournalError> {
+    ) -> Result<OperationId, JournalError> {
         let record = OperationRecord::new_v2_absent_final_with_capacity_plan(
             intent,
             payload,
@@ -4198,7 +4243,7 @@ impl OperationJournalCoordinator {
     }
 
     #[cfg(test)]
-    pub(super) fn record_path_for_test(&self, operation_id: Uuid) -> PathBuf {
+    pub(super) fn record_path_for_test(&self, operation_id: OperationId) -> PathBuf {
         self.store.record_path(operation_id)
     }
 
@@ -4214,7 +4259,7 @@ impl OperationJournalCoordinator {
         payload: Value,
         direction: super::file_io::HistoryFileIoDirection,
         actions: &[super::file_io::HistoryFileAction],
-    ) -> Result<Uuid, BoundedAdmissionError> {
+    ) -> Result<OperationId, BoundedAdmissionError> {
         if self.store.capacity_blocked() {
             return Err(RejectedBeforeIntent::RecoveryBlocked.into());
         }
@@ -4247,7 +4292,7 @@ impl OperationJournalCoordinator {
 
     fn prepare_admitted_bounded_waveform_restore(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         direction: super::file_io::HistoryFileIoDirection,
         actions: &[super::file_io::HistoryFileAction],
     ) -> Result<PreparedOperationOutcome, BoundedAdmissionError> {
@@ -4296,7 +4341,7 @@ impl OperationJournalCoordinator {
     /// `CopyValidated` participant checkpoint. This deliberately stops before final replacement.
     pub(crate) fn stage_admitted_bounded_waveform_restore(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<FilesystemStageOutcome, JournalError> {
         let record = self
             .store
@@ -4501,7 +4546,7 @@ impl OperationJournalCoordinator {
 
     fn stage_retry_or_audit(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         phase: OperationPhase,
         reason: String,
     ) -> Result<FilesystemStageOutcome, JournalError> {
@@ -4533,7 +4578,7 @@ impl OperationJournalCoordinator {
 
     fn validate_already_published_absent_final_noop(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<FilesystemStageOutcome, JournalError> {
         let record = self
             .store
@@ -4656,7 +4701,7 @@ impl OperationJournalCoordinator {
 
     fn prepare_expected_identity_publication_attempt(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<ExpectedIdentityPublicationAttemptContext, JournalError> {
         let authorizing_record = self
             .store
@@ -4754,7 +4799,7 @@ impl OperationJournalCoordinator {
     /// intentionally return `None` so the two publication owner paths cannot cross-dispatch.
     pub(crate) fn prepare_expected_identity_publication_attempt_if_needed(
         &self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<Option<ExpectedIdentityPublicationAttemptContext>, JournalError> {
         let record = self
             .store
@@ -4860,7 +4905,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     fn attempt_publish_staged_waveform_restore(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<FilesystemStageOutcome, JournalError> {
         let (phase, is_absent_final) = {
             let record = self
@@ -4905,7 +4950,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     fn attempt_publish_staged_waveform_restore_with_adapter(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         adapter: &super::expected_identity_replacement::TestQualifiedExpectedIdentityReplacementAdapter,
     ) -> Result<FilesystemStageOutcome, JournalError> {
         let mut context = self
@@ -4926,7 +4971,7 @@ impl OperationJournalCoordinator {
 
     fn update_platform_qualification(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         assessment: ReplacementQualificationAssessment,
     ) -> Result<FilesystemStageOutcome, JournalError> {
         match self
@@ -4946,7 +4991,7 @@ impl OperationJournalCoordinator {
 
     fn update_attempt_disposition(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         disposition: OperationDisposition,
         reason: String,
     ) -> Result<FilesystemStageOutcome, JournalError> {
@@ -4980,7 +5025,7 @@ impl OperationJournalCoordinator {
     #[cfg(test)]
     fn guarded_publish(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         published: FilesystemPublishedWaveformRestore,
     ) -> Result<(), JournalError> {
         self.store.guarded_publish(operation_id, published)
@@ -4989,7 +5034,7 @@ impl OperationJournalCoordinator {
     /// Advance phase/disposition through one atomic durable record replacement.
     pub(crate) fn update(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         phase: OperationPhase,
         disposition: OperationDisposition,
     ) -> Result<(), JournalError> {
@@ -5010,14 +5055,14 @@ impl OperationJournalCoordinator {
     /// Guarded, idempotent IntentDurable -> Prepared transition for validated evidence.
     pub(crate) fn guarded_prepare(
         &mut self,
-        operation_id: Uuid,
+        operation_id: OperationId,
         prepared: PreparedWaveformRestore,
     ) -> Result<(), JournalError> {
         self.store.guarded_prepare(operation_id, prepared)
     }
 
     /// Return a typed operation record, if present.
-    pub(crate) fn record(&self, operation_id: Uuid) -> Option<&OperationRecord> {
+    pub(crate) fn record(&self, operation_id: OperationId) -> Option<&OperationRecord> {
         self.store.record(operation_id)
     }
 }
@@ -5301,6 +5346,27 @@ mod tests {
         }
     }
 
+    #[test]
+    fn operation_id_keeps_uuid_json_and_filename_compatibility() {
+        let uuid =
+            Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").expect("valid operation UUID");
+        let operation_id = OperationId::from_uuid(uuid);
+        let mut record = OperationRecord::new(intent(), Value::Null);
+        record.operation_id = operation_id;
+        let persisted = schema_v1_value(&record);
+
+        assert_eq!(
+            persisted["operation_id"],
+            serde_json::json!(uuid)
+        );
+        assert_eq!(operation_id.to_string(), uuid.to_string());
+        assert_eq!(format!("{operation_id}.json"), format!("{uuid}.json"));
+
+        let decoded: PersistedOperationRecordV1 =
+            serde_json::from_value(persisted).expect("deserialize persisted operation record");
+        assert_eq!(OperationId::from_uuid(decoded.operation_id), operation_id);
+    }
+
     fn schema_v1_bytes(record: &OperationRecord) -> Vec<u8> {
         encode_schema_v1(record).expect("encode schema-v1 fixture")
     }
@@ -5340,9 +5406,9 @@ mod tests {
 
     #[test]
     fn absent_final_adapter_results_are_operation_fenced_before_use() {
-        let operation_id = Uuid::new_v4();
+        let operation_id = OperationId::for_test();
         let recovery_result = AbsentFinalRecoveryResult {
-            operation_id: Uuid::new_v4(),
+            operation_id: OperationId::for_test(),
             classification: AbsentFinalRecoveryClassification::NeitherPresent,
             observation: None,
         };
@@ -5353,7 +5419,7 @@ mod tests {
         ));
 
         let adoption_result = AbsentFinalAdoptionQualificationResult {
-            operation_id: Uuid::new_v4(),
+            operation_id: OperationId::for_test(),
             outcome: AbsentFinalAdoptionOutcome::UnsupportedPlatform,
         };
         assert!(matches!(
@@ -5411,7 +5477,7 @@ mod tests {
     fn admit_absent_final_v2_fixture(
         journal: &mut OperationJournalCoordinator,
     ) -> (
-        Uuid,
+        OperationId,
         PreparedAbsentFinalNoReplace,
         FilesystemStagedWaveformRestore,
     ) {
@@ -5432,7 +5498,7 @@ mod tests {
     fn admit_real_absent_final_v2_fixture(
         journal: &mut OperationJournalCoordinator,
         directory: &tempfile::TempDir,
-    ) -> (Uuid, PathBuf, PathBuf) {
+    ) -> (OperationId, PathBuf, PathBuf) {
         let target_parent_path = directory.path().join("target-parent");
         fs::create_dir(&target_parent_path).expect("real target parent");
         let staging_path = target_parent_path.join("staging.wav");
@@ -5482,7 +5548,7 @@ mod tests {
     fn admit_real_absent_final_v2_adoption_fixture(
         journal: &mut OperationJournalCoordinator,
         directory: &tempfile::TempDir,
-    ) -> (Uuid, PathBuf, PathBuf) {
+    ) -> (OperationId, PathBuf, PathBuf) {
         let (operation_id, final_path, staging_path) =
             admit_real_absent_final_v2_fixture(journal, directory);
         fs::rename(&staging_path, &final_path).expect("staging to final rename");
@@ -5501,7 +5567,7 @@ mod tests {
     #[cfg(unix)]
     fn publish_absent_final_via_owner_route(
         journal: &mut OperationJournalCoordinator,
-        operation_id: Uuid,
+        operation_id: OperationId,
     ) -> Result<FilesystemStageOutcome, JournalError> {
         let mut context = journal
             .prepare_absent_final_publication_attempt_if_needed(operation_id)?
@@ -5538,7 +5604,7 @@ mod tests {
         }
     }
 
-    fn v2_absent_record_on_disk() -> (tempfile::TempDir, Uuid, PathBuf, Value) {
+    fn v2_absent_record_on_disk() -> (tempfile::TempDir, OperationId, PathBuf, Value) {
         let directory = tempfile::tempdir().unwrap();
         let mut journal = OperationJournalCoordinator::open(directory.path().to_path_buf())
             .expect("open v2 fixture journal");
@@ -5553,7 +5619,7 @@ mod tests {
         phase: OperationPhase,
         disposition: OperationDisposition,
         evidence: SchemaV2EvidencePresence,
-    ) -> (tempfile::TempDir, Uuid, PathBuf, Vec<u8>) {
+    ) -> (tempfile::TempDir, OperationId, PathBuf, Vec<u8>) {
         let (directory, operation_id, path, mut value) = v2_absent_record_on_disk();
         let prepared_value = value["prepared"].clone();
         let staged_value = value["staged"].clone();
@@ -5769,7 +5835,7 @@ mod tests {
     fn assert_unknown_nested_record_is_retained_unchanged(
         directory: &Path,
         path: &Path,
-        operation_id: Uuid,
+        operation_id: OperationId,
         bytes: &[u8],
     ) {
         for _ in 0..2 {
@@ -6064,7 +6130,7 @@ mod tests {
         tempfile::TempDir,
         tempfile::TempDir,
         OperationJournalCoordinator,
-        Uuid,
+        OperationId,
         PathBuf,
         PathBuf,
         PathBuf,
@@ -6308,7 +6374,7 @@ mod tests {
                     drift: None,
                 },
             )
-            .replace_operation_id_for_test(Uuid::new_v4());
+            .replace_operation_id_for_test(OperationId::for_test());
         let record_before = journal.record(id).unwrap().clone();
         let claims_before = journal.store.capacity_claims().clone();
         let target_before = fs::read(&target).unwrap();
@@ -7569,7 +7635,7 @@ mod tests {
 
     fn assert_malformed_qualification_recovery(
         journal: &OperationJournalCoordinator,
-        operation_id: Uuid,
+        operation_id: OperationId,
         path: &Path,
         bytes: &[u8],
     ) {
@@ -8740,7 +8806,7 @@ mod tests {
             .expect("absent-final owner handoff");
         let request = context.take_guard_request().expect("take owner request");
         assert!(matches!(
-            super::super::acquire_absent_final_publication_guard(request, Uuid::new_v4()),
+            super::super::acquire_absent_final_publication_guard(request, OperationId::for_test()),
             Err(AbsentFinalAdoptionOutcome::OperationIdDrift)
         ));
         assert_eq!(journal.record(operation_id), Some(&record_before));


### PR DESCRIPTION
## Goal

Complete the remaining reasonable Authority and contracts alignment slice by making durable operation identity an opaque typed boundary.

## Scope and non-goals

Scope:
- Introduce OperationId(Uuid) and carry it through the operation journal, journal owner, file-owner evidence, absent-final recovery, and pending-history state boundaries.
- Preserve UUID JSON encoding and <uuid>.json journal filenames.
- Add a UUID compatibility regression test.
- Update docs/IO_ALIGNMENT_ESTIMATE.md to Authority/contracts 100% and overall 48%.

Non-goals:
- No coordinator, telemetry, watcher/Finder, projection, readiness, schema, or PR #980 work.
- No journal schema bump or migration.

## Definition of Done

- Raw UUID operation identities no longer cross the named production boundaries.
- Journal admission remains the only source of operation IDs.
- Operation-bound drift remains fail-closed.
- Legacy schema-v1/v2 records retain their persisted representation and reopen behavior.
- Estimate document records the completed Authority/contracts category.

## Validation

- cargo check -p wavecrate --tests --bins — passed using Radiant revision 13ae1f524313a5257fee6691679799a1aca99d32 declared by this repository.
- cargo test -p wavecrate --lib native_app::transaction_history — 157 passed.
- cargo test -p wavecrate --lib native_app::tests::transactions — 23 passed.
- cargo test -p wavecrate --lib operation_id_keeps_uuid_json_and_filename_compatibility — 1 passed.
- git diff --check — passed.
- cargo fmt --all -- --check — existing unrelated formatting drift remains in harvest/source-diagnostics/playmark/release-contract files; changed hunks are formatted.
- A broad cargo test -p wavecrate --lib run exposed unrelated existing UI/audio failures and over-60-second hangs and was stopped; focused gates above are green.

## Known limitations

The full-suite UI/audio failures and hangs are pre-existing environment/baseline limitations and are outside this contract-only diff. Later I/O target phases remain intentionally below 100%.

User approval is required before merge; this task grants conditional merge authority if Terra returns a positive review.