### PR TITLE
fix: align Wavecrate with Radiant input metadata API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "13ae1f524313a5257fee6691679799a1aca99d32"
+revision = "9220dce1fb8889c69454825f2f042f0cb6ec8698"
 path = "../radiant"
 
 [package]

--- a/radiant-dependency.toml
+++ b/radiant-dependency.toml
@@ -4,5 +4,5 @@
 # sibling may remain on a feature branch or contain uncommitted work. Setup,
 # CI, and release helpers provision this exact revision into a clean checkout.
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "13ae1f524313a5257fee6691679799a1aca99d32"
+revision = "9220dce1fb8889c69454825f2f042f0cb6ec8698"
 path = "../radiant"

--- a/src/native_app/app_chrome/library_browser/library_sidebar/collections_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/collections_section/tests.rs
@@ -48,7 +48,9 @@ fn collection_input_routes_double_click_to_rename() {
     assert!(matches!(
         collection_row(&row).view_dispatch_widget_output(
             retained_collection_row_input_id(collection_id),
-            ui::WidgetOutput::typed(ui::InteractiveRowMessage::DoubleActivate),
+            ui::WidgetOutput::typed(ui::InteractiveRowMessage::DoubleActivate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::RenameCollection(collection)

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -198,7 +198,9 @@ fn filter_section_filter_labels_dispatch_family_enable_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_filter_family_label_toggle_id("Name"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SetFilterFamilyEnabled(FilterFamily::Name, false)
@@ -207,7 +209,9 @@ fn filter_section_filter_labels_dispatch_family_enable_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_filter_family_label_toggle_id("Rating"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SetFilterFamilyEnabled(FilterFamily::Rating, false)
@@ -216,7 +220,9 @@ fn filter_section_filter_labels_dispatch_family_enable_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_filter_family_label_toggle_id("Tags"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SetFilterFamilyEnabled(FilterFamily::Tags, true)
@@ -287,7 +293,9 @@ fn filter_section_projects_curation_scope_dropdown_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             CURATION_FILTER_DROPDOWN_TRIGGER_ID,
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::ToggleCurationFilterDropdown)
     );
@@ -342,7 +350,9 @@ fn filter_section_projects_curation_scope_dropdown_and_dispatches_changes() {
             .expect("open curation dropdown should project an overlay menu")
             .view_dispatch_widget_output(
                 automation_curation_filter_dropdown_option_id("Tags"),
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SetCurationScope(BrowserCurationScope::Tags, true)
@@ -385,7 +395,9 @@ fn filter_section_uses_harvest_dropdown_as_only_filter_mode_trigger() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             HARVEST_FILTER_DROPDOWN_TRIGGER_ID,
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::ToggleHarvestFilterDropdown)
     );
@@ -411,7 +423,9 @@ fn filter_section_projects_harvest_filter_dropdown_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             HARVEST_FILTER_DROPDOWN_TRIGGER_ID,
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::ToggleHarvestFilterDropdown)
     );
@@ -452,7 +466,9 @@ fn filter_section_projects_harvest_filter_dropdown_and_dispatches_changes() {
                 .expect("open harvest dropdown should project an overlay menu")
                 .view_dispatch_widget_output(
                     automation_harvest_filter_dropdown_option_id(label),
-                    ui::WidgetOutput::typed(ButtonMessage::Activate),
+                    ui::WidgetOutput::typed(ButtonMessage::Activate {
+                        provenance: ui::InteractionProvenance::Programmatic,
+                    }),
                 ),
             Some(GuiMessage::FolderBrowser(
                 FolderBrowserMessage::SetHarvestFilter(filter, true)
@@ -503,7 +519,9 @@ fn filter_section_hides_clear_buttons_when_filters_are_empty() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             name_filter_clear_button_id(),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         None
     );
@@ -537,7 +555,9 @@ fn filter_section_projects_name_clear_button_for_active_name_filter() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             name_filter_clear_button_id(),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::NameFilterInput(empty_filter_message())
@@ -573,7 +593,9 @@ fn filter_section_projects_tag_clear_button_for_active_tag_filter() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             tag_filter_clear_button_id(),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::TagFilterInput(empty_filter_message())
@@ -610,7 +632,9 @@ fn filter_section_projects_playback_type_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_playback_type_filter_toggle_id("1-Shot"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::TogglePlaybackTypeFilter(PlaybackTypeFilter::OneShot, true)
@@ -619,7 +643,9 @@ fn filter_section_projects_playback_type_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_playback_type_filter_toggle_id("Loop"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::TogglePlaybackTypeFilter(PlaybackTypeFilter::Loop, false)
@@ -769,7 +795,9 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_rating_filter_toggle_id("K4"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ToggleRatingFilter(4, true)
@@ -778,7 +806,9 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_rating_filter_toggle_id("U"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ToggleRatingFilter(0, false)
@@ -787,7 +817,9 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_rating_filter_toggle_id("T3"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ToggleRatingFilter(-3, false)

--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/status.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/status.rs
@@ -129,7 +129,9 @@ mod tests {
             )
             .view_dispatch_widget_output(
                 widget_ids::FOLDER_TREE_INCLUDE_SUBFOLDERS_TOGGLE_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::FolderBrowser(
                 FolderBrowserMessage::ToggleFolderSubtreeListing
@@ -166,7 +168,9 @@ mod tests {
             )
             .view_dispatch_widget_output(
                 widget_ids::FOLDER_TREE_SHOW_EMPTY_FOLDERS_TOGGLE_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::FolderBrowser(
                 FolderBrowserMessage::ToggleEmptyFolderVisibility

--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/tests.rs
@@ -321,6 +321,7 @@ fn standard_folder_rows_derive_stable_input_id_from_row_key() {
             position,
             button: ui::PointerButton::Primary,
             modifiers: Default::default(),
+            timestamp: None,
         },
     );
     let output = surface.dispatch_widget_input(
@@ -330,6 +331,7 @@ fn standard_folder_rows_derive_stable_input_id_from_row_key() {
             position,
             button: ui::PointerButton::Primary,
             modifiers: Default::default(),
+            timestamp: None,
         },
     );
 

--- a/src/native_app/app_chrome/library_browser/library_sidebar/harvest_family.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/harvest_family.rs
@@ -130,21 +130,27 @@ mod tests {
         assert_eq!(
             harvest_family_section(&harvest_family_model()).view_dispatch_widget_output(
                 widget_ids::HARVEST_FAMILY_ORIGIN_BUTTON_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::ShowSelectedSampleHarvestOrigin)
         );
         assert_eq!(
             harvest_family_section(&harvest_family_model()).view_dispatch_widget_output(
                 widget_ids::HARVEST_FAMILY_DERIVATIVES_BUTTON_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::ShowSelectedSampleHarvestDerivatives)
         );
         assert_eq!(
             harvest_family_section(&harvest_family_model()).view_dispatch_widget_output(
                 widget_ids::HARVEST_FAMILY_DESTINATION_BUTTON_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::OpenSelectedSampleHarvestDestination)
         );

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
@@ -110,7 +110,9 @@ fn source_add_button_routes_add_source_message() {
     assert_eq!(
         source_add_button(false).view_dispatch_widget_output(
             AUTOMATION_SOURCE_ADD_BUTTON_ID,
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(FolderBrowserMessage::AddSource))
     );
@@ -178,7 +180,9 @@ fn source_row_routes_primary_activation_through_interactive_row() {
     assert_eq!(
         source_row(row).view_dispatch_widget_output(
             retained_source_row_input_id(source.id.as_str()),
-            ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate),
+            ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SelectSource(source.id.clone())
@@ -373,7 +377,9 @@ fn source_row_keeps_actions_enabled_while_processing_feedback_is_overlay_owned()
     assert_eq!(
         source_row(row).view_dispatch_widget_output(
             retained_source_row_input_id(source.id.as_str()),
-            ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate),
+            ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SelectSource(source.id.clone())

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target_tests.rs
@@ -200,7 +200,9 @@ fn production_hit_target_derives_stable_input_identity_from_sample_row_key() {
     )
     .view_dispatch_widget_output(
         input_id,
-        WidgetOutput::typed(InteractiveRowMessage::DoubleActivate),
+        WidgetOutput::typed(InteractiveRowMessage::DoubleActivate {
+            provenance: radiant::widgets::InteractionProvenance::Programmatic,
+        }),
     );
 
     assert_eq!(

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
@@ -494,6 +494,7 @@ impl Widget for StarmapWidget {
                 pointer,
                 button: PointerButton::Primary,
                 modifiers,
+                ..
             } => self.begin_audition_drag_message(bounds, pointer.position, modifiers),
             CanvasGestureEvent::Drag {
                 pointer,
@@ -501,7 +502,7 @@ impl Widget for StarmapWidget {
                 modifiers,
                 ..
             } => self.update_audition_drag_message(bounds, pointer.position, modifiers),
-            CanvasGestureEvent::Hover(pointer) if self.active_drag.is_some() => self
+            CanvasGestureEvent::Hover { pointer, .. } if self.active_drag.is_some() => self
                 .update_audition_drag_message(
                     bounds,
                     pointer.position,
@@ -510,7 +511,7 @@ impl Widget for StarmapWidget {
                         .map(|drag| drag.modifiers)
                         .unwrap_or_default(),
                 ),
-            CanvasGestureEvent::Hover(pointer) => {
+            CanvasGestureEvent::Hover { pointer, .. } => {
                 self.set_hovered_file_at(bounds, pointer.position);
                 None
             }
@@ -537,7 +538,7 @@ impl Widget for StarmapWidget {
                     },
                 )))
             }
-            CanvasGestureEvent::Wheel { pointer, delta } => {
+            CanvasGestureEvent::Wheel { pointer, delta, .. } => {
                 let factor = if delta.y < 0.0 { 1.15 } else { 1.0 / 1.15 };
                 Some(WidgetOutput::typed(GuiMessage::ChangeStarmapViewport(
                     StarmapViewportChange::Zoom {
@@ -550,6 +551,7 @@ impl Widget for StarmapWidget {
                 pointer,
                 button: PointerButton::Primary,
                 modifiers,
+                ..
             } => self.begin_audition_drag_message(bounds, pointer.position, modifiers),
             CanvasGestureEvent::DoubleClick { .. } => None,
             CanvasGestureEvent::Release {

--- a/src/native_app/app_chrome/metadata_tag_library.rs
+++ b/src/native_app/app_chrome/metadata_tag_library.rs
@@ -242,6 +242,9 @@ mod tests {
                 bounds,
                 ui::WidgetInput::PointerMove {
                     position: bounds.center(),
+                    modifiers: Default::default(),
+                    timestamp: None,
+                    sequence_range: None,
                 },
             );
 
@@ -269,7 +272,9 @@ mod tests {
         assert_eq!(
             category_header(&category).view_dispatch_widget_output(
                 input_id,
-                ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate),
+                ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::Metadata(
                 MetadataMessage::ToggleMetadataTagCategory(String::from(category_id))

--- a/src/native_app/app_chrome/status_bar.rs
+++ b/src/native_app/app_chrome/status_bar.rs
@@ -574,6 +574,9 @@ mod tests {
 
         runtime.dispatch_event(Event::PointerMove {
             position: compact_rect.center(),
+            modifiers: Default::default(),
+            timestamp: None,
+            sequence_range: None,
         });
 
         assert!(

--- a/src/native_app/app_chrome/toolbar/beat_count_input.rs
+++ b/src/native_app/app_chrome/toolbar/beat_count_input.rs
@@ -60,8 +60,11 @@ impl BeatGuideCountInputWidget {
         input: WidgetInput,
     ) -> Option<BeatGuideCountInputMessage> {
         match input {
-            WidgetInput::Character(character) if !character.is_ascii_digit() => None,
-            WidgetInput::TextEdit(TextEditCommand::InsertText(text)) => {
+            WidgetInput::Character { character, .. } if !character.is_ascii_digit() => None,
+            WidgetInput::TextEdit {
+                command: TextEditCommand::InsertText(text),
+                timestamp,
+            } => {
                 let digits = text
                     .chars()
                     .filter(char::is_ascii_digit)
@@ -72,14 +75,23 @@ impl BeatGuideCountInputWidget {
                 self.input
                     .handle_input(
                         bounds,
-                        WidgetInput::TextEdit(TextEditCommand::InsertText(digits)),
+                        WidgetInput::TextEdit {
+                            command: TextEditCommand::InsertText(digits),
+                            timestamp,
+                        },
                     )
                     .and_then(input_message)
             }
-            WidgetInput::KeyPress(WidgetKey::ArrowUp) if self.accepts_editing_input() => {
+            WidgetInput::KeyPress {
+                key: WidgetKey::ArrowUp,
+                ..
+            } if self.accepts_editing_input() => {
                 Some(BeatGuideCountInputMessage::Set(self.step_value(1)))
             }
-            WidgetInput::KeyPress(WidgetKey::ArrowDown) if self.accepts_editing_input() => {
+            WidgetInput::KeyPress {
+                key: WidgetKey::ArrowDown,
+                ..
+            } if self.accepts_editing_input() => {
                 Some(BeatGuideCountInputMessage::Set(self.step_value(-1)))
             }
             WidgetInput::Wheel { delta, .. } if delta.y < 0.0 => {

--- a/src/native_app/sample_library/folder_browser/source_management/reorder.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/reorder.rs
@@ -28,7 +28,9 @@ impl FolderBrowserState {
         message: DragHandleMessage,
     ) -> bool {
         match message {
-            DragHandleMessage::Started { origin, position } => {
+            DragHandleMessage::Started {
+                origin, position, ..
+            } => {
                 let Some(source_slot) = self.configured_source_slot(&source_id) else {
                     return false;
                 };
@@ -43,11 +45,11 @@ impl FolderBrowserState {
                 self.update_source_reorder_target(&source_id, position.y);
                 false
             }
-            DragHandleMessage::Moved { position } => {
+            DragHandleMessage::Moved { position, .. } => {
                 self.update_source_reorder_target(&source_id, position.y);
                 false
             }
-            DragHandleMessage::Ended { position } => {
+            DragHandleMessage::Ended { position, .. } => {
                 self.update_source_reorder_target(&source_id, position.y);
                 self.commit_source_reorder(&source_id)
             }

--- a/src/native_app/tests/audio_settings_controls/routing.rs
+++ b/src/native_app/tests/audio_settings_controls/routing.rs
@@ -50,7 +50,9 @@ fn general_settings_button_opens_general_tab() {
     assert_eq!(
         surface.dispatch_widget_output(
             crate::native_app::test_support::settings::GENERAL_SETTINGS_BUTTON_ID,
-            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(
             crate::native_app::test_support::state::GuiMessage::Settings(
@@ -78,7 +80,9 @@ fn help_tooltips_button_toggles_help_mode() {
     assert_eq!(
         surface.dispatch_widget_output(
             crate::native_app::test_support::settings::HELP_TOOLTIPS_BUTTON_ID,
-            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(
             crate::native_app::test_support::state::GuiMessage::Settings(
@@ -107,7 +111,9 @@ fn normalized_audition_button_toggles_forced_normalized_mode() {
     assert_eq!(
         surface.dispatch_widget_output(
             crate::native_app::test_support::settings::NORMALIZED_AUDITION_BUTTON_ID,
-            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(
             crate::native_app::test_support::state::GuiMessage::Settings(
@@ -145,7 +151,9 @@ fn release_update_button_opens_download_page() {
     assert_eq!(
         surface.dispatch_widget_output(
             crate::native_app::test_support::settings::RELEASE_UPDATE_BUTTON_ID,
-            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(crate::native_app::test_support::state::GuiMessage::OpenReleaseDownloadPage)
     );

--- a/src/native_app/tests/metadata_tag_tests/autocomplete/category_completion.rs
+++ b/src/native_app/tests/metadata_tag_tests/autocomplete/category_completion.rs
@@ -12,14 +12,14 @@ fn metadata_category_completion_mouse_click_commits_pending_tag() {
     assert!(runtime.focus_widget(input_id));
 
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::Character('d')),
+        runtime.dispatch_focused_input(WidgetInput::character('d')),
         Some(input_id)
     );
     for character in "eep-kick".chars() {
-        runtime.dispatch_focused_input(WidgetInput::Character(character));
+        runtime.dispatch_focused_input(WidgetInput::character(character));
     }
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Enter)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Enter)),
         Some(input_id)
     );
 
@@ -62,10 +62,10 @@ fn metadata_category_completion_pointer_hover_updates_active_category() {
     assert!(runtime.focus_widget(input_id));
 
     for character in "deep-kick".chars() {
-        runtime.dispatch_focused_input(WidgetInput::Character(character));
+        runtime.dispatch_focused_input(WidgetInput::character(character));
     }
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Enter)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Enter)),
         Some(input_id)
     );
 
@@ -78,6 +78,9 @@ fn metadata_category_completion_pointer_hover_updates_active_category() {
         category_rect.center(),
         WidgetInput::PointerMove {
             position: category_rect.center(),
+            modifiers: Default::default(),
+            timestamp: None,
+            sequence_range: None,
         },
     );
 
@@ -105,10 +108,10 @@ fn metadata_category_completion_pointer_hover_uses_full_row_width() {
     assert!(runtime.focus_widget(input_id));
 
     for character in "deep-kick".chars() {
-        runtime.dispatch_focused_input(WidgetInput::Character(character));
+        runtime.dispatch_focused_input(WidgetInput::character(character));
     }
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Enter)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Enter)),
         Some(input_id)
     );
 
@@ -122,6 +125,9 @@ fn metadata_category_completion_pointer_hover_uses_full_row_width() {
         right_side,
         WidgetInput::PointerMove {
             position: right_side,
+            modifiers: Default::default(),
+            timestamp: None,
+            sequence_range: None,
         },
     );
 

--- a/src/native_app/tests/metadata_tag_tests/autocomplete/commit.rs
+++ b/src/native_app/tests/metadata_tag_tests/autocomplete/commit.rs
@@ -18,12 +18,12 @@ fn metadata_autocomplete_suffix_is_not_editable_input_text() {
     assert!(runtime.focus_widget(input_id));
 
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Backspace)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Backspace)),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().metadata.tag_draft, "k");
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Backspace)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Backspace)),
         Some(input_id)
     );
     assert!(runtime.bridge().state().metadata.tag_draft.is_empty());
@@ -58,11 +58,11 @@ fn metadata_autocomplete_enter_commits_typed_prefix_without_selecting_first_sugg
     assert!(runtime.focus_widget(input_id));
 
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::Character('k')),
+        runtime.dispatch_focused_input(WidgetInput::character('k')),
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::Character('i')),
+        runtime.dispatch_focused_input(WidgetInput::character('i')),
         Some(input_id)
     );
 
@@ -82,7 +82,7 @@ fn metadata_autocomplete_enter_commits_typed_prefix_without_selecting_first_sugg
     );
 
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Enter)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Enter)),
         Some(input_id)
     );
 

--- a/src/native_app/tests/sample_browser/similarity.rs
+++ b/src/native_app/tests/sample_browser/similarity.rs
@@ -133,7 +133,8 @@ fn sample_browser_similarity_controls_emit_control_messages() {
         surface.dispatch_widget_output(
             crate::native_app::ui::ids::AUTOMATION_SAMPLE_SIMILARITY_WEIGHTING_TOGGLE_ID,
             radiant::widgets::WidgetOutput::typed(radiant::widgets::ToggleMessage::ValueChanged {
-                checked: true
+                checked: true,
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
             },),
         ),
         Some(
@@ -149,7 +150,8 @@ fn sample_browser_similarity_controls_emit_control_messages() {
                 "spectrum",
             ),
             radiant::widgets::WidgetOutput::typed(radiant::widgets::ToggleMessage::ValueChanged {
-                checked: false
+                checked: false,
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
             },),
         ),
         Some(

--- a/src/native_app/tests/toolbar_playback/basics.rs
+++ b/src/native_app/tests/toolbar_playback/basics.rs
@@ -84,7 +84,9 @@ fn toolbar_icon_button_routes_messages_through_radiant_builder() {
                 .view_dispatch_widget_output(
                     101,
                     radiant::widgets::WidgetOutput::typed(
-                        radiant::widgets::ButtonMessage::Activate
+                        radiant::widgets::ButtonMessage::Activate {
+                            provenance: radiant::widgets::InteractionProvenance::Programmatic,
+                        }
                     ),
                 ),
             Some(message)
@@ -102,9 +104,13 @@ fn toolbar_icon_button_routes_messages_through_radiant_builder() {
             101,
             radiant::widgets::WidgetOutput::typed(
                 radiant::widgets::ButtonMessage::ActivateWithModifiers {
-                    modifiers: PointerModifiers {
-                        command: true,
-                        ..Default::default()
+                    provenance: radiant::widgets::InteractionProvenance::Pointer {
+                        modifiers: PointerModifiers {
+                            command: true,
+                            ..Default::default()
+                        },
+                        timestamp: None,
+                        sequence_range: None,
                     },
                 },
             ),
@@ -125,9 +131,13 @@ fn toolbar_icon_button_routes_messages_through_radiant_builder() {
             101,
             radiant::widgets::WidgetOutput::typed(
                 radiant::widgets::ButtonMessage::ActivateWithModifiers {
-                    modifiers: PointerModifiers {
-                        shift: true,
-                        ..Default::default()
+                    provenance: radiant::widgets::InteractionProvenance::Pointer {
+                        modifiers: PointerModifiers {
+                            shift: true,
+                            ..Default::default()
+                        },
+                        timestamp: None,
+                        sequence_range: None,
                     },
                 },
             ),
@@ -219,7 +229,9 @@ fn apply_edit_mark_edits_button_appears_only_for_pending_effects() {
     assert_eq!(
         crate::native_app::test_support::toolbar::main_toolbar(&state).view_dispatch_widget_output(
             crate::native_app::test_support::toolbar::TOOLBAR_APPLY_EDIT_MARK_EDITS_ID,
-            radiant::widgets::WidgetOutput::typed(radiant::widgets::ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(radiant::widgets::ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            },),
         ),
         Some(crate::native_app::test_support::state::GuiMessage::RequestApplyEditSelectionEffects)
     );
@@ -571,7 +583,7 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
     let input_id = crate::native_app::test_support::toolbar::TOOLBAR_BEAT_GUIDE_COUNT_ID;
 
     assert_eq!(
-        runtime.dispatch_event(Event::KeyPress(WidgetKey::ArrowUp)),
+        runtime.dispatch_event(Event::key_press(WidgetKey::ArrowUp)),
         None,
         "unfocused number field should not receive arrow keys"
     );
@@ -587,29 +599,29 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('1')),
+        runtime.dispatch_event(Event::character('1')),
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('6')),
+        runtime.dispatch_event(Event::character('6')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 16);
 
     assert_eq!(
-        runtime.dispatch_event(Event::KeyPress(WidgetKey::ArrowUp)),
+        runtime.dispatch_event(Event::key_press(WidgetKey::ArrowUp)),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 17);
     assert_eq!(
-        runtime.dispatch_event(Event::KeyPress(WidgetKey::ArrowDown)),
+        runtime.dispatch_event(Event::key_press(WidgetKey::ArrowDown)),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 16);
 
     runtime.clear_focus();
     assert_eq!(
-        runtime.dispatch_event(Event::KeyPress(WidgetKey::ArrowDown)),
+        runtime.dispatch_event(Event::key_press(WidgetKey::ArrowDown)),
         None
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 16);
@@ -624,7 +636,7 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('0')),
+        runtime.dispatch_event(Event::character('0')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 16);
@@ -641,17 +653,17 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('9')),
+        runtime.dispatch_event(Event::character('9')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 9);
     assert_eq!(
-        runtime.dispatch_event(Event::Character('9')),
+        runtime.dispatch_event(Event::character('9')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 9);
     assert_eq!(
-        runtime.dispatch_event(Event::Character('9')),
+        runtime.dispatch_event(Event::character('9')),
         Some(input_id)
     );
     runtime.clear_focus();
@@ -667,7 +679,7 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('x')),
+        runtime.dispatch_event(Event::character('x')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 32);

--- a/src/native_app/waveform/playmark_label_editor.rs
+++ b/src/native_app/waveform/playmark_label_editor.rs
@@ -10,7 +10,7 @@ use radiant::{
 };
 use std::sync::{Arc, Mutex};
 
-use super::{playmark_label, PlaymarkLabelMessage, WaveformState, WaveformWidget};
+use super::{PlaymarkLabelMessage, WaveformState, WaveformWidget, playmark_label};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct PlaymarkLabelEditorState {
@@ -178,7 +178,7 @@ impl Widget for PlaymarkLabelWidget {
                 .map(WidgetOutput::typed);
         }
         (matches!(input, WidgetInput::PointerPress { position, button: PointerButton::Primary, .. } if label_rect.contains(position))
-            || matches!(input, WidgetInput::KeyPress(WidgetKey::Enter | WidgetKey::Space)))
+            || matches!(input, WidgetInput::KeyPress { key: WidgetKey::Enter | WidgetKey::Space, .. }))
         .then(|| WidgetOutput::typed(PlaymarkLabelMessage::BeginEdit))
     }
 

--- a/src/native_app/waveform/widget_input.rs
+++ b/src/native_app/waveform/widget_input.rs
@@ -209,7 +209,7 @@ impl WaveformWidget {
         self.active_drag_kind?;
         match event {
             CanvasGestureEvent::Drag { pointer, .. } => Some(*pointer),
-            CanvasGestureEvent::Hover(pointer) => Some(*pointer),
+            CanvasGestureEvent::Hover { pointer, .. } => Some(*pointer),
             _ => None,
         }
     }
@@ -374,6 +374,7 @@ impl WaveformWidget {
             pointer,
             button: PointerButton::Primary,
             modifiers,
+            ..
         } = event
         else {
             return None;


### PR DESCRIPTION
## Goal
Restore Wavecrate's build against the current Radiant sibling by advancing the canonical Radiant pin to `9220dce1fb8889c69454825f2f042f0cb6ec8698` and adapting Wavecrate to Radiant's metadata-bearing input, gesture, drag, and interaction-message APIs.

## Scope and non-goals
- Updated the two canonical Radiant revision declarations.
- Updated the affected Wavecrate interaction handlers and test fixtures while preserving pointer positions, modifiers, deltas, provenance, and beat-count text-edit timestamps.
- No Radiant source changes, I/O behavior, product redesign, persistence changes, or unrelated cleanup.

## Definition of Done
- Both dependency contracts pin exactly `9220dce1fb8889c69454825f2f042f0cb6ec8698`.
- All workspace targets compile with the locked dependency graph.
- Changed interaction behavior remains covered and passes.
- No old tuple-style Radiant input/gesture/message usage remains in the affected paths.

## Validation
All commands below were run against a clean temporary archive of Radiant `9220dce1` paired with the committed Wavecrate diff:
- `cargo check --workspace --all-targets --locked` — PASS
- `cargo test --workspace --locked --no-run` — PASS
- `cargo test --locked --lib beat_guide_count_field` — 2 passed
- `cargo test --locked --lib metadata_tag_tests::autocomplete` — 9 passed
- `cargo test --locked --lib library_sidebar::filter_section::tests::row_projection` — 17 passed
- `cargo test --locked --lib sample_browser::similarity` — 12 passed
- `cargo test --locked --test radiant_dependency_contract --test release_orchestration` — 18 passed
- changed-file `rustfmt --check` and `git diff --check` — PASS
- Terra UI/input specialist review — APPROVE, no required findings

## Known limitations
- The live `../radiant` checkout is concurrently dirty with unrelated rendering work, so it was not modified or used as clean validation evidence.
- Repository-wide Clippy and formatting still report pre-existing warnings/diffs in untouched files; this PR does not expand into that cleanup.
- The broad workspace runtime suite was not used as a pass gate because the isolated run exposed unrelated fixture/filesystem failures and long-running tests; all changed interaction suites pass.
- Native startup/visual accessibility acceptance remains a follow-up because this is a compatibility-only API migration.

User approval is required before merge.