### PR TITLE
build: update Wavecrate to canonical Radiant main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -647,6 +656,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bit_field"
@@ -1010,6 +1025,17 @@ name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
@@ -2093,6 +2119,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "glutin_wgl_sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2168,20 @@ dependencies = [
  "presser",
  "thiserror 1.0.69",
  "windows 0.58.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2171,6 +2223,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+ "svg_fmt",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2261,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -3150,11 +3214,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
- "codespan-reporting",
+ "codespan-reporting 0.12.0",
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
@@ -3164,7 +3228,33 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
- "spirv",
+ "spirv 0.3.0+sdk-1.3.268.0",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting 0.13.1",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv 0.4.0+sdk-1.4.341.0",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -3504,7 +3594,7 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -3639,7 +3729,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3732,6 +3822,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3741,7 +3843,20 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -3769,7 +3884,7 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -4316,6 +4431,7 @@ version = "0.1.0"
 dependencies = [
  "arboard",
  "block2 0.5.1",
+ "cc",
  "kurbo",
  "lyon_tessellation",
  "objc2 0.5.2",
@@ -4328,9 +4444,9 @@ dependencies = [
  "roxmltree 0.21.1",
  "serde",
  "serde_json",
- "skrifa",
+ "skrifa 0.42.1",
  "tracing",
- "vello",
+ "vello 0.9.0",
  "vello_svg",
  "windows 0.62.2",
  "windows-core 0.62.2",
@@ -4488,6 +4604,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4518,6 +4646,16 @@ name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -5053,7 +5191,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.37.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -5116,6 +5264,15 @@ name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.13.0",
 ]
@@ -5968,12 +6125,30 @@ dependencies = [
  "log",
  "peniko",
  "png 0.17.16",
- "skrifa",
+ "skrifa 0.40.0",
  "static_assertions",
  "thiserror 2.0.18",
- "vello_encoding",
- "vello_shaders",
- "wgpu",
+ "vello_encoding 0.7.0",
+ "vello_shaders 0.7.0",
+ "wgpu 27.0.1",
+]
+
+[[package]]
+name = "vello"
+version = "0.9.0"
+source = "git+https://github.com/PORTALSURFER/vello.git?rev=a08d1c11641908414e5e273d18e50f0f367095a1#a08d1c11641908414e5e273d18e50f0f367095a1"
+dependencies = [
+ "bytemuck",
+ "futures-intrusive",
+ "log",
+ "peniko",
+ "png 0.18.1",
+ "skrifa 0.42.1",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "vello_encoding 0.9.0",
+ "vello_shaders 0.9.0",
+ "wgpu 29.0.4",
 ]
 
 [[package]]
@@ -5983,9 +6158,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24c91203ec4b483440614a9a5c7c2d991932af72c5349659a63ec49476f0b79c"
 dependencies = [
  "bytemuck",
- "guillotiere",
+ "guillotiere 0.6.2",
  "peniko",
- "skrifa",
+ "skrifa 0.40.0",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_encoding"
+version = "0.9.0"
+source = "git+https://github.com/PORTALSURFER/vello.git?rev=a08d1c11641908414e5e273d18e50f0f367095a1#a08d1c11641908414e5e273d18e50f0f367095a1"
+dependencies = [
+ "bytemuck",
+ "guillotiere 0.7.0",
+ "peniko",
+ "skrifa 0.42.1",
  "smallvec",
 ]
 
@@ -5997,20 +6184,32 @@ checksum = "7a765d44d4bd354146e44f9a860f4e92effd91a97302549be9e47f0a18d8128c"
 dependencies = [
  "bytemuck",
  "log",
- "naga",
+ "naga 27.0.3",
  "thiserror 2.0.18",
- "vello_encoding",
+ "vello_encoding 0.7.0",
+]
+
+[[package]]
+name = "vello_shaders"
+version = "0.9.0"
+source = "git+https://github.com/PORTALSURFER/vello.git?rev=a08d1c11641908414e5e273d18e50f0f367095a1#a08d1c11641908414e5e273d18e50f0f367095a1"
+dependencies = [
+ "bytemuck",
+ "log",
+ "naga 29.0.4",
+ "thiserror 2.0.18",
+ "vello_encoding 0.9.0",
 ]
 
 [[package]]
 name = "vello_svg"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79dfa03829a8fb45ad458a05bd533d399d2259d042cdd78f391b290dbbdf1bd3"
+checksum = "41e9fad114de34b1b0cc37fa63d2607899ab42771d831759ab37767de65f73b4"
 dependencies = [
  "thiserror 2.0.18",
  "usvg",
- "vello",
+ "vello 0.9.0",
 ]
 
 [[package]]
@@ -6160,7 +6359,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "skrifa",
+ "skrifa 0.40.0",
  "symphonia",
  "sysinfo",
  "tempfile",
@@ -6173,7 +6372,7 @@ dependencies = [
  "ureq",
  "url",
  "uuid",
- "vello",
+ "vello 0.7.0",
  "wavecrate-analysis",
  "wavecrate-library",
  "wavecrate-scan",
@@ -6437,7 +6636,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "naga",
+ "naga 27.0.3",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -6447,9 +6646,39 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core 27.0.3",
+ "wgpu-hal 27.0.4",
+ "wgpu-types 27.0.1",
+]
+
+[[package]]
+name = "wgpu"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga 29.0.4",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core 29.0.4",
+ "wgpu-hal 29.0.4",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -6459,8 +6688,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
@@ -6468,7 +6697,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "log",
- "naga",
+ "naga 27.0.3",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -6477,11 +6706,44 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
- "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core-deps-apple 27.0.0",
+ "wgpu-core-deps-emscripten 27.0.0",
+ "wgpu-core-deps-windows-linux-android 27.0.0",
+ "wgpu-hal 27.0.4",
+ "wgpu-types 27.0.1",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga 29.0.4",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple 29.0.4",
+ "wgpu-core-deps-emscripten 29.0.4",
+ "wgpu-core-deps-windows-linux-android 29.0.4",
+ "wgpu-hal 29.0.4",
+ "wgpu-naga-bridge",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -6490,7 +6752,16 @@ version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 27.0.4",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+dependencies = [
+ "wgpu-hal 29.0.4",
 ]
 
 [[package]]
@@ -6499,7 +6770,16 @@ version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 27.0.4",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+dependencies = [
+ "wgpu-hal 29.0.4",
 ]
 
 [[package]]
@@ -6508,7 +6788,16 @@ version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 27.0.4",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+dependencies = [
+ "wgpu-hal 29.0.4",
 ]
 
 [[package]]
@@ -6520,17 +6809,17 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.13.0",
  "block",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "core-graphics-types 0.2.0",
- "glow",
+ "glow 0.16.0",
  "glutin_wgl_sys",
  "gpu-alloc",
- "gpu-allocator",
+ "gpu-allocator 0.27.0",
  "gpu-descriptor",
  "hashbrown 0.16.1",
  "js-sys",
@@ -6539,7 +6828,7 @@ dependencies = [
  "libloading",
  "log",
  "metal",
- "naga",
+ "naga 27.0.3",
  "ndk-sys",
  "objc",
  "once_cell",
@@ -6555,9 +6844,73 @@ dependencies = [
  "thiserror 2.0.18",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types",
+ "wgpu-types 27.0.1",
  "windows 0.58.0",
  "windows-core 0.58.0",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.9.1",
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow 0.17.0",
+ "glutin_wgl_sys",
+ "gpu-allocator 0.28.0",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga 29.0.4",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float 5.3.0",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types 29.0.4",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+dependencies = [
+ "naga 29.0.4",
+ "wgpu-types 29.0.4",
 ]
 
 [[package]]
@@ -6571,6 +6924,20 @@ dependencies = [
  "js-sys",
  "log",
  "thiserror 2.0.18",
+ "web-sys",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 
 [workspace.metadata.radiant]
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "13ae1f524313a5257fee6691679799a1aca99d32"
+revision = "fa707ff5cba809d334968416f9bcd1b702083db1"
 path = "../radiant"
 
 [package]
@@ -92,6 +92,9 @@ symphonia = { version = "0.5.4", features = ["wav", "pcm", "mp3", "flac"] }
 rayon = "1.10"
 crossbeam-queue = "0.3.12"
 reson = { path = "crates/reson" }
+
+[patch.crates-io]
+vello = { git = "https://github.com/PORTALSURFER/vello.git", rev = "a08d1c11641908414e5e273d18e50f0f367095a1" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 fsevent-sys = "4.1.0"

--- a/radiant-dependency.toml
+++ b/radiant-dependency.toml
@@ -4,5 +4,5 @@
 # sibling may remain on a feature branch or contain uncommitted work. Setup,
 # CI, and release helpers provision this exact revision into a clean checkout.
 repository = "https://github.com/PORTALSURFER/radiant.git"
-revision = "13ae1f524313a5257fee6691679799a1aca99d32"
+revision = "fa707ff5cba809d334968416f9bcd1b702083db1"
 path = "../radiant"

--- a/src/native_app/app_chrome/library_browser/library_sidebar/collections_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/collections_section/tests.rs
@@ -48,7 +48,9 @@ fn collection_input_routes_double_click_to_rename() {
     assert!(matches!(
         collection_row(&row).view_dispatch_widget_output(
             retained_collection_row_input_id(collection_id),
-            ui::WidgetOutput::typed(ui::InteractiveRowMessage::DoubleActivate),
+            ui::WidgetOutput::typed(ui::InteractiveRowMessage::DoubleActivate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::RenameCollection(collection)

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -198,7 +198,9 @@ fn filter_section_filter_labels_dispatch_family_enable_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_filter_family_label_toggle_id("Name"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SetFilterFamilyEnabled(FilterFamily::Name, false)
@@ -207,7 +209,9 @@ fn filter_section_filter_labels_dispatch_family_enable_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_filter_family_label_toggle_id("Rating"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SetFilterFamilyEnabled(FilterFamily::Rating, false)
@@ -216,7 +220,9 @@ fn filter_section_filter_labels_dispatch_family_enable_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_filter_family_label_toggle_id("Tags"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SetFilterFamilyEnabled(FilterFamily::Tags, true)
@@ -287,7 +293,9 @@ fn filter_section_projects_curation_scope_dropdown_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             CURATION_FILTER_DROPDOWN_TRIGGER_ID,
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::ToggleCurationFilterDropdown)
     );
@@ -342,7 +350,9 @@ fn filter_section_projects_curation_scope_dropdown_and_dispatches_changes() {
             .expect("open curation dropdown should project an overlay menu")
             .view_dispatch_widget_output(
                 automation_curation_filter_dropdown_option_id("Tags"),
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SetCurationScope(BrowserCurationScope::Tags, true)
@@ -385,7 +395,9 @@ fn filter_section_uses_harvest_dropdown_as_only_filter_mode_trigger() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             HARVEST_FILTER_DROPDOWN_TRIGGER_ID,
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::ToggleHarvestFilterDropdown)
     );
@@ -411,7 +423,9 @@ fn filter_section_projects_harvest_filter_dropdown_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             HARVEST_FILTER_DROPDOWN_TRIGGER_ID,
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::ToggleHarvestFilterDropdown)
     );
@@ -452,7 +466,9 @@ fn filter_section_projects_harvest_filter_dropdown_and_dispatches_changes() {
                 .expect("open harvest dropdown should project an overlay menu")
                 .view_dispatch_widget_output(
                     automation_harvest_filter_dropdown_option_id(label),
-                    ui::WidgetOutput::typed(ButtonMessage::Activate),
+                    ui::WidgetOutput::typed(ButtonMessage::Activate {
+                        provenance: ui::InteractionProvenance::Programmatic,
+                    }),
                 ),
             Some(GuiMessage::FolderBrowser(
                 FolderBrowserMessage::SetHarvestFilter(filter, true)
@@ -503,7 +519,9 @@ fn filter_section_hides_clear_buttons_when_filters_are_empty() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             name_filter_clear_button_id(),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         None
     );
@@ -537,7 +555,9 @@ fn filter_section_projects_name_clear_button_for_active_name_filter() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             name_filter_clear_button_id(),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::NameFilterInput(empty_filter_message())
@@ -573,7 +593,9 @@ fn filter_section_projects_tag_clear_button_for_active_tag_filter() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             tag_filter_clear_button_id(),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::TagFilterInput(empty_filter_message())
@@ -610,7 +632,9 @@ fn filter_section_projects_playback_type_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_playback_type_filter_toggle_id("1-Shot"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::TogglePlaybackTypeFilter(PlaybackTypeFilter::OneShot, true)
@@ -619,7 +643,9 @@ fn filter_section_projects_playback_type_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_playback_type_filter_toggle_id("Loop"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::TogglePlaybackTypeFilter(PlaybackTypeFilter::Loop, false)
@@ -769,7 +795,9 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_rating_filter_toggle_id("K4"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ToggleRatingFilter(4, true)
@@ -778,7 +806,9 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_rating_filter_toggle_id("U"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ToggleRatingFilter(0, false)
@@ -787,7 +817,9 @@ fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             automation_rating_filter_toggle_id("T3"),
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ToggleRatingFilter(-3, false)

--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/status.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/status.rs
@@ -129,7 +129,9 @@ mod tests {
             )
             .view_dispatch_widget_output(
                 widget_ids::FOLDER_TREE_INCLUDE_SUBFOLDERS_TOGGLE_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::FolderBrowser(
                 FolderBrowserMessage::ToggleFolderSubtreeListing
@@ -166,7 +168,9 @@ mod tests {
             )
             .view_dispatch_widget_output(
                 widget_ids::FOLDER_TREE_SHOW_EMPTY_FOLDERS_TOGGLE_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::FolderBrowser(
                 FolderBrowserMessage::ToggleEmptyFolderVisibility

--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/tests.rs
@@ -321,6 +321,7 @@ fn standard_folder_rows_derive_stable_input_id_from_row_key() {
             position,
             button: ui::PointerButton::Primary,
             modifiers: Default::default(),
+            timestamp: None,
         },
     );
     let output = surface.dispatch_widget_input(
@@ -330,6 +331,7 @@ fn standard_folder_rows_derive_stable_input_id_from_row_key() {
             position,
             button: ui::PointerButton::Primary,
             modifiers: Default::default(),
+            timestamp: None,
         },
     );
 

--- a/src/native_app/app_chrome/library_browser/library_sidebar/harvest_family.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/harvest_family.rs
@@ -130,21 +130,27 @@ mod tests {
         assert_eq!(
             harvest_family_section(&harvest_family_model()).view_dispatch_widget_output(
                 widget_ids::HARVEST_FAMILY_ORIGIN_BUTTON_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::ShowSelectedSampleHarvestOrigin)
         );
         assert_eq!(
             harvest_family_section(&harvest_family_model()).view_dispatch_widget_output(
                 widget_ids::HARVEST_FAMILY_DERIVATIVES_BUTTON_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::ShowSelectedSampleHarvestDerivatives)
         );
         assert_eq!(
             harvest_family_section(&harvest_family_model()).view_dispatch_widget_output(
                 widget_ids::HARVEST_FAMILY_DESTINATION_BUTTON_ID,
-                ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ui::WidgetOutput::typed(ButtonMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::OpenSelectedSampleHarvestDestination)
         );

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
@@ -110,7 +110,9 @@ fn source_add_button_routes_add_source_message() {
     assert_eq!(
         source_add_button(false).view_dispatch_widget_output(
             AUTOMATION_SOURCE_ADD_BUTTON_ID,
-            ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ui::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(FolderBrowserMessage::AddSource))
     );
@@ -178,7 +180,9 @@ fn source_row_routes_primary_activation_through_interactive_row() {
     assert_eq!(
         source_row(row).view_dispatch_widget_output(
             retained_source_row_input_id(source.id.as_str()),
-            ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate),
+            ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SelectSource(source.id.clone())
@@ -373,7 +377,9 @@ fn source_row_keeps_actions_enabled_while_processing_feedback_is_overlay_owned()
     assert_eq!(
         source_row(row).view_dispatch_widget_output(
             retained_source_row_input_id(source.id.as_str()),
-            ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate),
+            ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate {
+                provenance: ui::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SelectSource(source.id.clone())

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target_tests.rs
@@ -200,7 +200,9 @@ fn production_hit_target_derives_stable_input_identity_from_sample_row_key() {
     )
     .view_dispatch_widget_output(
         input_id,
-        WidgetOutput::typed(InteractiveRowMessage::DoubleActivate),
+        WidgetOutput::typed(InteractiveRowMessage::DoubleActivate {
+            provenance: radiant::widgets::InteractionProvenance::Programmatic,
+        }),
     );
 
     assert_eq!(

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
@@ -494,6 +494,7 @@ impl Widget for StarmapWidget {
                 pointer,
                 button: PointerButton::Primary,
                 modifiers,
+                ..
             } => self.begin_audition_drag_message(bounds, pointer.position, modifiers),
             CanvasGestureEvent::Drag {
                 pointer,
@@ -501,7 +502,7 @@ impl Widget for StarmapWidget {
                 modifiers,
                 ..
             } => self.update_audition_drag_message(bounds, pointer.position, modifiers),
-            CanvasGestureEvent::Hover(pointer) if self.active_drag.is_some() => self
+            CanvasGestureEvent::Hover { pointer, .. } if self.active_drag.is_some() => self
                 .update_audition_drag_message(
                     bounds,
                     pointer.position,
@@ -510,7 +511,7 @@ impl Widget for StarmapWidget {
                         .map(|drag| drag.modifiers)
                         .unwrap_or_default(),
                 ),
-            CanvasGestureEvent::Hover(pointer) => {
+            CanvasGestureEvent::Hover { pointer, .. } => {
                 self.set_hovered_file_at(bounds, pointer.position);
                 None
             }
@@ -537,7 +538,7 @@ impl Widget for StarmapWidget {
                     },
                 )))
             }
-            CanvasGestureEvent::Wheel { pointer, delta } => {
+            CanvasGestureEvent::Wheel { pointer, delta, .. } => {
                 let factor = if delta.y < 0.0 { 1.15 } else { 1.0 / 1.15 };
                 Some(WidgetOutput::typed(GuiMessage::ChangeStarmapViewport(
                     StarmapViewportChange::Zoom {
@@ -550,6 +551,7 @@ impl Widget for StarmapWidget {
                 pointer,
                 button: PointerButton::Primary,
                 modifiers,
+                ..
             } => self.begin_audition_drag_message(bounds, pointer.position, modifiers),
             CanvasGestureEvent::DoubleClick { .. } => None,
             CanvasGestureEvent::Release {

--- a/src/native_app/app_chrome/metadata_tag_library.rs
+++ b/src/native_app/app_chrome/metadata_tag_library.rs
@@ -242,6 +242,9 @@ mod tests {
                 bounds,
                 ui::WidgetInput::PointerMove {
                     position: bounds.center(),
+                    modifiers: Default::default(),
+                    timestamp: None,
+                    sequence_range: None,
                 },
             );
 
@@ -269,7 +272,9 @@ mod tests {
         assert_eq!(
             category_header(&category).view_dispatch_widget_output(
                 input_id,
-                ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate),
+                ui::WidgetOutput::typed(ui::InteractiveRowMessage::Activate {
+                    provenance: ui::InteractionProvenance::Programmatic,
+                }),
             ),
             Some(GuiMessage::Metadata(
                 MetadataMessage::ToggleMetadataTagCategory(String::from(category_id))

--- a/src/native_app/app_chrome/status_bar.rs
+++ b/src/native_app/app_chrome/status_bar.rs
@@ -574,6 +574,9 @@ mod tests {
 
         runtime.dispatch_event(Event::PointerMove {
             position: compact_rect.center(),
+            modifiers: Default::default(),
+            timestamp: None,
+            sequence_range: None,
         });
 
         assert!(

--- a/src/native_app/app_chrome/toolbar.rs
+++ b/src/native_app/app_chrome/toolbar.rs
@@ -11,7 +11,9 @@ pub(in crate::native_app) use beat_count_input::{
     BeatGuideCountInputMessage, BeatGuideCountInputWidget,
 };
 
-pub(in crate::native_app) use icons::{ToolbarIcon, toolbar_icon_color, toolbar_icon_glyph};
+pub(in crate::native_app) use icons::{
+    ToolbarIcon, toolbar_icon_color, toolbar_icon_glyph, toolbar_icon_label,
+};
 pub(in crate::native_app) use projection::{
     ToolbarControlProjection, ToolbarIconButtonProjection, ToolbarProjection,
 };
@@ -145,6 +147,7 @@ fn toolbar_icon_button_from_projection(
         button.icon_enabled,
         button.active,
     ))
+    .label(toolbar_icon_label(button.icon))
     .enabled(button.enabled)
     .active(button.active)
     .mapped(move |message| toolbar_button_message(button.icon, message))
@@ -178,5 +181,24 @@ fn toolbar_button_message(icon: ToolbarIcon, message: ButtonMessage) -> GuiMessa
         ToolbarIcon::Metronome => GuiMessage::ToggleMetronome,
         ToolbarIcon::Play => GuiMessage::PlaySelectedSample,
         ToolbarIcon::Stop => GuiMessage::StopPlayback,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use radiant::prelude::IntoView;
+
+    #[test]
+    fn toolbar_icon_button_exposes_an_accessible_label() {
+        let surface = toolbar_icon_button(123, ToolbarIcon::Play, true, false).into_surface();
+        let label = surface
+            .find_widget(123)
+            .expect("toolbar icon button")
+            .widget_object()
+            .automation_semantics()
+            .label;
+
+        assert_eq!(label.as_deref(), Some("Play"));
     }
 }

--- a/src/native_app/app_chrome/toolbar/beat_count_input.rs
+++ b/src/native_app/app_chrome/toolbar/beat_count_input.rs
@@ -60,8 +60,11 @@ impl BeatGuideCountInputWidget {
         input: WidgetInput,
     ) -> Option<BeatGuideCountInputMessage> {
         match input {
-            WidgetInput::Character(character) if !character.is_ascii_digit() => None,
-            WidgetInput::TextEdit(TextEditCommand::InsertText(text)) => {
+            WidgetInput::Character { character, .. } if !character.is_ascii_digit() => None,
+            WidgetInput::TextEdit {
+                command: TextEditCommand::InsertText(text),
+                timestamp,
+            } => {
                 let digits = text
                     .chars()
                     .filter(char::is_ascii_digit)
@@ -72,14 +75,23 @@ impl BeatGuideCountInputWidget {
                 self.input
                     .handle_input(
                         bounds,
-                        WidgetInput::TextEdit(TextEditCommand::InsertText(digits)),
+                        WidgetInput::TextEdit {
+                            command: TextEditCommand::InsertText(digits),
+                            timestamp,
+                        },
                     )
                     .and_then(input_message)
             }
-            WidgetInput::KeyPress(WidgetKey::ArrowUp) if self.accepts_editing_input() => {
+            WidgetInput::KeyPress {
+                key: WidgetKey::ArrowUp,
+                ..
+            } if self.accepts_editing_input() => {
                 Some(BeatGuideCountInputMessage::Set(self.step_value(1)))
             }
-            WidgetInput::KeyPress(WidgetKey::ArrowDown) if self.accepts_editing_input() => {
+            WidgetInput::KeyPress {
+                key: WidgetKey::ArrowDown,
+                ..
+            } if self.accepts_editing_input() => {
                 Some(BeatGuideCountInputMessage::Set(self.step_value(-1)))
             }
             WidgetInput::Wheel { delta, .. } if delta.y < 0.0 => {

--- a/src/native_app/app_chrome/toolbar/icons.rs
+++ b/src/native_app/app_chrome/toolbar/icons.rs
@@ -46,6 +46,21 @@ pub(in crate::native_app) fn toolbar_icon_color(enabled: bool, active: bool) -> 
     TOOLBAR_ICON_TINTS.color(enabled, active)
 }
 
+pub(in crate::native_app) fn toolbar_icon_label(icon: ToolbarIcon) -> &'static str {
+    match icon {
+        ToolbarIcon::FocusLoaded => "Focus loaded sample",
+        ToolbarIcon::Loop => "Loop playback",
+        ToolbarIcon::Random => "Play random section",
+        ToolbarIcon::SimilarSections => "Similar sections",
+        ToolbarIcon::ZeroCrossingSnap => "Zero-crossing snap",
+        ToolbarIcon::BpmSnap => "BPM snap",
+        ToolbarIcon::BeatGuides => "Beat guides",
+        ToolbarIcon::Metronome => "Metronome",
+        ToolbarIcon::Play => "Play",
+        ToolbarIcon::Stop => "Stop",
+    }
+}
+
 pub(in crate::native_app) fn toolbar_icon_glyph(
     icon: ToolbarIcon,
     enabled: bool,

--- a/src/native_app/sample_library/folder_browser/source_management/reorder.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/reorder.rs
@@ -28,7 +28,9 @@ impl FolderBrowserState {
         message: DragHandleMessage,
     ) -> bool {
         match message {
-            DragHandleMessage::Started { origin, position } => {
+            DragHandleMessage::Started {
+                origin, position, ..
+            } => {
                 let Some(source_slot) = self.configured_source_slot(&source_id) else {
                     return false;
                 };
@@ -43,11 +45,11 @@ impl FolderBrowserState {
                 self.update_source_reorder_target(&source_id, position.y);
                 false
             }
-            DragHandleMessage::Moved { position } => {
+            DragHandleMessage::Moved { position, .. } => {
                 self.update_source_reorder_target(&source_id, position.y);
                 false
             }
-            DragHandleMessage::Ended { position } => {
+            DragHandleMessage::Ended { position, .. } => {
                 self.update_source_reorder_target(&source_id, position.y);
                 self.commit_source_reorder(&source_id)
             }

--- a/src/native_app/tests/audio_settings_controls/routing.rs
+++ b/src/native_app/tests/audio_settings_controls/routing.rs
@@ -50,7 +50,9 @@ fn general_settings_button_opens_general_tab() {
     assert_eq!(
         surface.dispatch_widget_output(
             crate::native_app::test_support::settings::GENERAL_SETTINGS_BUTTON_ID,
-            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(
             crate::native_app::test_support::state::GuiMessage::Settings(
@@ -78,7 +80,9 @@ fn help_tooltips_button_toggles_help_mode() {
     assert_eq!(
         surface.dispatch_widget_output(
             crate::native_app::test_support::settings::HELP_TOOLTIPS_BUTTON_ID,
-            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(
             crate::native_app::test_support::state::GuiMessage::Settings(
@@ -107,7 +111,9 @@ fn normalized_audition_button_toggles_forced_normalized_mode() {
     assert_eq!(
         surface.dispatch_widget_output(
             crate::native_app::test_support::settings::NORMALIZED_AUDITION_BUTTON_ID,
-            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(
             crate::native_app::test_support::state::GuiMessage::Settings(
@@ -145,7 +151,9 @@ fn release_update_button_opens_download_page() {
     assert_eq!(
         surface.dispatch_widget_output(
             crate::native_app::test_support::settings::RELEASE_UPDATE_BUTTON_ID,
-            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            }),
         ),
         Some(crate::native_app::test_support::state::GuiMessage::OpenReleaseDownloadPage)
     );

--- a/src/native_app/tests/metadata_tag_tests/autocomplete/category_completion.rs
+++ b/src/native_app/tests/metadata_tag_tests/autocomplete/category_completion.rs
@@ -12,14 +12,14 @@ fn metadata_category_completion_mouse_click_commits_pending_tag() {
     assert!(runtime.focus_widget(input_id));
 
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::Character('d')),
+        runtime.dispatch_focused_input(WidgetInput::character('d')),
         Some(input_id)
     );
     for character in "eep-kick".chars() {
-        runtime.dispatch_focused_input(WidgetInput::Character(character));
+        runtime.dispatch_focused_input(WidgetInput::character(character));
     }
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Enter)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Enter)),
         Some(input_id)
     );
 
@@ -62,10 +62,10 @@ fn metadata_category_completion_pointer_hover_updates_active_category() {
     assert!(runtime.focus_widget(input_id));
 
     for character in "deep-kick".chars() {
-        runtime.dispatch_focused_input(WidgetInput::Character(character));
+        runtime.dispatch_focused_input(WidgetInput::character(character));
     }
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Enter)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Enter)),
         Some(input_id)
     );
 
@@ -78,6 +78,9 @@ fn metadata_category_completion_pointer_hover_updates_active_category() {
         category_rect.center(),
         WidgetInput::PointerMove {
             position: category_rect.center(),
+            modifiers: Default::default(),
+            timestamp: None,
+            sequence_range: None,
         },
     );
 
@@ -105,10 +108,10 @@ fn metadata_category_completion_pointer_hover_uses_full_row_width() {
     assert!(runtime.focus_widget(input_id));
 
     for character in "deep-kick".chars() {
-        runtime.dispatch_focused_input(WidgetInput::Character(character));
+        runtime.dispatch_focused_input(WidgetInput::character(character));
     }
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Enter)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Enter)),
         Some(input_id)
     );
 
@@ -122,6 +125,9 @@ fn metadata_category_completion_pointer_hover_uses_full_row_width() {
         right_side,
         WidgetInput::PointerMove {
             position: right_side,
+            modifiers: Default::default(),
+            timestamp: None,
+            sequence_range: None,
         },
     );
 

--- a/src/native_app/tests/metadata_tag_tests/autocomplete/commit.rs
+++ b/src/native_app/tests/metadata_tag_tests/autocomplete/commit.rs
@@ -18,12 +18,12 @@ fn metadata_autocomplete_suffix_is_not_editable_input_text() {
     assert!(runtime.focus_widget(input_id));
 
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Backspace)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Backspace)),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().metadata.tag_draft, "k");
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Backspace)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Backspace)),
         Some(input_id)
     );
     assert!(runtime.bridge().state().metadata.tag_draft.is_empty());
@@ -58,11 +58,11 @@ fn metadata_autocomplete_enter_commits_typed_prefix_without_selecting_first_sugg
     assert!(runtime.focus_widget(input_id));
 
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::Character('k')),
+        runtime.dispatch_focused_input(WidgetInput::character('k')),
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::Character('i')),
+        runtime.dispatch_focused_input(WidgetInput::character('i')),
         Some(input_id)
     );
 
@@ -82,7 +82,7 @@ fn metadata_autocomplete_enter_commits_typed_prefix_without_selecting_first_sugg
     );
 
     assert_eq!(
-        runtime.dispatch_focused_input(WidgetInput::KeyPress(WidgetKey::Enter)),
+        runtime.dispatch_focused_input(WidgetInput::key_press(WidgetKey::Enter)),
         Some(input_id)
     );
 

--- a/src/native_app/tests/sample_browser/similarity.rs
+++ b/src/native_app/tests/sample_browser/similarity.rs
@@ -133,7 +133,8 @@ fn sample_browser_similarity_controls_emit_control_messages() {
         surface.dispatch_widget_output(
             crate::native_app::ui::ids::AUTOMATION_SAMPLE_SIMILARITY_WEIGHTING_TOGGLE_ID,
             radiant::widgets::WidgetOutput::typed(radiant::widgets::ToggleMessage::ValueChanged {
-                checked: true
+                checked: true,
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
             },),
         ),
         Some(
@@ -149,7 +150,8 @@ fn sample_browser_similarity_controls_emit_control_messages() {
                 "spectrum",
             ),
             radiant::widgets::WidgetOutput::typed(radiant::widgets::ToggleMessage::ValueChanged {
-                checked: false
+                checked: false,
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
             },),
         ),
         Some(

--- a/src/native_app/tests/toolbar_playback/basics.rs
+++ b/src/native_app/tests/toolbar_playback/basics.rs
@@ -84,7 +84,9 @@ fn toolbar_icon_button_routes_messages_through_radiant_builder() {
                 .view_dispatch_widget_output(
                     101,
                     radiant::widgets::WidgetOutput::typed(
-                        radiant::widgets::ButtonMessage::Activate
+                        radiant::widgets::ButtonMessage::Activate {
+                            provenance: radiant::widgets::InteractionProvenance::Programmatic,
+                        }
                     ),
                 ),
             Some(message)
@@ -102,9 +104,13 @@ fn toolbar_icon_button_routes_messages_through_radiant_builder() {
             101,
             radiant::widgets::WidgetOutput::typed(
                 radiant::widgets::ButtonMessage::ActivateWithModifiers {
-                    modifiers: PointerModifiers {
-                        command: true,
-                        ..Default::default()
+                    provenance: radiant::widgets::InteractionProvenance::Pointer {
+                        modifiers: PointerModifiers {
+                            command: true,
+                            ..Default::default()
+                        },
+                        timestamp: None,
+                        sequence_range: None,
                     },
                 },
             ),
@@ -125,9 +131,13 @@ fn toolbar_icon_button_routes_messages_through_radiant_builder() {
             101,
             radiant::widgets::WidgetOutput::typed(
                 radiant::widgets::ButtonMessage::ActivateWithModifiers {
-                    modifiers: PointerModifiers {
-                        shift: true,
-                        ..Default::default()
+                    provenance: radiant::widgets::InteractionProvenance::Pointer {
+                        modifiers: PointerModifiers {
+                            shift: true,
+                            ..Default::default()
+                        },
+                        timestamp: None,
+                        sequence_range: None,
                     },
                 },
             ),
@@ -219,7 +229,9 @@ fn apply_edit_mark_edits_button_appears_only_for_pending_effects() {
     assert_eq!(
         crate::native_app::test_support::toolbar::main_toolbar(&state).view_dispatch_widget_output(
             crate::native_app::test_support::toolbar::TOOLBAR_APPLY_EDIT_MARK_EDITS_ID,
-            radiant::widgets::WidgetOutput::typed(radiant::widgets::ButtonMessage::Activate),
+            radiant::widgets::WidgetOutput::typed(radiant::widgets::ButtonMessage::Activate {
+                provenance: radiant::widgets::InteractionProvenance::Programmatic,
+            },),
         ),
         Some(crate::native_app::test_support::state::GuiMessage::RequestApplyEditSelectionEffects)
     );
@@ -571,7 +583,7 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
     let input_id = crate::native_app::test_support::toolbar::TOOLBAR_BEAT_GUIDE_COUNT_ID;
 
     assert_eq!(
-        runtime.dispatch_event(Event::KeyPress(WidgetKey::ArrowUp)),
+        runtime.dispatch_event(Event::key_press(WidgetKey::ArrowUp)),
         None,
         "unfocused number field should not receive arrow keys"
     );
@@ -587,29 +599,29 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('1')),
+        runtime.dispatch_event(Event::character('1')),
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('6')),
+        runtime.dispatch_event(Event::character('6')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 16);
 
     assert_eq!(
-        runtime.dispatch_event(Event::KeyPress(WidgetKey::ArrowUp)),
+        runtime.dispatch_event(Event::key_press(WidgetKey::ArrowUp)),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 17);
     assert_eq!(
-        runtime.dispatch_event(Event::KeyPress(WidgetKey::ArrowDown)),
+        runtime.dispatch_event(Event::key_press(WidgetKey::ArrowDown)),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 16);
 
     runtime.clear_focus();
     assert_eq!(
-        runtime.dispatch_event(Event::KeyPress(WidgetKey::ArrowDown)),
+        runtime.dispatch_event(Event::key_press(WidgetKey::ArrowDown)),
         None
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 16);
@@ -624,7 +636,7 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('0')),
+        runtime.dispatch_event(Event::character('0')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 16);
@@ -641,17 +653,17 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('9')),
+        runtime.dispatch_event(Event::character('9')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 9);
     assert_eq!(
-        runtime.dispatch_event(Event::Character('9')),
+        runtime.dispatch_event(Event::character('9')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 9);
     assert_eq!(
-        runtime.dispatch_event(Event::Character('9')),
+        runtime.dispatch_event(Event::character('9')),
         Some(input_id)
     );
     runtime.clear_focus();
@@ -667,7 +679,7 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
         Some(input_id)
     );
     assert_eq!(
-        runtime.dispatch_event(Event::Character('x')),
+        runtime.dispatch_event(Event::character('x')),
         Some(input_id)
     );
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 32);

--- a/src/native_app/waveform/playmark_label_editor.rs
+++ b/src/native_app/waveform/playmark_label_editor.rs
@@ -10,7 +10,7 @@ use radiant::{
 };
 use std::sync::{Arc, Mutex};
 
-use super::{playmark_label, PlaymarkLabelMessage, WaveformState, WaveformWidget};
+use super::{PlaymarkLabelMessage, WaveformState, WaveformWidget, playmark_label};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct PlaymarkLabelEditorState {
@@ -178,7 +178,7 @@ impl Widget for PlaymarkLabelWidget {
                 .map(WidgetOutput::typed);
         }
         (matches!(input, WidgetInput::PointerPress { position, button: PointerButton::Primary, .. } if label_rect.contains(position))
-            || matches!(input, WidgetInput::KeyPress(WidgetKey::Enter | WidgetKey::Space)))
+            || matches!(input, WidgetInput::KeyPress { key: WidgetKey::Enter | WidgetKey::Space, .. }))
         .then(|| WidgetOutput::typed(PlaymarkLabelMessage::BeginEdit))
     }
 

--- a/src/native_app/waveform/widget_input.rs
+++ b/src/native_app/waveform/widget_input.rs
@@ -209,7 +209,7 @@ impl WaveformWidget {
         self.active_drag_kind?;
         match event {
             CanvasGestureEvent::Drag { pointer, .. } => Some(*pointer),
-            CanvasGestureEvent::Hover(pointer) => Some(*pointer),
+            CanvasGestureEvent::Hover { pointer, .. } => Some(*pointer),
             _ => None,
         }
     }
@@ -374,6 +374,7 @@ impl WaveformWidget {
             pointer,
             button: PointerButton::Primary,
             modifiers,
+            ..
         } = event
         else {
             return None;


### PR DESCRIPTION
## Goal
Update Wavecrate to canonical Radiant main at `fa707ff5cba809d334968416f9bcd1b702083db1` and keep the native integration compatible with the current input and interaction APIs.

## Scope
- Pin the exact canonical Radiant revision in `Cargo.toml` and `radiant-dependency.toml`.
- Update `Cargo.lock` and mirror Radiant’s Vello patch so `vello_svg` resolves against the required fork without disturbing Wavecrate’s independent `vello 0.7` dependency.
- Port the forced metadata/provenance input migrations across current Wavecrate handlers and fixtures.
- Adopt Radiant’s new `IconButtonBuilder::label` API for all main-toolbar icon buttons, preserving existing visual tooltips and behavior.
- No Radiant source changes, I/O redesign, product redesign, persistence changes, or unrelated cleanup.

## Definition of Done
- Both canonical dependency declarations pin exactly `fa707ff5cba809d334968416f9bcd1b702083db1`.
- Locked workspace targets compile against a clean sibling Radiant checkout at that commit.
- Existing interaction compatibility suites pass.
- Toolbar icon buttons expose stable accessibility labels through Radiant semantics.

## Validation
- `cargo test --workspace --locked --no-run` — PASS against clean Radiant `fa707ff5`.
- `cargo check --workspace --all-targets --locked` — PASS against canonical Radiant.
- Focused migration suites: beat-guide count 2 passed; metadata autocomplete 9 passed; filter row projection 17 passed; sample-browser similarity 12 passed.
- `cargo test --locked --test radiant_dependency_contract --test release_orchestration` — 18 passed.
- Toolbar semantic regression test — 1 passed against clean Radiant `fa707ff5`.
- Changed Rust files `rustfmt --check` and `git diff --check` — PASS.

## Known limitations
- Full runtime test execution and manual native accessibility/VoiceOver acceptance are not included; the workspace target compilation and focused behavior tests are green.
- Repository-wide formatting still reports unrelated pre-existing drift outside this diff.

User approval is required before merge.