### PR TITLE
feat: claim profile ownership before journal startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6326,6 +6326,8 @@ dependencies = [
  "base64",
  "bincode",
  "blake3",
+ "cap-fs-ext",
+ "cap-std",
  "chacha20poly1305",
  "criterion",
  "crossbeam-queue",
@@ -6438,7 +6440,9 @@ name = "wavecrate-library"
 version = "0.19.1"
 dependencies = [
  "blake3",
+ "cap-fs-ext",
  "cap-primitives",
+ "cap-std",
  "directories",
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ sqlite-ext-unsafe = ["wavecrate-library/sqlite-ext-unsafe"]
 [dependencies]
 hound = "3.5.1"
 sysinfo = "0.37.2"
+cap-fs-ext = "4.0.2"
+cap-std = "4.0.2"
 rusqlite = { version = "0.37.0", features = ["bundled", "load_extension"] }
 uuid = { version = "1.19.0", features = ["v4", "serde"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/wavecrate-library/Cargo.toml
+++ b/crates/wavecrate-library/Cargo.toml
@@ -41,4 +41,5 @@ windows = { version = "0.62.2", features = [
     "Win32_System_Threading",
     "Win32_Storage",
     "Win32_Storage_FileSystem",
+    "Win32_System_IO",
 ] }

--- a/crates/wavecrate-library/Cargo.toml
+++ b/crates/wavecrate-library/Cargo.toml
@@ -14,7 +14,9 @@ test-support = []
 
 [dependencies]
 blake3 = "1.6.1"
+cap-fs-ext = "4.0.2"
 cap-primitives = "4.0.2"
+cap-std = "4.0.2"
 directories = "6.0.0"
 rusqlite = { version = "0.37.0", features = ["backup", "bundled", "load_extension"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/wavecrate-library/src/app_dirs.rs
+++ b/crates/wavecrate-library/src/app_dirs.rs
@@ -10,6 +10,7 @@ mod error;
 mod overrides;
 mod paths;
 mod profile;
+mod profile_ownership;
 mod resolution;
 mod state;
 mod storage_usage;
@@ -21,6 +22,7 @@ pub use paths::{
     rebuildable_cache_root_dir, waveform_cache_dir,
 };
 pub use profile::{PersistenceMode, PersistenceProfileGuard, ResolvedPersistence};
+pub use profile_ownership::{ProfileOwnershipError, WritableProfileGuard};
 pub use resolution::{
     app_root_dir, config_base_dir_path, ensure_test_config_base, persistence_mode,
     resolve_persistence, set_app_root_override,

--- a/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
+++ b/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
@@ -238,7 +238,7 @@ fn open_profile_root(path: &Path) -> io::Result<Dir> {
             };
             dir = dir.open_dir_nofollow(name)?;
         }
-        return Ok(dir);
+        Ok(dir)
     }
     #[cfg(windows)]
     {

--- a/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
+++ b/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
@@ -3,9 +3,11 @@
 use std::{
     fs::File,
     io::{self, Write},
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority};
+use cap_std::fs::{Dir, OpenOptions};
 use thiserror::Error;
 
 const PROFILE_OWNER_LOCK_FILE_NAME: &str = "profile-owner.lock";
@@ -22,8 +24,8 @@ pub enum ProfileOwnershipError {
     /// Resolving the current profile root failed.
     #[error("profile root unavailable: {0}")]
     AppDirectory(String),
-    /// Opening, validating, or writing the profile lock failed.
-    #[error("profile ownership lock failed at {path}: {source}")]
+    /// Opening, validating, or writing the profile ownership boundary failed.
+    #[error("profile ownership filesystem operation failed at {path}: {source}")]
     Io {
         /// Profile lock path involved in the failure.
         path: PathBuf,
@@ -34,6 +36,24 @@ pub enum ProfileOwnershipError {
     #[error("profile ownership lock is not a regular file: {path}")]
     NotRegularFile {
         /// Profile lock path that failed validation.
+        path: PathBuf,
+    },
+    /// The retained profile root no longer matches the path used to acquire ownership.
+    #[error("profile root was replaced after ownership acquisition: {path}")]
+    ProfileRootReplaced {
+        /// Profile root path whose identity changed.
+        path: PathBuf,
+    },
+    /// The profile-owner lock entry no longer matches the acquired lock file.
+    #[error("profile ownership lock was replaced after acquisition: {path}")]
+    ProfileOwnerLockReplaced {
+        /// Profile lock path whose identity changed.
+        path: PathBuf,
+    },
+    /// The host could not provide a stable identity for the retained capability.
+    #[error("profile ownership identity unavailable at {path}")]
+    IdentityUnavailable {
+        /// Profile path whose identity could not be established.
         path: PathBuf,
     },
     /// This platform has no verified nonblocking profile ownership primitive.
@@ -52,7 +72,10 @@ pub enum ProfileOwnershipError {
 #[derive(Debug)]
 pub struct WritableProfileGuard {
     profile_root: PathBuf,
-    _lock_path: PathBuf,
+    profile_identity: String,
+    lock_path: PathBuf,
+    lock_identity: String,
+    root_dir: Dir,
     _lock_file: File,
 }
 
@@ -63,18 +86,246 @@ impl WritableProfileGuard {
             .map_err(|error| ProfileOwnershipError::AppDirectory(error.to_string()))?
             .app_root;
         let lock_path = profile_root.join(PROFILE_OWNER_LOCK_FILE_NAME);
-        let lock_file = acquire_lock(&lock_path)?;
-        Ok(Self {
+        #[cfg(all(not(unix), not(windows)))]
+        return Err(ProfileOwnershipError::Unsupported { path: lock_path });
+
+        let root_dir =
+            open_profile_root(&profile_root).map_err(|source| ProfileOwnershipError::Io {
+                path: profile_root.clone(),
+                source,
+            })?;
+        let profile_identity = identity_for_root(&profile_root, &root_dir)?;
+        let lock_file = acquire_lock(&root_dir, &lock_path)?;
+        let lock_identity = identity_for_lock(&lock_path, &lock_file)?;
+        let guard = Self {
             profile_root,
-            _lock_path: lock_path,
+            profile_identity,
+            lock_path,
+            lock_identity,
+            root_dir,
             _lock_file: lock_file,
-        })
+        };
+        guard.validate_current()?;
+        Ok(guard)
     }
 
     /// Return the profile root protected by this guard.
     pub fn profile_root(&self) -> &Path {
         &self.profile_root
     }
+
+    /// Revalidate the acquired root and lock identities without following links.
+    ///
+    /// A successful check means the configured profile path still names the same root and
+    /// lock entries that were acquired. The retained directory capability remains the authority
+    /// for child access; this check detects a path replacement so the owner can fail closed.
+    pub fn validate_current(&self) -> Result<(), ProfileOwnershipError> {
+        let current_root = open_profile_root(&self.profile_root).map_err(|_| {
+            ProfileOwnershipError::ProfileRootReplaced {
+                path: self.profile_root.clone(),
+            }
+        })?;
+        let current_identity = identity_from_dir(&current_root).ok_or_else(|| {
+            ProfileOwnershipError::ProfileRootReplaced {
+                path: self.profile_root.clone(),
+            }
+        })?;
+        if current_identity != self.profile_identity {
+            return Err(ProfileOwnershipError::ProfileRootReplaced {
+                path: self.profile_root.clone(),
+            });
+        }
+
+        let current_lock = open_lock_file(&current_root, false).map_err(|_| {
+            ProfileOwnershipError::ProfileOwnerLockReplaced {
+                path: self.lock_path.clone(),
+            }
+        })?;
+        if !is_regular_file(&current_lock).unwrap_or(false) {
+            return Err(ProfileOwnershipError::ProfileOwnerLockReplaced {
+                path: self.lock_path.clone(),
+            });
+        }
+        let current_lock_identity =
+            identity_from_file(&self.lock_path, &current_lock).ok_or_else(|| {
+                ProfileOwnershipError::ProfileOwnerLockReplaced {
+                    path: self.lock_path.clone(),
+                }
+            })?;
+        if current_lock_identity != self.lock_identity {
+            return Err(ProfileOwnershipError::ProfileOwnerLockReplaced {
+                path: self.lock_path.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Clone the retained no-follow profile-root capability for a production participant.
+    pub fn profile_root_dir(&self) -> Result<Dir, ProfileOwnershipError> {
+        self.validate_current()?;
+        self.root_dir
+            .try_clone()
+            .map_err(|source| ProfileOwnershipError::Io {
+                path: self.profile_root.clone(),
+                source,
+            })
+    }
+
+    /// Create or open one direct child directory relative to the retained profile capability.
+    pub fn open_child_dir(&self, child: &Path) -> Result<Dir, ProfileOwnershipError> {
+        let child_name =
+            single_normal_component(child).map_err(|source| ProfileOwnershipError::Io {
+                path: self.profile_root.join(child),
+                source,
+            })?;
+        self.validate_current()?;
+        match self.root_dir.create_dir(child_name) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(source) => {
+                return Err(ProfileOwnershipError::Io {
+                    path: self.profile_root.join(child),
+                    source,
+                });
+            }
+        }
+        let child_dir = self
+            .root_dir
+            .open_dir_nofollow(child_name)
+            .map_err(|source| ProfileOwnershipError::Io {
+                path: self.profile_root.join(child),
+                source,
+            })?;
+        self.validate_current()?;
+        Ok(child_dir)
+    }
+}
+
+fn single_normal_component(path: &Path) -> io::Result<&Path> {
+    let mut components = path.components();
+    let Some(Component::Normal(name)) = components.next() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "profile child must be a single normal component",
+        ));
+    };
+    if components.next().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "profile child must be a single normal component",
+        ));
+    }
+    Ok(Path::new(name))
+}
+
+fn open_profile_root(path: &Path) -> io::Result<Dir> {
+    let mut components = path.components();
+    #[cfg(unix)]
+    {
+        if !matches!(components.next(), Some(Component::RootDir)) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "profile root must be absolute",
+            ));
+        }
+        let mut dir = Dir::open_ambient_dir(Path::new("/"), ambient_authority())?;
+        for component in components {
+            let Component::Normal(name) = component else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "profile root contains a non-normal component",
+                ));
+            };
+            dir = dir.open_dir_nofollow(name)?;
+        }
+        return Ok(dir);
+    }
+    #[cfg(windows)]
+    {
+        let Some(Component::Prefix(prefix)) = components.next() else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "profile root must have a Windows path prefix",
+            ));
+        };
+        if !matches!(components.next(), Some(Component::RootDir)) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "profile root must be absolute",
+            ));
+        }
+        let mut anchor = PathBuf::from(prefix.as_os_str());
+        anchor.push(std::path::MAIN_SEPARATOR_STR);
+        let mut dir = Dir::open_ambient_dir(anchor, ambient_authority())?;
+        for component in components {
+            let Component::Normal(name) = component else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "profile root contains a non-normal component",
+                ));
+            };
+            dir = dir.open_dir_nofollow(name)?;
+        }
+        return Ok(dir);
+    }
+    #[cfg(all(not(unix), not(windows)))]
+    {
+        let _ = (path, components);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "no verified profile-root capability on this platform",
+        ))
+    }
+}
+
+fn identity_for_root(path: &Path, dir: &Dir) -> Result<String, ProfileOwnershipError> {
+    identity_from_dir(dir).ok_or_else(|| ProfileOwnershipError::IdentityUnavailable {
+        path: path.to_path_buf(),
+    })
+}
+
+fn identity_for_lock(path: &Path, file: &File) -> Result<String, ProfileOwnershipError> {
+    identity_from_file(path, file).ok_or_else(|| ProfileOwnershipError::IdentityUnavailable {
+        path: path.to_path_buf(),
+    })
+}
+
+fn identity_from_dir(dir: &Dir) -> Option<String> {
+    let retained_file = dir.try_clone().ok()?.into_std_file();
+    crate::filesystem_identity::stable_filesystem_identity_from_open_file(&retained_file)
+}
+
+fn identity_from_file(_path: &Path, file: &File) -> Option<String> {
+    crate::filesystem_identity::stable_filesystem_identity_from_open_file(file)
+}
+
+fn is_regular_file(file: &File) -> io::Result<bool> {
+    let metadata = file.metadata()?;
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+        return Ok(
+            metadata.is_file() && metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0 == 0
+        );
+    }
+    #[cfg(not(windows))]
+    {
+        Ok(metadata.is_file() && !metadata.is_symlink())
+    }
+}
+
+fn open_lock_file(root_dir: &Dir, create: bool) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .create(create)
+        .follow(FollowSymlinks::No);
+    root_dir
+        .open_with(Path::new(PROFILE_OWNER_LOCK_FILE_NAME), &options)
+        .map(|file| file.into_std())
 }
 
 fn write_diagnostic(mut file: File, path: &Path) -> Result<File, ProfileOwnershipError> {
@@ -89,28 +340,17 @@ fn write_diagnostic(mut file: File, path: &Path) -> Result<File, ProfileOwnershi
 }
 
 #[cfg(unix)]
-fn acquire_lock(path: &Path) -> Result<File, ProfileOwnershipError> {
-    use std::os::{fd::AsRawFd, unix::fs::OpenOptionsExt};
+fn acquire_lock(root_dir: &Dir, path: &Path) -> Result<File, ProfileOwnershipError> {
+    use std::os::fd::AsRawFd;
 
-    let mut options = std::fs::OpenOptions::new();
-    options
-        .read(true)
-        .write(true)
-        .create(true)
-        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
-    let file = options
-        .open(path)
-        .map_err(|source| ProfileOwnershipError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
-    let metadata = file
-        .metadata()
-        .map_err(|source| ProfileOwnershipError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
-    if !metadata.is_file() {
+    let file = open_lock_file(root_dir, true).map_err(|source| ProfileOwnershipError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !is_regular_file(&file).map_err(|source| ProfileOwnershipError::Io {
+        path: path.to_path_buf(),
+        source,
+    })? {
         return Err(ProfileOwnershipError::NotRegularFile {
             path: path.to_path_buf(),
         });
@@ -136,40 +376,22 @@ fn acquire_lock(path: &Path) -> Result<File, ProfileOwnershipError> {
 }
 
 #[cfg(windows)]
-fn acquire_lock(path: &Path) -> Result<File, ProfileOwnershipError> {
-    use std::os::windows::{
-        fs::{MetadataExt, OpenOptionsExt},
-        io::AsRawHandle,
-    };
-    use windows::Win32::Foundation::{
-        ERROR_LOCK_VIOLATION, FILE_ATTRIBUTE_REPARSE_POINT, HANDLE, WIN32_ERROR,
-    };
+fn acquire_lock(root_dir: &Dir, path: &Path) -> Result<File, ProfileOwnershipError> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::Foundation::{ERROR_LOCK_VIOLATION, HANDLE, WIN32_ERROR};
     use windows::Win32::Storage::FileSystem::{
-        FILE_FLAG_OPEN_REPARSE_POINT, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
-        LockFileEx,
+        LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
     };
     use windows::Win32::System::IO::OVERLAPPED;
 
-    let mut options = std::fs::OpenOptions::new();
-    options
-        .read(true)
-        .write(true)
-        .create(true)
-        .share_mode(0x00000001 | 0x00000002)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT.0);
-    let file = options
-        .open(path)
-        .map_err(|source| ProfileOwnershipError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
-    let metadata = file
-        .metadata()
-        .map_err(|source| ProfileOwnershipError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?;
-    if !metadata.is_file() || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0 {
+    let file = open_lock_file(root_dir, true).map_err(|source| ProfileOwnershipError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !is_regular_file(&file).map_err(|source| ProfileOwnershipError::Io {
+        path: path.to_path_buf(),
+        source,
+    })? {
         return Err(ProfileOwnershipError::NotRegularFile {
             path: path.to_path_buf(),
         });
@@ -202,7 +424,7 @@ fn acquire_lock(path: &Path) -> Result<File, ProfileOwnershipError> {
 }
 
 #[cfg(all(not(unix), not(windows)))]
-fn acquire_lock(path: &Path) -> Result<File, ProfileOwnershipError> {
+fn acquire_lock(_root_dir: &Dir, path: &Path) -> Result<File, ProfileOwnershipError> {
     Err(ProfileOwnershipError::Unsupported {
         path: path.to_path_buf(),
     })
@@ -299,6 +521,61 @@ mod tests {
         assert_ne!(first_root, second.profile_root());
         assert!(first_root.ends_with("ownership-one"));
         assert!(second.profile_root().ends_with("ownership-two"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_root_capability_and_identity_detect_profile_root_replacement() {
+        let _runtime = test_runtime();
+        let base = tempdir().expect("profile base");
+        let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+        let _profile_guard = PersistenceProfileGuard::named("ownership-root-replaced");
+        let guard = WritableProfileGuard::acquire_current().expect("profile holder");
+        let root = guard.profile_root().to_path_buf();
+        let journal = guard
+            .open_child_dir(Path::new("operation_journal"))
+            .expect("journal capability");
+
+        let displaced = base.path().join("displaced-profile-root");
+        fs::rename(&root, &displaced).expect("displace acquired root");
+        fs::create_dir(&root).expect("replacement profile root");
+        fs::create_dir(root.join("operation_journal")).expect("replacement journal");
+        fs::write(
+            root.join("operation_journal").join("replacement-marker"),
+            b"replacement",
+        )
+        .expect("replacement marker");
+
+        assert!(matches!(
+            guard.validate_current(),
+            Err(ProfileOwnershipError::ProfileRootReplaced { path }) if path == root
+        ));
+        assert!(
+            !journal
+                .entries()
+                .expect("retained journal entries")
+                .filter_map(Result::ok)
+                .any(|entry| entry.file_name() == "replacement-marker")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_lock_identity_detects_profile_lock_replacement() {
+        let _runtime = test_runtime();
+        let base = tempdir().expect("profile base");
+        let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+        let _profile_guard = PersistenceProfileGuard::named("ownership-lock-replaced");
+        let guard = WritableProfileGuard::acquire_current().expect("profile holder");
+        let lock_path = guard.profile_root().join(PROFILE_OWNER_LOCK_FILE_NAME);
+        let displaced = guard.profile_root().join("profile-owner.lock.old");
+        fs::rename(&lock_path, &displaced).expect("displace acquired lock entry");
+        fs::write(&lock_path, b"replacement").expect("replacement lock entry");
+
+        assert!(matches!(
+            guard.validate_current(),
+            Err(ProfileOwnershipError::ProfileOwnerLockReplaced { path }) if path == lock_path
+        ));
     }
 
     #[cfg(unix)]

--- a/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
+++ b/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
@@ -1,0 +1,359 @@
+//! Cross-process writable ownership for one Wavecrate persistence profile.
+
+use std::{
+    fs::File,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+use thiserror::Error;
+
+const PROFILE_OWNER_LOCK_FILE_NAME: &str = "profile-owner.lock";
+
+/// Errors returned while acquiring writable ownership of the current profile.
+#[derive(Debug, Error)]
+pub enum ProfileOwnershipError {
+    /// Another process currently holds the profile ownership lock.
+    #[error("profile is owned by another process: {path}")]
+    ProfileOwnedByAnotherProcess {
+        /// Profile lock path that could not be acquired.
+        path: PathBuf,
+    },
+    /// Resolving the current profile root failed.
+    #[error("profile root unavailable: {0}")]
+    AppDirectory(String),
+    /// Opening, validating, or writing the profile lock failed.
+    #[error("profile ownership lock failed at {path}: {source}")]
+    Io {
+        /// Profile lock path involved in the failure.
+        path: PathBuf,
+        /// Underlying filesystem error.
+        source: io::Error,
+    },
+    /// The profile lock path exists but is not a regular file.
+    #[error("profile ownership lock is not a regular file: {path}")]
+    NotRegularFile {
+        /// Profile lock path that failed validation.
+        path: PathBuf,
+    },
+    /// This platform has no verified nonblocking profile ownership primitive.
+    #[error("profile ownership is unsupported on this platform: {path}")]
+    Unsupported {
+        /// Profile lock path that could not be protected.
+        path: PathBuf,
+    },
+}
+
+/// Process-wide writable ownership for one resolved Wavecrate profile.
+///
+/// The guard retains the open lock file for its entire lifetime. The lock path is
+/// intentionally never removed or renamed; its contents are diagnostic only, while
+/// the live descriptor lock is the authority.
+#[derive(Debug)]
+pub struct WritableProfileGuard {
+    profile_root: PathBuf,
+    _lock_path: PathBuf,
+    _lock_file: File,
+}
+
+impl WritableProfileGuard {
+    /// Resolve the current profile and acquire its nonblocking writable-owner lock.
+    pub fn acquire_current() -> Result<Self, ProfileOwnershipError> {
+        let profile_root = super::resolution::resolve_persistence()
+            .map_err(|error| ProfileOwnershipError::AppDirectory(error.to_string()))?
+            .app_root;
+        let lock_path = profile_root.join(PROFILE_OWNER_LOCK_FILE_NAME);
+        let lock_file = acquire_lock(&lock_path)?;
+        Ok(Self {
+            profile_root,
+            _lock_path: lock_path,
+            _lock_file: lock_file,
+        })
+    }
+
+    /// Return the profile root protected by this guard.
+    pub fn profile_root(&self) -> &Path {
+        &self.profile_root
+    }
+}
+
+fn write_diagnostic(mut file: File, path: &Path) -> Result<File, ProfileOwnershipError> {
+    file.set_len(0)
+        .and_then(|_| file.write_all(format!("version=1\npid={}\n", std::process::id()).as_bytes()))
+        .and_then(|_| file.sync_all())
+        .map_err(|source| ProfileOwnershipError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn acquire_lock(path: &Path) -> Result<File, ProfileOwnershipError> {
+    use std::os::{fd::AsRawFd, unix::fs::OpenOptionsExt};
+
+    let mut options = std::fs::OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .create(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    let file = options
+        .open(path)
+        .map_err(|source| ProfileOwnershipError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let metadata = file
+        .metadata()
+        .map_err(|source| ProfileOwnershipError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if !metadata.is_file() {
+        return Err(ProfileOwnershipError::NotRegularFile {
+            path: path.to_path_buf(),
+        });
+    }
+
+    // Advisory descriptor locking is released by the kernel when this process exits,
+    // while the path remains available for diagnostics and future acquisition.
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if result != 0 {
+        let source = io::Error::last_os_error();
+        if source.kind() == io::ErrorKind::WouldBlock {
+            return Err(ProfileOwnershipError::ProfileOwnedByAnotherProcess {
+                path: path.to_path_buf(),
+            });
+        }
+        return Err(ProfileOwnershipError::Io {
+            path: path.to_path_buf(),
+            source,
+        });
+    }
+
+    write_diagnostic(file, path)
+}
+
+#[cfg(windows)]
+fn acquire_lock(path: &Path) -> Result<File, ProfileOwnershipError> {
+    use std::os::windows::{
+        fs::{MetadataExt, OpenOptionsExt},
+        io::AsRawHandle,
+    };
+    use windows::Win32::Foundation::{
+        ERROR_LOCK_VIOLATION, FILE_ATTRIBUTE_REPARSE_POINT, HANDLE, WIN32_ERROR,
+    };
+    use windows::Win32::Storage::FileSystem::{
+        FILE_FLAG_OPEN_REPARSE_POINT, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+        LockFileEx,
+    };
+    use windows::Win32::System::IO::OVERLAPPED;
+
+    let mut options = std::fs::OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .create(true)
+        .share_mode(0x00000001 | 0x00000002)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT.0);
+    let file = options
+        .open(path)
+        .map_err(|source| ProfileOwnershipError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let metadata = file
+        .metadata()
+        .map_err(|source| ProfileOwnershipError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if !metadata.is_file() || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0 {
+        return Err(ProfileOwnershipError::NotRegularFile {
+            path: path.to_path_buf(),
+        });
+    }
+
+    let mut overlapped = OVERLAPPED::default();
+    let result = unsafe {
+        LockFileEx(
+            HANDLE(file.as_raw_handle()),
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            None,
+            u32::MAX,
+            u32::MAX,
+            &mut overlapped,
+        )
+    };
+    if let Err(error) = result {
+        if WIN32_ERROR::from_error(&error) == Some(ERROR_LOCK_VIOLATION) {
+            return Err(ProfileOwnershipError::ProfileOwnedByAnotherProcess {
+                path: path.to_path_buf(),
+            });
+        }
+        return Err(ProfileOwnershipError::Io {
+            path: path.to_path_buf(),
+            source: io::Error::other(error.to_string()),
+        });
+    }
+
+    write_diagnostic(file, path)
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn acquire_lock(path: &Path) -> Result<File, ProfileOwnershipError> {
+    Err(ProfileOwnershipError::Unsupported {
+        path: path.to_path_buf(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        app_dirs::{APP_DIR_NAME, ConfigBaseGuard, PROFILE_DIR_NAME, PersistenceProfileGuard},
+        test_runtime::TestRuntimeGuard,
+    };
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn test_runtime() -> TestRuntimeGuard {
+        TestRuntimeGuard::acquire()
+    }
+
+    fn profile_root(base: &std::path::Path, profile: &str) -> PathBuf {
+        base.join(APP_DIR_NAME).join(PROFILE_DIR_NAME).join(profile)
+    }
+
+    #[test]
+    fn active_profile_owner_conflicts_without_replacing_lock_contents() {
+        let _runtime = test_runtime();
+        let base = tempdir().expect("profile base");
+        let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+        let _profile_guard = PersistenceProfileGuard::named("ownership-conflict");
+        let holder = WritableProfileGuard::acquire_current().expect("profile holder");
+        let lock_path = holder.profile_root().join(PROFILE_OWNER_LOCK_FILE_NAME);
+        let contents = fs::read(&lock_path).expect("owner diagnostic");
+
+        let error = WritableProfileGuard::acquire_current().expect_err("active owner conflict");
+
+        assert!(matches!(
+            error,
+            ProfileOwnershipError::ProfileOwnedByAnotherProcess { path } if path == lock_path
+        ));
+        assert_eq!(
+            fs::read(lock_path).expect("owner diagnostic after conflict"),
+            contents
+        );
+    }
+
+    #[test]
+    fn dropping_profile_owner_allows_reopen() {
+        let _runtime = test_runtime();
+        let base = tempdir().expect("profile base");
+        let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+        let _profile_guard = PersistenceProfileGuard::named("ownership-reopen");
+        let holder = WritableProfileGuard::acquire_current().expect("profile holder");
+        let root = holder.profile_root().to_path_buf();
+        drop(holder);
+
+        let reopened = WritableProfileGuard::acquire_current().expect("reopen profile");
+
+        assert_eq!(reopened.profile_root(), root);
+    }
+
+    #[test]
+    fn stale_lock_contents_do_not_block_acquisition() {
+        let _runtime = test_runtime();
+        let base = tempdir().expect("profile base");
+        let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+        let _profile_guard = PersistenceProfileGuard::named("ownership-stale");
+        let root = profile_root(base.path(), "ownership-stale");
+        fs::create_dir_all(&root).expect("profile root");
+        let lock_path = root.join(PROFILE_OWNER_LOCK_FILE_NAME);
+        fs::write(&lock_path, b"pid=stale\nunknown=diagnostic\n").expect("stale diagnostic");
+
+        let guard = WritableProfileGuard::acquire_current().expect("stale contents ignored");
+
+        assert_eq!(guard.profile_root(), root);
+        assert_eq!(
+            fs::read(lock_path).expect("fresh owner diagnostic"),
+            format!("version=1\npid={}\n", std::process::id()).as_bytes()
+        );
+    }
+
+    #[test]
+    fn distinct_profile_roots_are_independently_writable() {
+        let _runtime = test_runtime();
+        let base = tempdir().expect("profile base");
+        let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+        let first_profile = PersistenceProfileGuard::named("ownership-one");
+        let first = WritableProfileGuard::acquire_current().expect("first profile holder");
+        let first_root = first.profile_root().to_path_buf();
+        drop(first_profile);
+
+        let _second_profile = PersistenceProfileGuard::named("ownership-two");
+        let second = WritableProfileGuard::acquire_current().expect("second profile holder");
+
+        assert_ne!(first_root, second.profile_root());
+        assert!(first_root.ends_with("ownership-one"));
+        assert!(second.profile_root().ends_with("ownership-two"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_profile_lock_fails_closed_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let _runtime = test_runtime();
+        let base = tempdir().expect("profile base");
+        let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+        let _profile_guard = PersistenceProfileGuard::named("ownership-symlink");
+        let root = profile_root(base.path(), "ownership-symlink");
+        fs::create_dir_all(&root).expect("profile root");
+        let target = base.path().join("target");
+        fs::write(&target, b"do not touch").expect("target");
+        let lock_path = root.join(PROFILE_OWNER_LOCK_FILE_NAME);
+        symlink(&target, &lock_path).expect("profile lock symlink");
+
+        let result = WritableProfileGuard::acquire_current();
+
+        assert!(result.is_err());
+        assert_eq!(
+            fs::read(&target).expect("target after failed acquire"),
+            b"do not touch"
+        );
+        assert!(
+            fs::symlink_metadata(lock_path)
+                .expect("symlink after failed acquire")
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn reparse_profile_lock_fails_closed_without_touching_target() {
+        use std::os::windows::fs::symlink_file;
+
+        let _runtime = test_runtime();
+        let base = tempdir().expect("profile base");
+        let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+        let _profile_guard = PersistenceProfileGuard::named("ownership-reparse");
+        let root = profile_root(base.path(), "ownership-reparse");
+        fs::create_dir_all(&root).expect("profile root");
+        let target = base.path().join("target");
+        fs::write(&target, b"do not touch").expect("target");
+        let lock_path = root.join(PROFILE_OWNER_LOCK_FILE_NAME);
+        symlink_file(&target, &lock_path).expect("profile lock reparse point");
+
+        let result = WritableProfileGuard::acquire_current();
+
+        assert!(result.is_err());
+        assert_eq!(
+            fs::read(&target).expect("target after failed acquire"),
+            b"do not touch"
+        );
+    }
+}

--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -31,11 +31,14 @@ use crate::native_app::sample_library::sample_ratings::{
 use crate::native_app::source_processing::{
     SourceProcessingRegistration, SourceProcessingSupervisor,
 };
+use crate::native_app::transaction_history::operation_journal::{
+    RecoveryRootCapability, RecoveryUnavailable,
+};
 use crate::native_app::waveform::WaveformPreservedMarks;
 
 pub(in crate::native_app) struct BackgroundTaskState {
-    pub(in crate::native_app) waveform_recovery_root:
-        Option<crate::native_app::transaction_history::operation_journal::RecoveryRootCapability>,
+    pub(in crate::native_app) waveform_recovery:
+        Result<RecoveryRootCapability, RecoveryUnavailable>,
     pub(in crate::native_app) worker_sender: Sender<GuiMessage>,
     pub(in crate::native_app) worker_receiver: Option<Receiver<GuiMessage>>,
     pub(in crate::native_app) next_task_id: u64,
@@ -472,25 +475,27 @@ impl BackgroundTaskState {
                 )
             })
             .collect();
-        let waveform_recovery_root = recovery_root.map(|path| {
-            let file = std::fs::File::open(&path).expect("test recovery root");
-            let identity =
-                wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(
+        let waveform_recovery = match recovery_root {
+            Some(path) => {
+                let file = std::fs::File::open(&path).expect("test recovery root");
+                let identity = wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(
                     &file,
                 )
                 .expect("test recovery root identity");
-            crate::native_app::transaction_history::operation_journal::RecoveryRootCapability {
-                path,
-                file: Arc::new(file),
-                identity,
+                Ok(RecoveryRootCapability {
+                    path,
+                    file: Arc::new(file),
+                    identity,
+                })
             }
-        });
+            None => Err(RecoveryUnavailable::OperationJournalUnavailable),
+        };
         #[cfg(not(test))]
         let operation_journal = super::OperationJournalOwner::start();
         #[cfg(test)]
         let operation_journal = super::OperationJournalOwner::disabled();
         Self {
-            waveform_recovery_root,
+            waveform_recovery,
             worker_sender,
             worker_receiver,
             next_task_id: 1,
@@ -551,14 +556,14 @@ impl BackgroundTaskState {
         &mut self,
     ) -> Option<super::journal::OperationJournalStatus> {
         let status = self.operation_journal.take_status()?;
-        if let super::journal::OperationJournalStatus::Available { recovery_root, .. } = &status {
-            self.waveform_recovery_root = Some(recovery_root.clone());
-        } else if matches!(
-            status,
+        match &status {
+            super::journal::OperationJournalStatus::Available { recovery, .. } => {
+                self.waveform_recovery = recovery.clone();
+            }
             super::journal::OperationJournalStatus::Initializing
-                | super::journal::OperationJournalStatus::Unavailable { .. }
-        ) {
-            self.waveform_recovery_root = None;
+            | super::journal::OperationJournalStatus::Unavailable { .. } => {
+                self.waveform_recovery = Err(RecoveryUnavailable::OperationJournalUnavailable);
+            }
         }
         Some(status)
     }

--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -15,7 +15,7 @@ use wavecrate_library::app_dirs::{ProfileOwnershipError, WritableProfileGuard};
 use crate::native_app::transaction_history::operation_journal::{
     BoundedAdmissionError, FilesystemStageOutcome, JournalError, OperationDisposition, OperationId,
     OperationIntent, OperationJournalCoordinator, OperationPhase, PreparedOperationOutcome,
-    RecoveryRootCapability,
+    RecoveryRootCapability, RecoveryUnavailable,
 };
 use crate::native_app::transaction_history::{
     HistoryFileAction, HistoryFileIoDirection, RejectedBeforeIntent,
@@ -61,7 +61,9 @@ pub(in crate::native_app) enum OperationJournalStatus {
     Initializing,
     Available {
         summary: crate::native_app::transaction_history::operation_journal::RecoverySummary,
-        recovery_root: RecoveryRootCapability,
+        /// Explicit-directory tests may receive a capability. Production reports the typed
+        /// unavailable result until participant recovery leases exist.
+        recovery: Result<RecoveryRootCapability, RecoveryUnavailable>,
     },
     Unavailable {
         reason: OperationJournalUnavailable,
@@ -73,6 +75,7 @@ pub(in crate::native_app) enum OperationJournalUnavailable {
     JournalOwnedByAnotherProcess { path: PathBuf },
     ProfileOwnedByAnotherProcess { path: PathBuf },
     ProfileOwnershipChanged { path: PathBuf },
+    UnsupportedPlatform { path: PathBuf, reason: String },
     OpenFailed(String),
     OwnerStartFailed(String),
 }
@@ -101,6 +104,13 @@ impl std::fmt::Display for OperationJournalUnavailable {
                     path.display()
                 )
             }
+            Self::UnsupportedPlatform { path, reason } => {
+                write!(
+                    formatter,
+                    "operation journal unsupported or unverified at {}: {reason}",
+                    path.display()
+                )
+            }
             Self::OpenFailed(error) => formatter.write_str(error),
             Self::OwnerStartFailed(error) => formatter.write_str(error),
         }
@@ -114,6 +124,9 @@ impl OperationJournalUnavailable {
                 Self::JournalOwnedByAnotherProcess { path }
             }
             JournalError::ProfileOwnership(error) => Self::from_profile_ownership_error(error),
+            JournalError::UnsupportedPlatform { path, reason } => {
+                Self::UnsupportedPlatform { path, reason }
+            }
             error => Self::OpenFailed(error.to_string()),
         }
     }
@@ -580,34 +593,28 @@ fn run_owner(
         match opened {
             Ok(coordinator) => {
                 let summary = coordinator.recovery_summary();
-                // The explicit journal directory is also the recovery root for
-                // test/runtime overrides. Production uses the root held by the
-                // profile guard so journal and recovery share one resolved root.
-                let recovery_path = profile_guard
-                    .as_ref()
-                    .map(|guard| guard.profile_root().to_path_buf())
-                    .or_else(|| directory.clone());
-                let recovery_root = match match profile_guard.as_ref() {
-                    Some(profile_guard) => crate::native_app::transaction_history::operation_journal::open_recovery_root_capability_from_profile(profile_guard),
-                    None => crate::native_app::transaction_history::operation_journal::open_recovery_root_capability(recovery_path),
-                } {
-                    Ok(capability) => capability,
-                    Err(error) => {
-                        let reason = OperationJournalUnavailable::from_error(error);
-                        *unavailable.lock().expect("journal unavailable state") = Some(reason.clone());
-                        lifecycle.store(OwnerLifecycle::Unavailable as u8, std::sync::atomic::Ordering::Release);
-                        let _ = status_tx.send(OperationJournalStatus::Unavailable { reason });
-                        break None;
+                // The explicit journal directory retains its existing test-only recovery seam.
+                // Production deliberately does not publish a profile capability to asynchronous
+                // destructive-edit workers until a participant lease/recovery lifecycle exists.
+                let recovery = if profile_guard.is_some() {
+                    Err(RecoveryUnavailable::ParticipantLeaseRequired)
+                } else {
+                    match crate::native_app::transaction_history::operation_journal::open_recovery_root_capability(directory.clone()) {
+                        Ok(capability) => Ok(capability),
+                        Err(error) => {
+                            let reason = OperationJournalUnavailable::from_error(error);
+                            *unavailable.lock().expect("journal unavailable state") = Some(reason.clone());
+                            lifecycle.store(OwnerLifecycle::Unavailable as u8, std::sync::atomic::Ordering::Release);
+                            let _ = status_tx.send(OperationJournalStatus::Unavailable { reason });
+                            break None;
+                        }
                     }
                 };
                 lifecycle.store(
                     OwnerLifecycle::Available as u8,
                     std::sync::atomic::Ordering::Release,
                 );
-                let _ = status_tx.send(OperationJournalStatus::Available {
-                    summary,
-                    recovery_root,
-                });
+                let _ = status_tx.send(OperationJournalStatus::Available { summary, recovery });
                 break Some(coordinator);
             }
             Err(JournalError::JournalOwnedByAnotherProcess { path }) => {
@@ -938,6 +945,42 @@ mod tests {
             kind: OperationKind::FileHistory,
             label: String::from("owner test"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn production_available_does_not_publish_unleased_recovery_capability() {
+        let mut runtime = TestRuntimeGuard::acquire();
+        let base = tempfile::tempdir().expect("profile base");
+        runtime.set_var("WAVECRATE_CONFIG_HOME", base.path().as_os_str());
+        runtime.set_var("WAVECRATE_CONFIG_PROFILE", "native-owner-recovery-unleased");
+
+        let owner = OperationJournalOwner::start_with_current_profile_for_test();
+        assert_eq!(
+            owner
+                .statuses
+                .recv_timeout(Duration::from_secs(2))
+                .expect("initializing status"),
+            OperationJournalStatus::Initializing
+        );
+        let status = owner
+            .statuses
+            .recv_timeout(Duration::from_secs(2))
+            .expect("available status");
+        assert!(matches!(
+            status,
+            OperationJournalStatus::Available {
+                recovery: Err(RecoveryUnavailable::ParticipantLeaseRequired),
+                ..
+            }
+        ));
+
+        let profile_root = base
+            .path()
+            .join(wavecrate_library::app_dirs::APP_DIR_NAME)
+            .join(wavecrate_library::app_dirs::PROFILE_DIR_NAME)
+            .join("native-owner-recovery-unleased");
+        assert!(!profile_root.join("session_recovery").exists());
     }
 
     #[test]

--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -161,6 +161,7 @@ pub(in crate::native_app) enum JournalOperationError {
 pub(in crate::native_app) enum OperationJournalRestoreError {
     RejectedBeforeIntent(RejectedBeforeIntent),
     Journal(String),
+    RecoveryUnavailable(RecoveryUnavailable),
     Unavailable(String),
     Closed,
 }

--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -10,6 +10,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
+use wavecrate_library::app_dirs::{ProfileOwnershipError, WritableProfileGuard};
 
 use crate::native_app::transaction_history::operation_journal::{
     BoundedAdmissionError, FilesystemStageOutcome, JournalError, OperationDisposition, OperationId,
@@ -69,7 +70,8 @@ pub(in crate::native_app) enum OperationJournalStatus {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(in crate::native_app) enum OperationJournalUnavailable {
-    OwnedByAnotherProcess { path: PathBuf },
+    JournalOwnedByAnotherProcess { path: PathBuf },
+    ProfileOwnedByAnotherProcess { path: PathBuf },
     OpenFailed(String),
     OwnerStartFailed(String),
 }
@@ -77,8 +79,19 @@ pub(in crate::native_app) enum OperationJournalUnavailable {
 impl std::fmt::Display for OperationJournalUnavailable {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::OwnedByAnotherProcess { path } => {
-                write!(formatter, "owned by another process: {}", path.display())
+            Self::JournalOwnedByAnotherProcess { path } => {
+                write!(
+                    formatter,
+                    "journal owned by another process: {}",
+                    path.display()
+                )
+            }
+            Self::ProfileOwnedByAnotherProcess { path } => {
+                write!(
+                    formatter,
+                    "profile owned by another process: {}",
+                    path.display()
+                )
             }
             Self::OpenFailed(error) => formatter.write_str(error),
             Self::OwnerStartFailed(error) => formatter.write_str(error),
@@ -89,7 +102,18 @@ impl std::fmt::Display for OperationJournalUnavailable {
 impl OperationJournalUnavailable {
     fn from_error(error: JournalError) -> Self {
         match error {
-            JournalError::OwnedByAnotherProcess { path } => Self::OwnedByAnotherProcess { path },
+            JournalError::JournalOwnedByAnotherProcess { path } => {
+                Self::JournalOwnedByAnotherProcess { path }
+            }
+            error => Self::OpenFailed(error.to_string()),
+        }
+    }
+
+    fn from_profile_ownership_error(error: ProfileOwnershipError) -> Self {
+        match error {
+            ProfileOwnershipError::ProfileOwnedByAnotherProcess { path } => {
+                Self::ProfileOwnedByAnotherProcess { path }
+            }
             error => Self::OpenFailed(error.to_string()),
         }
     }
@@ -197,6 +221,11 @@ impl OperationJournalOwner {
         // applies strict no-follow traversal to its capability root.
         let directory = std::fs::canonicalize(&directory).unwrap_or(directory);
         Self::start_with_optional_directory(Some(directory))
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn start_with_current_profile_for_test() -> Self {
+        Self::start_with_optional_directory(None)
     }
 
     fn start_with_optional_directory(directory: Option<PathBuf>) -> Self {
@@ -494,6 +523,30 @@ fn run_owner(
     unavailable: Arc<Mutex<Option<OperationJournalUnavailable>>>,
 ) {
     let _ = status_tx.send(OperationJournalStatus::Initializing);
+    let profile_guard = if directory.is_none() {
+        if stop.load(std::sync::atomic::Ordering::Acquire) {
+            lifecycle.store(
+                OwnerLifecycle::Closed as u8,
+                std::sync::atomic::Ordering::Release,
+            );
+            return;
+        }
+        match WritableProfileGuard::acquire_current() {
+            Ok(guard) => Some(guard),
+            Err(error) => {
+                let reason = OperationJournalUnavailable::from_profile_ownership_error(error);
+                *unavailable.lock().expect("journal unavailable state") = Some(reason.clone());
+                lifecycle.store(
+                    OwnerLifecycle::Unavailable as u8,
+                    std::sync::atomic::Ordering::Release,
+                );
+                let _ = status_tx.send(OperationJournalStatus::Unavailable { reason });
+                return;
+            }
+        }
+    } else {
+        None
+    };
     let mut retry_interval = OWNER_RETRY_INTERVAL;
     let retry_started = Instant::now();
     let mut coordinator = loop {
@@ -504,18 +557,23 @@ fn run_owner(
             );
             return;
         }
-        let opened = match directory.as_ref() {
-            Some(directory) => OperationJournalCoordinator::open(directory.clone()),
-            None => OperationJournalCoordinator::open_current_profile(),
+        let opened = match (directory.as_ref(), profile_guard.as_ref()) {
+            (Some(directory), None) => OperationJournalCoordinator::open(directory.clone()),
+            (None, Some(profile_guard)) => {
+                OperationJournalCoordinator::open_current_profile(profile_guard)
+            }
+            _ => unreachable!("profile guard and journal directory startup modes diverged"),
         };
         match opened {
             Ok(coordinator) => {
                 let summary = coordinator.recovery_summary();
                 // The explicit journal directory is also the recovery root for
-                // test/runtime overrides. Production callers pass `None`, so
-                // the capability helper resolves the profile app root here on
-                // the owner thread.
-                let recovery_path = directory.clone();
+                // test/runtime overrides. Production uses the root held by the
+                // profile guard so journal and recovery share one resolved root.
+                let recovery_path = profile_guard
+                    .as_ref()
+                    .map(|guard| guard.profile_root().to_path_buf())
+                    .or_else(|| directory.clone());
                 let recovery_root = match crate::native_app::transaction_history::operation_journal::open_recovery_root_capability(recovery_path) {
                     Ok(capability) => capability,
                     Err(error) => {
@@ -536,10 +594,10 @@ fn run_owner(
                 });
                 break Some(coordinator);
             }
-            Err(JournalError::OwnedByAnotherProcess { path }) => {
+            Err(JournalError::JournalOwnedByAnotherProcess { path }) => {
                 // Ownership replacement is retried here, never admitted while initializing.
                 if retry_started.elapsed() >= OWNER_RETRY_TIMEOUT {
-                    let reason = OperationJournalUnavailable::OwnedByAnotherProcess { path };
+                    let reason = OperationJournalUnavailable::JournalOwnedByAnotherProcess { path };
                     *unavailable.lock().expect("journal unavailable state") = Some(reason.clone());
                     lifecycle.store(
                         OwnerLifecycle::Unavailable as u8,
@@ -816,6 +874,7 @@ fn run_owner(
         }
     }
     drop(coordinator);
+    drop(profile_guard);
     lifecycle.store(
         OwnerLifecycle::Closed as u8,
         std::sync::atomic::Ordering::Release,
@@ -830,6 +889,7 @@ mod tests {
         FilesystemStagedParticipant, OperationActor, OperationKind,
     };
     use crate::native_app::waveform_edits::waveform_restore_action_for_capacity_tests;
+    use wavecrate_library::{app_dirs::WritableProfileGuard, test_runtime::TestRuntimeGuard};
 
     fn fixture_directory() -> tempfile::TempDir {
         #[cfg(target_os = "macos")]
@@ -1064,6 +1124,58 @@ mod tests {
             .recv_timeout(Duration::from_secs(2))
             .expect("startup status");
         assert!(matches!(status, OperationJournalStatus::Available { .. }));
+    }
+
+    #[test]
+    fn production_owner_loser_reports_profile_conflict_without_journal_admission() {
+        let mut runtime = TestRuntimeGuard::acquire();
+        let base = tempfile::tempdir().expect("profile base");
+        runtime.set_var("WAVECRATE_CONFIG_HOME", base.path().as_os_str());
+        runtime.set_var("WAVECRATE_CONFIG_PROFILE", "native-owner-conflict");
+
+        let holder = WritableProfileGuard::acquire_current().expect("profile holder");
+        let profile_root = holder.profile_root().to_path_buf();
+        let lock_path = profile_root.join("profile-owner.lock");
+        let journal_directory = profile_root.join("operation_journal");
+        let loser = OperationJournalOwner::start_with_current_profile_for_test();
+
+        assert_eq!(
+            loser
+                .statuses
+                .recv_timeout(Duration::from_secs(2))
+                .expect("initializing status"),
+            OperationJournalStatus::Initializing
+        );
+        assert!(matches!(
+            loser
+                .statuses
+                .recv_timeout(Duration::from_secs(2))
+                .expect("profile conflict status"),
+            OperationJournalStatus::Unavailable {
+                reason: OperationJournalUnavailable::ProfileOwnedByAnotherProcess { path }
+            } if path == lock_path
+        ));
+        assert!(!journal_directory.exists());
+        assert!(matches!(
+            loser.admit(intent(), Value::Null),
+            Err(JournalOwnerQueueError::Unavailable(
+                OperationJournalUnavailable::ProfileOwnedByAnotherProcess { .. }
+            ))
+        ));
+
+        drop(holder);
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(
+            OwnerLifecycle::from_u8(loser.lifecycle.load(std::sync::atomic::Ordering::Acquire)),
+            OwnerLifecycle::Unavailable
+        );
+        assert!(loser.statuses.try_recv().is_err());
+        assert!(matches!(
+            loser.admit(intent(), Value::Null),
+            Err(JournalOwnerQueueError::Unavailable(
+                OperationJournalUnavailable::ProfileOwnedByAnotherProcess { .. }
+            ))
+        ));
     }
 
     #[test]

--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -497,6 +497,8 @@ impl OperationJournalOwner {
     ///
     /// The owner thread observes the closed channel, drops its coordinator, and releases the
     /// profile lock itself. This call never waits for owner-thread I/O or synchronization.
+    /// The return value reports only whether this call closed the sender; it is not an
+    /// acknowledgement that the coordinator or profile lock has been released.
     pub(in crate::native_app) fn shutdown(&mut self) -> bool {
         let previous = self.lifecycle.swap(
             OwnerLifecycle::Closing as u8,

--- a/src/native_app/app/state/journal.rs
+++ b/src/native_app/app/state/journal.rs
@@ -72,6 +72,7 @@ pub(in crate::native_app) enum OperationJournalStatus {
 pub(in crate::native_app) enum OperationJournalUnavailable {
     JournalOwnedByAnotherProcess { path: PathBuf },
     ProfileOwnedByAnotherProcess { path: PathBuf },
+    ProfileOwnershipChanged { path: PathBuf },
     OpenFailed(String),
     OwnerStartFailed(String),
 }
@@ -93,6 +94,13 @@ impl std::fmt::Display for OperationJournalUnavailable {
                     path.display()
                 )
             }
+            Self::ProfileOwnershipChanged { path } => {
+                write!(
+                    formatter,
+                    "profile ownership changed after acquisition: {}",
+                    path.display()
+                )
+            }
             Self::OpenFailed(error) => formatter.write_str(error),
             Self::OwnerStartFailed(error) => formatter.write_str(error),
         }
@@ -105,6 +113,7 @@ impl OperationJournalUnavailable {
             JournalError::JournalOwnedByAnotherProcess { path } => {
                 Self::JournalOwnedByAnotherProcess { path }
             }
+            JournalError::ProfileOwnership(error) => Self::from_profile_ownership_error(error),
             error => Self::OpenFailed(error.to_string()),
         }
     }
@@ -113,6 +122,10 @@ impl OperationJournalUnavailable {
         match error {
             ProfileOwnershipError::ProfileOwnedByAnotherProcess { path } => {
                 Self::ProfileOwnedByAnotherProcess { path }
+            }
+            ProfileOwnershipError::ProfileRootReplaced { path }
+            | ProfileOwnershipError::ProfileOwnerLockReplaced { path } => {
+                Self::ProfileOwnershipChanged { path }
             }
             error => Self::OpenFailed(error.to_string()),
         }
@@ -574,7 +587,10 @@ fn run_owner(
                     .as_ref()
                     .map(|guard| guard.profile_root().to_path_buf())
                     .or_else(|| directory.clone());
-                let recovery_root = match crate::native_app::transaction_history::operation_journal::open_recovery_root_capability(recovery_path) {
+                let recovery_root = match match profile_guard.as_ref() {
+                    Some(profile_guard) => crate::native_app::transaction_history::operation_journal::open_recovery_root_capability_from_profile(profile_guard),
+                    None => crate::native_app::transaction_history::operation_journal::open_recovery_root_capability(recovery_path),
+                } {
                     Ok(capability) => capability,
                     Err(error) => {
                         let reason = OperationJournalUnavailable::from_error(error);
@@ -622,7 +638,23 @@ fn run_owner(
         }
     };
 
+    let mut profile_ownership_changed = false;
     while !stop.load(std::sync::atomic::Ordering::Acquire) {
+        if !profile_ownership_changed {
+            if let Some(profile_guard) = profile_guard.as_ref() {
+                if let Err(error) = profile_guard.validate_current() {
+                    let reason = OperationJournalUnavailable::from_profile_ownership_error(error);
+                    *unavailable.lock().expect("journal unavailable state") = Some(reason.clone());
+                    lifecycle.store(
+                        OwnerLifecycle::Unavailable as u8,
+                        std::sync::atomic::Ordering::Release,
+                    );
+                    let _ = status_tx.send(OperationJournalStatus::Unavailable { reason });
+                    coordinator = None;
+                    profile_ownership_changed = true;
+                }
+            }
+        }
         match command_rx.recv_timeout(OWNER_POLL_INTERVAL) {
             Ok(JournalCommand::BoundedWaveformRestore {
                 intent,
@@ -1174,6 +1206,57 @@ mod tests {
             loser.admit(intent(), Value::Null),
             Err(JournalOwnerQueueError::Unavailable(
                 OperationJournalUnavailable::ProfileOwnedByAnotherProcess { .. }
+            ))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn production_owner_closes_admission_when_profile_root_is_replaced() {
+        let mut runtime = TestRuntimeGuard::acquire();
+        let base = tempfile::tempdir().expect("profile base");
+        runtime.set_var("WAVECRATE_CONFIG_HOME", base.path().as_os_str());
+        runtime.set_var("WAVECRATE_CONFIG_PROFILE", "native-owner-root-replaced");
+
+        let owner = OperationJournalOwner::start_with_current_profile_for_test();
+        assert_eq!(
+            owner
+                .statuses
+                .recv_timeout(Duration::from_secs(2))
+                .expect("initializing status"),
+            OperationJournalStatus::Initializing
+        );
+        assert!(matches!(
+            owner
+                .statuses
+                .recv_timeout(Duration::from_secs(2))
+                .expect("available status"),
+            OperationJournalStatus::Available { .. }
+        ));
+
+        let profile_root = base
+            .path()
+            .join(wavecrate_library::app_dirs::APP_DIR_NAME)
+            .join(wavecrate_library::app_dirs::PROFILE_DIR_NAME)
+            .join("native-owner-root-replaced");
+        let displaced = base.path().join("displaced-native-profile-root");
+        std::fs::rename(&profile_root, &displaced).expect("displace acquired root");
+        std::fs::create_dir(&profile_root).expect("replacement profile root");
+
+        assert!(matches!(
+            owner
+                .statuses
+                .recv_timeout(Duration::from_secs(2))
+                .expect("profile replacement status"),
+            OperationJournalStatus::Unavailable {
+                reason: OperationJournalUnavailable::ProfileOwnershipChanged { path }
+            } if path == profile_root
+        ));
+        assert!(!profile_root.join("operation_journal").exists());
+        assert!(matches!(
+            owner.admit(intent(), Value::Null),
+            Err(JournalOwnerQueueError::Unavailable(
+                OperationJournalUnavailable::ProfileOwnershipChanged { .. }
             ))
         ));
     }

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -503,7 +503,9 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn shutdown(&mut self) -> Option<serde_json::Value> {
         let started_at = Instant::now();
-        let operation_journal_released = self.background.operation_journal.shutdown();
+        // `shutdown` closes the caller-side command sender. The owner thread still has to drop
+        // the coordinator and profile guard; this telemetry is not a release acknowledgement.
+        let operation_journal_close_requested = self.background.operation_journal.shutdown();
         let source_processing = self.background.source_processing.shutdown();
         let harvest_touched_unflushed = self.background.harvest_touched_persist.close();
         let harvest_selection_derivation_unflushed =
@@ -532,7 +534,7 @@ impl NativeAppState {
         Some(serde_json::json!({
             "waveform_cache_shutdown_flush_ms": duration_ms(elapsed),
             "source_processing": source_processing,
-            "operation_journal_released": operation_journal_released,
+            "operation_journal_close_requested": operation_journal_close_requested,
             "harvest_touched_unflushed": harvest_touched_unflushed,
             "harvest_selection_derivation_unflushed": harvest_selection_derivation_unflushed,
             "rating_persist_unflushed": rating_persist_unflushed,

--- a/src/native_app/tests.rs
+++ b/src/native_app/tests.rs
@@ -264,7 +264,7 @@ fn native_app_state_with_temp_sample_in(
     let identity =
         wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(&file)
             .expect("source app root identity");
-    state.background.waveform_recovery_root = Some(
+    state.background.waveform_recovery = Ok(
         crate::native_app::transaction_history::operation_journal::RecoveryRootCapability {
             path: app_root,
             file: std::sync::Arc::new(file),

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -78,6 +78,21 @@ fn begin_owner_restore_for_tests(
         .expect("owner restore command")
 }
 
+fn enable_test_owner_recovery(state: &mut crate::native_app::app::NativeAppState) {
+    let path = std::env::current_dir().expect("test recovery root");
+    let file = std::fs::File::open(&path).expect("test recovery root");
+    let identity =
+        wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(&file)
+            .expect("test recovery root identity");
+    state.background.waveform_recovery = Ok(
+        crate::native_app::transaction_history::operation_journal::RecoveryRootCapability {
+            path,
+            file: std::sync::Arc::new(file),
+            identity,
+        },
+    );
+}
+
 fn platform_qualification_assessment_for_tests() -> ReplacementQualificationAssessment {
     ReplacementQualificationAssessment {
         platform_family: ReplacementPlatformFamily::Other,
@@ -298,8 +313,30 @@ fn closed_owner_completion_fence_ignores_duplicate_unavailable_result() {
 }
 
 #[test]
+fn unavailable_owner_recovery_rejects_before_owner_admission() {
+    let mut state = gui_state_for_span_tests();
+    let command = begin_owner_restore_for_tests(&mut state);
+    let mut context = ui::UiUpdateContext::default();
+
+    state.start_history_file_io(command, &mut context);
+
+    assert!(context.into_command().is_empty());
+    assert!(!state.transactions.history.file_io_in_flight());
+    assert!(state.transactions.history.can_undo());
+    assert!(state.ui.status.sample.contains("not started"));
+    assert!(
+        state
+            .ui
+            .status
+            .sample
+            .contains("destructive recovery unavailable")
+    );
+}
+
+#[test]
 fn owner_route_enqueues_background_waiter_without_ui_block() {
     let mut state = gui_state_for_span_tests();
+    enable_test_owner_recovery(&mut state);
     let command = begin_owner_restore_for_tests(&mut state);
     let mut context = ui::UiUpdateContext::default();
     state.start_history_file_io(command, &mut context);
@@ -327,6 +364,7 @@ fn stale_owner_staging_completion_preserves_in_flight_transaction() {
 #[test]
 fn owner_staging_queue_failure_restores_original_stack_without_ui_wait() {
     let mut state = gui_state_for_span_tests();
+    enable_test_owner_recovery(&mut state);
     for _ in 0..32 {
         state
             .background

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -354,7 +354,9 @@ fn stale_owner_staging_completion_preserves_in_flight_transaction() {
         direction: command.direction,
         through_target: command.through_target,
         label: command.label,
-        result: Ok(FilesystemStageOutcome::FilesystemStaged(OperationId::for_test())),
+        result: Ok(FilesystemStageOutcome::FilesystemStaged(
+            OperationId::for_test(),
+        )),
     });
     assert!(state.transactions.history.file_io_in_flight());
     assert!(state.transactions.pending_history_owner_staging.is_none());

--- a/src/native_app/transaction_history/app_state.rs
+++ b/src/native_app/transaction_history/app_state.rs
@@ -258,6 +258,23 @@ impl NativeAppState {
         command: HistoryFileIoCommand,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        if let Err(error) = self.background.waveform_recovery.clone() {
+            let execution_id = command.execution_id;
+            let transaction_id = command.transaction_id;
+            let direction = command.direction;
+            let through_target = command.through_target;
+            self.restore_history_file_io_not_started(
+                execution_id,
+                transaction_id,
+                direction,
+                through_target,
+                owner_restore_error_status(
+                    direction,
+                    OperationJournalRestoreError::RecoveryUnavailable(error),
+                ),
+            );
+            return;
+        }
         let intent = OperationIntent {
             actor: OperationActor::User,
             kind: OperationKind::FileHistory,
@@ -620,6 +637,9 @@ fn owner_restore_error_status(
         }
         OperationJournalRestoreError::Journal(error) => {
             unreachable!("ambiguous journal errors must retain history in flight: {error}")
+        }
+        OperationJournalRestoreError::RecoveryUnavailable(error) => {
+            format!("destructive recovery unavailable: {error}")
         }
         OperationJournalRestoreError::Unavailable(error) => {
             format!("operation journal unavailable: {error}")

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -14,6 +14,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::fs::{Dir, OpenOptions as CapabilityOpenOptions};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use uuid::Uuid;
@@ -418,6 +420,46 @@ pub(crate) struct RecoveryRootCapability {
     pub(crate) path: PathBuf,
     pub(crate) file: Arc<File>,
     pub(crate) identity: String,
+}
+
+pub(crate) fn open_recovery_root_capability_from_profile(
+    profile_guard: &wavecrate_library::app_dirs::WritableProfileGuard,
+) -> Result<RecoveryRootCapability, JournalError> {
+    let path = profile_guard.profile_root().to_path_buf();
+    let dir = profile_guard
+        .profile_root_dir()
+        .map_err(JournalError::ProfileOwnership)?;
+    let file = dir.into_std_file();
+    if !file
+        .metadata()
+        .map_err(|source| JournalError::Write {
+            path: path.clone(),
+            source,
+        })?
+        .is_dir()
+    {
+        return Err(JournalError::Write {
+            path,
+            source: io::Error::new(
+                io::ErrorKind::InvalidData,
+                "recovery root is not a directory",
+            ),
+        });
+    }
+    let identity =
+        wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(&file)
+            .ok_or_else(|| JournalError::Write {
+                path: path.clone(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "recovery root identity unavailable",
+                ),
+            })?;
+    Ok(RecoveryRootCapability {
+        path,
+        file: Arc::new(file),
+        identity,
+    })
 }
 
 impl PartialEq for RecoveryRootCapability {
@@ -1962,6 +2004,9 @@ pub(crate) enum JournalError {
     /// The profile-local journal lock is owned by another process.
     #[error("operation journal is owned by another process: {path}")]
     JournalOwnedByAnotherProcess { path: PathBuf },
+    /// Profile ownership changed while opening the production journal or recovery root.
+    #[error(transparent)]
+    ProfileOwnership(#[from] wavecrate_library::app_dirs::ProfileOwnershipError),
     /// A durable operation record could not be written or synchronized.
     #[error("operation journal write failed at {path}: {source}")]
     Write { path: PathBuf, source: io::Error },
@@ -2071,6 +2116,7 @@ enum RetainedRecord {
 /// The profile-owned journal store. Holding this value holds exclusive ownership.
 pub(crate) struct OperationJournalStore {
     directory: PathBuf,
+    journal_dir: Option<Arc<Dir>>,
     _ownership: OwnershipLock,
     records: BTreeMap<OperationId, OperationRecord>,
     non_writable: BTreeSet<OperationId>,
@@ -2090,6 +2136,28 @@ impl OperationJournalStore {
         let ownership = OwnershipLock::acquire(&directory)?;
         let mut store = Self {
             directory,
+            journal_dir: None,
+            _ownership: ownership,
+            records: BTreeMap::new(),
+            non_writable: BTreeSet::new(),
+            retained: Vec::new(),
+            recovery: RecoverySummary::default(),
+            capacity_claims: BTreeMap::new(),
+            capacity_blocked: false,
+        };
+        store.scan()?;
+        Ok(store)
+    }
+
+    /// Open and scan a production journal through its retained profile-relative capability.
+    pub(crate) fn open_from_capability(
+        directory: PathBuf,
+        journal_dir: Dir,
+    ) -> Result<Self, JournalError> {
+        let ownership = OwnershipLock::acquire_at(&journal_dir, &directory)?;
+        let mut store = Self {
+            directory,
+            journal_dir: Some(Arc::new(journal_dir)),
             _ownership: ownership,
             records: BTreeMap::new(),
             non_writable: BTreeSet::new(),
@@ -2152,7 +2220,7 @@ impl OperationJournalStore {
             });
         }
         let path = self.record_path(record.operation_id);
-        atomic_durable_write(&path, &record)?;
+        self.atomic_durable_write(&path, &record)?;
         self.records.insert(record.operation_id, record);
         self.rebuild_capacity_claims();
         Ok(())
@@ -2179,7 +2247,7 @@ impl OperationJournalStore {
             source: io::Error::new(io::ErrorKind::InvalidInput, error.to_string()),
         })?;
         let path = self.record_path(record.operation_id);
-        atomic_durable_write(&path, &record)?;
+        self.atomic_durable_write(&path, &record)?;
         self.records.insert(record.operation_id, record);
         self.rebuild_capacity_claims();
         Ok(())
@@ -2298,7 +2366,7 @@ impl OperationJournalStore {
             updated.replacement_qualification = Some(assessment);
         }
         let path = self.record_path(operation_id);
-        atomic_durable_write(&path, &updated)?;
+        self.atomic_durable_write(&path, &updated)?;
         self.records.insert(operation_id, updated);
         self.rebuild_capacity_claims();
         Ok(())
@@ -2319,7 +2387,7 @@ impl OperationJournalStore {
                 let updated = current
                     .with_prepared(PreparedTargetContract::ExistingExpectedIdentity(prepared));
                 let path = self.record_path(operation_id);
-                atomic_durable_write(&path, &updated)?;
+                self.atomic_durable_write(&path, &updated)?;
                 self.records.insert(operation_id, updated);
                 self.rebuild_capacity_claims();
                 Ok(())
@@ -2364,7 +2432,7 @@ impl OperationJournalStore {
                 self.ensure_writable(operation_id)?;
                 let updated = current.with_staged(staged);
                 let path = self.record_path(operation_id);
-                atomic_durable_write(&path, &updated)?;
+                self.atomic_durable_write(&path, &updated)?;
                 self.records.insert(operation_id, updated);
                 self.rebuild_capacity_claims();
                 Ok(())
@@ -2427,7 +2495,7 @@ impl OperationJournalStore {
         })?;
         self.ensure_writable(operation_id)?;
         let path = self.record_path(operation_id);
-        atomic_durable_write(&path, &updated)?;
+        self.atomic_durable_write(&path, &updated)?;
         self.records.insert(operation_id, updated);
         self.rebuild_capacity_claims();
         Ok(())
@@ -2469,7 +2537,7 @@ impl OperationJournalStore {
         })?;
         self.ensure_writable(operation_id)?;
         let path = self.record_path(operation_id);
-        atomic_durable_write(&path, &updated)?;
+        self.atomic_durable_write(&path, &updated)?;
         self.records.insert(operation_id, updated);
         self.rebuild_capacity_claims();
         Ok(())
@@ -2511,7 +2579,7 @@ impl OperationJournalStore {
         })?;
         self.ensure_writable(operation_id)?;
         let path = self.record_path(operation_id);
-        atomic_durable_write(&path, &updated)?;
+        self.atomic_durable_write(&path, &updated)?;
         self.records.insert(operation_id, updated);
         self.rebuild_capacity_claims();
         Ok(())
@@ -2564,7 +2632,7 @@ impl OperationJournalStore {
                 self.ensure_writable(operation_id)?;
                 let updated = current.with_published(published);
                 let path = self.record_path(operation_id);
-                atomic_durable_write(&path, &updated)?;
+                self.atomic_durable_write(&path, &updated)?;
                 self.records.insert(operation_id, updated);
                 self.rebuild_capacity_claims();
                 Ok(())
@@ -2629,7 +2697,33 @@ impl OperationJournalStore {
             .join(format!("{operation_id}{RECORD_SUFFIX}"))
     }
 
+    fn atomic_durable_write(
+        &self,
+        path: &Path,
+        record: &OperationRecord,
+    ) -> Result<(), JournalError> {
+        if let Some(directory) = self.journal_dir.as_ref() {
+            let name = path.file_name().ok_or_else(|| JournalError::Write {
+                path: path.to_path_buf(),
+                source: io::Error::new(io::ErrorKind::InvalidInput, "record path has no file name"),
+            })?;
+            atomic_durable_write_relative(directory, path, Path::new(name), record)
+        } else {
+            atomic_durable_write(path, record)
+        }
+    }
+
     fn scan(&mut self) -> Result<(), JournalError> {
+        if let Some(directory) = self.journal_dir.clone() {
+            self.scan_capability(&directory)?;
+        } else {
+            self.scan_path_based()?;
+        }
+        self.rebuild_capacity_claims();
+        Ok(())
+    }
+
+    fn scan_path_based(&mut self) -> Result<(), JournalError> {
         let entries = fs::read_dir(&self.directory).map_err(|source| JournalError::Scan {
             path: self.directory.clone(),
             source,
@@ -2643,7 +2737,6 @@ impl OperationJournalStore {
             if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
                 continue;
             }
-            self.recovery.record_count += 1;
             let mut bytes = Vec::with_capacity(MAX_RECORD_BYTES);
             File::open(&path)
                 .map(|file| {
@@ -2655,179 +2748,232 @@ impl OperationJournalStore {
                     path: path.clone(),
                     source,
                 })?;
-            if bytes.len() > MAX_RECORD_BYTES {
-                self.recovery.oversize_count += 1;
-                self.recovery.attention_required = true;
-                self.retained.push(RetainedRecord::Oversize {
+            self.ingest_scan_entry(path, bytes)?;
+        }
+        Ok(())
+    }
+
+    fn scan_capability(&mut self, directory: &Dir) -> Result<(), JournalError> {
+        let entries = directory.entries().map_err(|source| JournalError::Scan {
+            path: self.directory.clone(),
+            source,
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|source| JournalError::Scan {
+                path: self.directory.clone(),
+                source,
+            })?;
+            let name = entry.file_name();
+            let path = self.directory.join(&name);
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let file_type = entry.file_type().map_err(|source| JournalError::Scan {
+                path: path.clone(),
+                source,
+            })?;
+            if !file_type.is_file() {
+                return Err(JournalError::Scan {
                     path,
-                    bytes: bytes.len() as u64,
+                    source: io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "operation journal entry is not a regular file",
+                    ),
                 });
-                continue;
             }
-            let value: Value = match serde_json::from_slice(&bytes) {
-                Ok(value) => value,
-                Err(_) => {
-                    self.recovery.malformed_count += 1;
-                    self.recovery.attention_required = true;
-                    self.retained
-                        .push(RetainedRecord::Malformed { path, bytes });
-                    continue;
-                }
-            };
-            let decoded = match dispatch_persisted_record(value) {
-                Ok(decoded) => decoded,
-                Err(()) => {
-                    self.recovery.malformed_count += 1;
-                    self.recovery.attention_required = true;
-                    self.retained
-                        .push(RetainedRecord::Malformed { path, bytes });
-                    continue;
-                }
-            };
-            let record: OperationRecord = match decoded {
-                DecodedPersistedRecord::UnknownVersion(version) => {
-                    self.recovery.unknown_version_count += 1;
-                    self.recovery.attention_required = true;
-                    self.retained.push(RetainedRecord::UnknownVersion {
-                        path,
-                        bytes,
-                        version,
-                    });
-                    continue;
-                }
-                DecodedPersistedRecord::V1(persisted) => persisted.into(),
-                DecodedPersistedRecord::V2(persisted) => persisted.into(),
-            };
-            if validate_schema_v2_phase_evidence_record(&record).is_err() {
+            let mut options = CapabilityOpenOptions::new();
+            options.read(true).follow(FollowSymlinks::No);
+            let file = entry
+                .open_with(&options)
+                .map_err(|source| JournalError::Scan {
+                    path: path.clone(),
+                    source,
+                })?;
+            let mut bytes = Vec::with_capacity(MAX_RECORD_BYTES);
+            file.take((MAX_RECORD_BYTES as u64).saturating_add(1))
+                .read_to_end(&mut bytes)
+                .map_err(|source| JournalError::Scan {
+                    path: path.clone(),
+                    source,
+                })?;
+            self.ingest_scan_entry(path, bytes)?;
+        }
+        Ok(())
+    }
+
+    fn ingest_scan_entry(&mut self, path: PathBuf, bytes: Vec<u8>) -> Result<(), JournalError> {
+        self.recovery.record_count += 1;
+        if bytes.len() > MAX_RECORD_BYTES {
+            self.recovery.oversize_count += 1;
+            self.recovery.attention_required = true;
+            self.retained.push(RetainedRecord::Oversize {
+                path,
+                bytes: bytes.len() as u64,
+            });
+            return Ok(());
+        }
+        let value: Value = match serde_json::from_slice(&bytes) {
+            Ok(value) => value,
+            Err(_) => {
                 self.recovery.malformed_count += 1;
                 self.recovery.attention_required = true;
                 self.retained
                     .push(RetainedRecord::Malformed { path, bytes });
-                continue;
+                return Ok(());
             }
-            let filename_id = path
-                .file_stem()
-                .and_then(|stem| stem.to_str())
-                .and_then(|stem| Uuid::parse_str(stem).ok())
-                .map(OperationId::from_uuid);
-            if filename_id != Some(record.operation_id)
-                || self.records.contains_key(&record.operation_id)
-            {
+        };
+        let decoded = match dispatch_persisted_record(value) {
+            Ok(decoded) => decoded,
+            Err(()) => {
                 self.recovery.malformed_count += 1;
                 self.recovery.attention_required = true;
                 self.retained
                     .push(RetainedRecord::Malformed { path, bytes });
-                continue;
+                return Ok(());
             }
-            if validate_capacity_plan_option(record.capacity_plan.as_ref()).is_err() {
-                self.recovery.malformed_count += 1;
+        };
+        let record: OperationRecord = match decoded {
+            DecodedPersistedRecord::UnknownVersion(version) => {
+                self.recovery.unknown_version_count += 1;
                 self.recovery.attention_required = true;
-                self.retained
-                    .push(RetainedRecord::Malformed { path, bytes });
-                continue;
+                self.retained.push(RetainedRecord::UnknownVersion {
+                    path,
+                    bytes,
+                    version,
+                });
+                return Ok(());
             }
-            if record
+            DecodedPersistedRecord::V1(persisted) => persisted.into(),
+            DecodedPersistedRecord::V2(persisted) => persisted.into(),
+        };
+        if validate_schema_v2_phase_evidence_record(&record).is_err() {
+            self.recovery.malformed_count += 1;
+            self.recovery.attention_required = true;
+            self.retained
+                .push(RetainedRecord::Malformed { path, bytes });
+            return Ok(());
+        }
+        let filename_id = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .and_then(|stem| Uuid::parse_str(stem).ok())
+            .map(OperationId::from_uuid);
+        if filename_id != Some(record.operation_id)
+            || self.records.contains_key(&record.operation_id)
+        {
+            self.recovery.malformed_count += 1;
+            self.recovery.attention_required = true;
+            self.retained
+                .push(RetainedRecord::Malformed { path, bytes });
+            return Ok(());
+        }
+        if validate_capacity_plan_option(record.capacity_plan.as_ref()).is_err() {
+            self.recovery.malformed_count += 1;
+            self.recovery.attention_required = true;
+            self.retained
+                .push(RetainedRecord::Malformed { path, bytes });
+            return Ok(());
+        }
+        if record
+            .prepared
+            .as_ref()
+            .is_some_and(|prepared| validate_prepared_contract(prepared).is_err())
+        {
+            self.recovery.malformed_count += 1;
+            self.recovery.attention_required = true;
+            self.retained
+                .push(RetainedRecord::Malformed { path, bytes });
+            return Ok(());
+        }
+        if record.schema_version == SCHEMA_V1
+            && record
+                .published
+                .as_ref()
+                .is_some_and(is_absent_final_no_replace_publication)
+        {
+            // A v1 record containing an absent-final claim is not a v2 record in disguise.
+            // Retain its original bytes and refuse to expose a writable runtime projection.
+            self.recovery.malformed_count += 1;
+            self.recovery.attention_required = true;
+            self.retained
+                .push(RetainedRecord::Malformed { path, bytes });
+            return Ok(());
+        }
+        if record.phase == OperationPhase::Prepared && record.prepared.is_none() {
+            self.recovery.malformed_count += 1;
+            self.recovery.attention_required = true;
+            self.retained
+                .push(RetainedRecord::Malformed { path, bytes });
+            return Ok(());
+        }
+        let staged_valid = match (record.phase, record.staged.as_ref()) {
+            (OperationPhase::FilesystemStaged, Some(staged)) => record
                 .prepared
                 .as_ref()
-                .is_some_and(|prepared| validate_prepared_contract(prepared).is_err())
-            {
-                self.recovery.malformed_count += 1;
-                self.recovery.attention_required = true;
-                self.retained
-                    .push(RetainedRecord::Malformed { path, bytes });
-                continue;
-            }
-            if record.schema_version == SCHEMA_V1
-                && record
-                    .published
-                    .as_ref()
-                    .is_some_and(is_absent_final_no_replace_publication)
-            {
-                // A v1 record containing an absent-final claim is not a v2 record in disguise.
-                // Retain its original bytes and refuse to expose a writable runtime projection.
-                self.recovery.malformed_count += 1;
-                self.recovery.attention_required = true;
-                self.retained
-                    .push(RetainedRecord::Malformed { path, bytes });
-                continue;
-            }
-            if record.phase == OperationPhase::Prepared && record.prepared.is_none() {
-                self.recovery.malformed_count += 1;
-                self.recovery.attention_required = true;
-                self.retained
-                    .push(RetainedRecord::Malformed { path, bytes });
-                continue;
-            }
-            let staged_valid = match (record.phase, record.staged.as_ref()) {
-                (OperationPhase::FilesystemStaged, Some(staged)) => record
-                    .prepared
-                    .as_ref()
-                    .is_some_and(|prepared| validate_staged_checkpoint(prepared, staged).is_ok()),
-                (OperationPhase::FilesystemStaged, None)
-                | (OperationPhase::IntentDurable | OperationPhase::Prepared, Some(_)) => false,
-                (_, Some(staged)) => record
-                    .prepared
-                    .as_ref()
-                    .is_some_and(|prepared| validate_staged_checkpoint(prepared, staged).is_ok()),
-                (_, None) => true,
-            };
-            if !staged_valid {
-                self.recovery.malformed_count += 1;
-                self.recovery.attention_required = true;
-                self.retained
-                    .push(RetainedRecord::Malformed { path, bytes });
-                continue;
-            }
-            let legacy_post_publication_without_evidence = record.schema_version == SCHEMA_V1
-                && record.published.is_none()
-                && (matches!(
-                    record.phase,
-                    OperationPhase::FilesystemPublished
-                        | OperationPhase::SourceReconciled
-                        | OperationPhase::GlobalReconciled
-                        | OperationPhase::ProjectionPublished
-                        | OperationPhase::ReadinessScheduled
-                ) || (record.phase == OperationPhase::Terminal
-                    && record.disposition.is_terminal()));
-            if legacy_post_publication_without_evidence {
-                self.recovery.malformed_count += 1;
-                self.recovery.attention_required = true;
-                if record.phase != OperationPhase::Terminal {
-                    self.recovery.unresolved_count += 1;
-                }
-                self.non_writable.insert(record.operation_id);
-                self.retained.push(RetainedRecord::Malformed {
-                    path: path.clone(),
-                    bytes: bytes.clone(),
-                });
-                self.records.insert(record.operation_id, record);
-                continue;
-            }
-            let published_valid = if record.phase.is_pre_publication() {
-                record.published.is_none()
-            } else if record.phase.is_post_publication() {
-                validate_record_publication(&record).is_ok()
-            } else {
-                record
-                    .published
-                    .as_ref()
-                    .map(|_| validate_record_publication(&record).is_ok())
-                    .unwrap_or(true)
-            };
-            if !published_valid {
-                self.recovery.malformed_count += 1;
-                self.recovery.attention_required = true;
-                self.retained
-                    .push(RetainedRecord::Malformed { path, bytes });
-                continue;
-            }
-            if record.phase != OperationPhase::Terminal || !record.disposition.is_terminal() {
-                self.recovery.unresolved_count += 1;
-                self.recovery.attention_required = true;
-            }
-            self.records.insert(record.operation_id, record);
+                .is_some_and(|prepared| validate_staged_checkpoint(prepared, staged).is_ok()),
+            (OperationPhase::FilesystemStaged, None)
+            | (OperationPhase::IntentDurable | OperationPhase::Prepared, Some(_)) => false,
+            (_, Some(staged)) => record
+                .prepared
+                .as_ref()
+                .is_some_and(|prepared| validate_staged_checkpoint(prepared, staged).is_ok()),
+            (_, None) => true,
+        };
+        if !staged_valid {
+            self.recovery.malformed_count += 1;
+            self.recovery.attention_required = true;
+            self.retained
+                .push(RetainedRecord::Malformed { path, bytes });
+            return Ok(());
         }
-        self.rebuild_capacity_claims();
+        let legacy_post_publication_without_evidence = record.schema_version == SCHEMA_V1
+            && record.published.is_none()
+            && (matches!(
+                record.phase,
+                OperationPhase::FilesystemPublished
+                    | OperationPhase::SourceReconciled
+                    | OperationPhase::GlobalReconciled
+                    | OperationPhase::ProjectionPublished
+                    | OperationPhase::ReadinessScheduled
+            ) || (record.phase == OperationPhase::Terminal
+                && record.disposition.is_terminal()));
+        if legacy_post_publication_without_evidence {
+            self.recovery.malformed_count += 1;
+            self.recovery.attention_required = true;
+            if record.phase != OperationPhase::Terminal {
+                self.recovery.unresolved_count += 1;
+            }
+            self.non_writable.insert(record.operation_id);
+            self.retained.push(RetainedRecord::Malformed {
+                path: path.clone(),
+                bytes: bytes.clone(),
+            });
+            self.records.insert(record.operation_id, record);
+            return Ok(());
+        }
+        let published_valid = if record.phase.is_pre_publication() {
+            record.published.is_none()
+        } else if record.phase.is_post_publication() {
+            validate_record_publication(&record).is_ok()
+        } else {
+            record
+                .published
+                .as_ref()
+                .map(|_| validate_record_publication(&record).is_ok())
+                .unwrap_or(true)
+        };
+        if !published_valid {
+            self.recovery.malformed_count += 1;
+            self.recovery.attention_required = true;
+            self.retained
+                .push(RetainedRecord::Malformed { path, bytes });
+            return Ok(());
+        }
+        if record.phase != OperationPhase::Terminal || !record.disposition.is_terminal() {
+            self.recovery.unresolved_count += 1;
+            self.recovery.attention_required = true;
+        }
+        self.records.insert(record.operation_id, record);
         Ok(())
     }
 }
@@ -3596,7 +3742,13 @@ impl OperationJournalCoordinator {
     pub(crate) fn open_current_profile(
         profile_guard: &wavecrate::app_dirs::WritableProfileGuard,
     ) -> Result<Self, JournalError> {
-        Self::open(profile_guard.profile_root().join("operation_journal"))
+        let directory = profile_guard.profile_root().join("operation_journal");
+        let journal_dir = profile_guard
+            .open_child_dir(Path::new("operation_journal"))
+            .map_err(JournalError::ProfileOwnership)?;
+        Ok(Self {
+            store: OperationJournalStore::open_from_capability(directory, journal_dir)?,
+        })
     }
 
     /// Open a journal at an explicit directory (used by isolated tests).
@@ -5193,6 +5345,119 @@ impl OwnershipLock {
             ),
         })
     }
+
+    fn acquire_at(directory: &Dir, display_directory: &Path) -> Result<Self, JournalError> {
+        let path = display_directory.join(LOCK_FILE_NAME);
+        let mut options = CapabilityOpenOptions::new();
+        options
+            .read(true)
+            .write(true)
+            .create(true)
+            .follow(FollowSymlinks::No);
+        let mut file = directory
+            .open_with(Path::new(LOCK_FILE_NAME), &options)
+            .map_err(|source| JournalError::Write {
+                path: path.clone(),
+                source,
+            })?
+            .into_std();
+
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            let metadata = file.metadata().map_err(|source| JournalError::Write {
+                path: path.clone(),
+                source,
+            })?;
+            if !metadata.is_file() {
+                return Err(JournalError::Write {
+                    path,
+                    source: io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "operation-journal owner is not a regular file",
+                    ),
+                });
+            }
+            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            if result != 0 {
+                let source = io::Error::last_os_error();
+                if source.kind() == io::ErrorKind::WouldBlock {
+                    return Err(JournalError::JournalOwnedByAnotherProcess { path });
+                }
+                return Err(JournalError::Write { path, source });
+            }
+            file.set_len(0)
+                .and_then(|_| file.write_all(format!("pid={}\n", std::process::id()).as_bytes()))
+                .and_then(|_| file.sync_all())
+                .map_err(|source| JournalError::Write {
+                    path: path.clone(),
+                    source,
+                })?;
+            return Ok(Self { file: Some(file) });
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::MetadataExt;
+            use std::os::windows::io::AsRawHandle;
+            use windows::Win32::Foundation::{FILE_ATTRIBUTE_REPARSE_POINT, HANDLE};
+            use windows::Win32::Storage::FileSystem::{
+                LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
+            };
+            use windows::Win32::System::IO::OVERLAPPED;
+
+            let metadata = file.metadata().map_err(|source| JournalError::Write {
+                path: path.clone(),
+                source,
+            })?;
+            if !metadata.is_file()
+                || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0
+            {
+                return Err(JournalError::Write {
+                    path,
+                    source: io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "operation-journal owner is not a regular non-reparse file",
+                    ),
+                });
+            }
+            let mut overlapped = OVERLAPPED::default();
+            let result = unsafe {
+                LockFileEx(
+                    HANDLE(file.as_raw_handle()),
+                    LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+                    None,
+                    u32::MAX,
+                    u32::MAX,
+                    &mut overlapped,
+                )
+            };
+            if result.is_err() {
+                return Err(JournalError::JournalOwnedByAnotherProcess { path });
+            }
+            file.set_len(0)
+                .and_then(|_| file.write_all(format!("pid={}\n", std::process::id()).as_bytes()))
+                .and_then(|_| file.sync_all())
+                .map_err(|source| JournalError::Write {
+                    path: path.clone(),
+                    source,
+                })?;
+            return Ok(Self { file: Some(file) });
+        }
+
+        #[cfg(all(not(unix), not(windows)))]
+        {
+            let _ = file;
+            Err(JournalError::Write {
+                path,
+                source: io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "no verified operation-journal ownership primitive on this platform",
+                ),
+            })
+        }
+    }
 }
 
 impl Drop for OwnershipLock {
@@ -5258,6 +5523,98 @@ fn atomic_durable_write(path: &Path, record: &OperationRecord) -> Result<(), Jou
         });
     }
     Ok(())
+}
+
+fn atomic_durable_write_relative(
+    directory: &Dir,
+    path: &Path,
+    name: &Path,
+    record: &OperationRecord,
+) -> Result<(), JournalError> {
+    validate_schema_v2_phase_evidence_record(record).map_err(|reason| JournalError::Write {
+        path: path.to_path_buf(),
+        source: io::Error::new(io::ErrorKind::InvalidInput, reason),
+    })?;
+    let temp_name = PathBuf::from(format!(
+        ".{}.tmp",
+        name.file_name().unwrap_or_default().to_string_lossy()
+    ));
+    let temp_path = path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(&temp_name);
+    let bytes = encode_record(record).map_err(|source| JournalError::Write {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if bytes.len() > MAX_RECORD_BYTES {
+        return Err(JournalError::Write {
+            path: path.to_path_buf(),
+            source: io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("journal record exceeds {MAX_RECORD_BYTES} bytes"),
+            ),
+        });
+    }
+
+    let mut options = CapabilityOpenOptions::new();
+    options
+        .write(true)
+        .create_new(true)
+        .follow(FollowSymlinks::No);
+    let mut file = directory
+        .open_with(&temp_name, &options)
+        .map_err(|source| JournalError::Write {
+            path: temp_path.clone(),
+            source,
+        })?;
+    if let Err(source) = file.write_all(&bytes).and_then(|_| file.sync_all()) {
+        let _ = directory.remove_file(&temp_name);
+        return Err(JournalError::Write {
+            path: temp_path,
+            source,
+        });
+    }
+    drop(file);
+    if let Err(source) = directory.rename(&temp_name, directory, name) {
+        let _ = directory.remove_file(&temp_name);
+        return Err(JournalError::Write {
+            path: path.to_path_buf(),
+            source,
+        });
+    }
+    if let Err(source) = sync_capability_directory(directory) {
+        return Err(JournalError::Write {
+            path: path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf(),
+            source,
+        });
+    }
+    Ok(())
+}
+
+fn sync_capability_directory(directory: &Dir) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        directory.try_clone()?.into_std_file().sync_all()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = directory;
+        // Windows uses the capability-relative rename; the underlying rename is the
+        // strongest namespace durability primitive available to this store.
+        Ok(())
+    }
+    #[cfg(all(not(unix), not(target_os = "windows")))]
+    {
+        let _ = directory;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "directory synchronization is not verified on this platform",
+        ))
+    }
 }
 
 fn replace_file(temp_path: &Path, path: &Path) -> io::Result<()> {

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -1959,9 +1959,9 @@ pub(crate) struct RecoverySummary {
 /// Errors from ownership, durable writes, or fail-closed recovery scanning.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum JournalError {
-    /// The profile-local journal is owned by another process.
+    /// The profile-local journal lock is owned by another process.
     #[error("operation journal is owned by another process: {path}")]
-    OwnedByAnotherProcess { path: PathBuf },
+    JournalOwnedByAnotherProcess { path: PathBuf },
     /// A durable operation record could not be written or synchronized.
     #[error("operation journal write failed at {path}: {source}")]
     Write { path: PathBuf, source: io::Error },
@@ -3592,11 +3592,11 @@ fn prepare_descriptor(
 }
 
 impl OperationJournalCoordinator {
-    /// Open the journal in the current profile and perform a non-mutating scan.
-    pub(crate) fn open_current_profile() -> Result<Self, JournalError> {
-        let directory = wavecrate::app_dirs::operation_journal_dir()
-            .map_err(|error| JournalError::AppDirectory(error.to_string()))?;
-        Self::open(directory)
+    /// Open the current profile's journal after the caller has acquired profile ownership.
+    pub(crate) fn open_current_profile(
+        profile_guard: &wavecrate::app_dirs::WritableProfileGuard,
+    ) -> Result<Self, JournalError> {
+        Self::open(profile_guard.profile_root().join("operation_journal"))
     }
 
     /// Open a journal at an explicit directory (used by isolated tests).
@@ -5109,7 +5109,7 @@ impl OwnershipLock {
             if result != 0 {
                 let source = io::Error::last_os_error();
                 if source.kind() == io::ErrorKind::WouldBlock {
-                    return Err(JournalError::OwnedByAnotherProcess { path });
+                    return Err(JournalError::JournalOwnedByAnotherProcess { path });
                 }
                 return Err(JournalError::Write { path, source });
             }
@@ -5172,7 +5172,7 @@ impl OwnershipLock {
                 )
             };
             if result.is_err() {
-                return Err(JournalError::OwnedByAnotherProcess { path });
+                return Err(JournalError::JournalOwnedByAnotherProcess { path });
             }
             file.set_len(0)
                 .and_then(|_| file.write_all(format!("pid={}\n", std::process::id()).as_bytes()))
@@ -5355,10 +5355,7 @@ mod tests {
         record.operation_id = operation_id;
         let persisted = schema_v1_value(&record);
 
-        assert_eq!(
-            persisted["operation_id"],
-            serde_json::json!(uuid)
-        );
+        assert_eq!(persisted["operation_id"], serde_json::json!(uuid));
         assert_eq!(operation_id.to_string(), uuid.to_string());
         assert_eq!(format!("{operation_id}.json"), format!("{uuid}.json"));
 
@@ -7869,7 +7866,7 @@ mod tests {
         let journal = OperationJournalCoordinator::open(dir.path().to_path_buf()).unwrap();
         assert!(matches!(
             OperationJournalCoordinator::open(dir.path().to_path_buf()),
-            Err(JournalError::OwnedByAnotherProcess { .. })
+            Err(JournalError::JournalOwnedByAnotherProcess { .. })
         ));
         drop(journal);
         assert!(OperationJournalCoordinator::open(dir.path().to_path_buf()).is_ok());

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -414,52 +414,15 @@ pub(crate) struct FilesystemStagedWaveformRestore {
     pub(crate) participant: FilesystemStagedParticipant,
 }
 
-/// Profile recovery root opened and identity-checked by the journal owner thread.
+/// Explicit-directory recovery root used by bounded test/runtime recovery seams.
+///
+/// Production does not publish this capability to asynchronous destructive-edit workers until
+/// the participant-lease and recovery lifecycle exists.
 #[derive(Clone, Debug)]
 pub(crate) struct RecoveryRootCapability {
     pub(crate) path: PathBuf,
     pub(crate) file: Arc<File>,
     pub(crate) identity: String,
-}
-
-pub(crate) fn open_recovery_root_capability_from_profile(
-    profile_guard: &wavecrate_library::app_dirs::WritableProfileGuard,
-) -> Result<RecoveryRootCapability, JournalError> {
-    let path = profile_guard.profile_root().to_path_buf();
-    let dir = profile_guard
-        .profile_root_dir()
-        .map_err(JournalError::ProfileOwnership)?;
-    let file = dir.into_std_file();
-    if !file
-        .metadata()
-        .map_err(|source| JournalError::Write {
-            path: path.clone(),
-            source,
-        })?
-        .is_dir()
-    {
-        return Err(JournalError::Write {
-            path,
-            source: io::Error::new(
-                io::ErrorKind::InvalidData,
-                "recovery root is not a directory",
-            ),
-        });
-    }
-    let identity =
-        wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file(&file)
-            .ok_or_else(|| JournalError::Write {
-                path: path.clone(),
-                source: io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "recovery root identity unavailable",
-                ),
-            })?;
-    Ok(RecoveryRootCapability {
-        path,
-        file: Arc::new(file),
-        identity,
-    })
 }
 
 impl PartialEq for RecoveryRootCapability {
@@ -513,6 +476,32 @@ pub(crate) fn open_recovery_root_capability(
         file: Arc::new(file),
         identity,
     })
+}
+
+/// Why asynchronous destructive recovery is not available at the current boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RecoveryUnavailable {
+    /// A participant lease and the corresponding cancel/drain/release lifecycle are not yet
+    /// implemented, so production must not hand a recovery capability to an async worker.
+    ParticipantLeaseRequired,
+    /// The journal owner is not available to authorize the recovery boundary.
+    OperationJournalUnavailable,
+    /// The required platform capability or durability primitive is not verified.
+    UnsupportedPlatform,
+}
+
+impl std::fmt::Display for RecoveryUnavailable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ParticipantLeaseRequired => formatter
+                .write_str("destructive recovery is unavailable until a participant lease exists"),
+            Self::OperationJournalUnavailable => formatter
+                .write_str("destructive recovery is unavailable while the journal is unavailable"),
+            Self::UnsupportedPlatform => {
+                formatter.write_str("destructive recovery is unsupported on this platform")
+            }
+        }
+    }
 }
 
 /// One complete, bounded durable operation record.
@@ -2007,6 +1996,9 @@ pub(crate) enum JournalError {
     /// Profile ownership changed while opening the production journal or recovery root.
     #[error(transparent)]
     ProfileOwnership(#[from] wavecrate_library::app_dirs::ProfileOwnershipError),
+    /// A production capability or durability primitive is not verified on this platform.
+    #[error("operation journal capability is unsupported or unverified at {path}: {reason}")]
+    UnsupportedPlatform { path: PathBuf, reason: String },
     /// A durable operation record could not be written or synchronized.
     #[error("operation journal write failed at {path}: {source}")]
     Write { path: PathBuf, source: io::Error },
@@ -2154,6 +2146,16 @@ impl OperationJournalStore {
         directory: PathBuf,
         journal_dir: Dir,
     ) -> Result<Self, JournalError> {
+        #[cfg(windows)]
+        {
+            let _ = journal_dir;
+            return Err(JournalError::UnsupportedPlatform {
+                path: directory,
+                reason: String::from(
+                    "production cap-std journal scan/rename is not verified on Windows",
+                ),
+            });
+        }
         let ownership = OwnershipLock::acquire_at(&journal_dir, &directory)?;
         let mut store = Self {
             directory,
@@ -3743,6 +3745,15 @@ impl OperationJournalCoordinator {
         profile_guard: &wavecrate::app_dirs::WritableProfileGuard,
     ) -> Result<Self, JournalError> {
         let directory = profile_guard.profile_root().join("operation_journal");
+        #[cfg(windows)]
+        {
+            return Err(JournalError::UnsupportedPlatform {
+                path: directory,
+                reason: String::from(
+                    "production cap-std journal scan/rename is not verified on Windows",
+                ),
+            });
+        }
         let journal_dir = profile_guard
             .open_child_dir(Path::new("operation_journal"))
             .map_err(JournalError::ProfileOwnership)?;
@@ -5279,6 +5290,7 @@ impl OwnershipLock {
         {
             use std::os::windows::fs::OpenOptionsExt;
             use std::os::windows::io::AsRawHandle;
+            use windows::Win32::Foundation::{ERROR_LOCK_VIOLATION, HANDLE, WIN32_ERROR};
             use windows::Win32::Storage::FileSystem::{
                 FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
                 LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
@@ -5323,8 +5335,14 @@ impl OwnershipLock {
                     &mut overlapped,
                 )
             };
-            if result.is_err() {
-                return Err(JournalError::JournalOwnedByAnotherProcess { path });
+            if let Err(error) = result {
+                if WIN32_ERROR::from_error(&error) == Some(ERROR_LOCK_VIOLATION) {
+                    return Err(JournalError::JournalOwnedByAnotherProcess { path });
+                }
+                return Err(JournalError::Write {
+                    path,
+                    source: io::Error::other(error.to_string()),
+                });
             }
             file.set_len(0)
                 .and_then(|_| file.write_all(format!("pid={}\n", std::process::id()).as_bytes()))
@@ -5401,7 +5419,9 @@ impl OwnershipLock {
         {
             use std::os::windows::fs::MetadataExt;
             use std::os::windows::io::AsRawHandle;
-            use windows::Win32::Foundation::{FILE_ATTRIBUTE_REPARSE_POINT, HANDLE};
+            use windows::Win32::Foundation::{
+                ERROR_LOCK_VIOLATION, FILE_ATTRIBUTE_REPARSE_POINT, HANDLE, WIN32_ERROR,
+            };
             use windows::Win32::Storage::FileSystem::{
                 LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
             };
@@ -5433,8 +5453,14 @@ impl OwnershipLock {
                     &mut overlapped,
                 )
             };
-            if result.is_err() {
-                return Err(JournalError::JournalOwnedByAnotherProcess { path });
+            if let Err(error) = result {
+                if WIN32_ERROR::from_error(&error) == Some(ERROR_LOCK_VIOLATION) {
+                    return Err(JournalError::JournalOwnedByAnotherProcess { path });
+                }
+                return Err(JournalError::Write {
+                    path,
+                    source: io::Error::other(error.to_string()),
+                });
             }
             file.set_len(0)
                 .and_then(|_| file.write_all(format!("pid={}\n", std::process::id()).as_bytes()))
@@ -5584,13 +5610,17 @@ fn atomic_durable_write_relative(
         });
     }
     if let Err(source) = sync_capability_directory(directory) {
-        return Err(JournalError::Write {
-            path: path
-                .parent()
-                .unwrap_or_else(|| Path::new("."))
-                .to_path_buf(),
-            source,
-        });
+        let path = path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        if source.kind() == io::ErrorKind::Unsupported {
+            return Err(JournalError::UnsupportedPlatform {
+                path,
+                reason: source.to_string(),
+            });
+        }
+        return Err(JournalError::Write { path, source });
     }
     Ok(())
 }
@@ -5603,9 +5633,10 @@ fn sync_capability_directory(directory: &Dir) -> io::Result<()> {
     #[cfg(target_os = "windows")]
     {
         let _ = directory;
-        // Windows uses the capability-relative rename; the underlying rename is the
-        // strongest namespace durability primitive available to this store.
-        Ok(())
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "capability-relative directory synchronization is not verified on Windows",
+        ))
     }
     #[cfg(all(not(unix), not(target_os = "windows")))]
     {

--- a/src/native_app/transaction_history/operation_journal.rs
+++ b/src/native_app/transaction_history/operation_journal.rs
@@ -2770,11 +2770,30 @@ impl OperationJournalStore {
             if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
                 continue;
             }
-            let file_type = entry.file_type().map_err(|source| JournalError::Scan {
-                path: path.clone(),
-                source,
-            })?;
-            if !file_type.is_file() {
+            #[cfg(unix)]
+            let file = Self::open_scan_entry_nonblocking(directory, &name, &path)?;
+            #[cfg(not(unix))]
+            let mut options = CapabilityOpenOptions::new();
+            #[cfg(not(unix))]
+            let file = {
+                options.read(true).follow(FollowSymlinks::No);
+                entry
+                    .open_with(&options)
+                    .map_err(|source| JournalError::Scan {
+                        path: path.clone(),
+                        source,
+                    })?
+                    .into_std()
+            };
+            #[cfg(not(unix))]
+            if !file
+                .metadata()
+                .map_err(|source| JournalError::Scan {
+                    path: path.clone(),
+                    source,
+                })?
+                .is_file()
+            {
                 return Err(JournalError::Scan {
                     path,
                     source: io::Error::new(
@@ -2783,14 +2802,6 @@ impl OperationJournalStore {
                     ),
                 });
             }
-            let mut options = CapabilityOpenOptions::new();
-            options.read(true).follow(FollowSymlinks::No);
-            let file = entry
-                .open_with(&options)
-                .map_err(|source| JournalError::Scan {
-                    path: path.clone(),
-                    source,
-                })?;
             let mut bytes = Vec::with_capacity(MAX_RECORD_BYTES);
             file.take((MAX_RECORD_BYTES as u64).saturating_add(1))
                 .read_to_end(&mut bytes)
@@ -2801,6 +2812,55 @@ impl OperationJournalStore {
             self.ingest_scan_entry(path, bytes)?;
         }
         Ok(())
+    }
+
+    #[cfg(unix)]
+    fn open_scan_entry_nonblocking(
+        directory: &Dir,
+        name: &std::ffi::OsStr,
+        path: &Path,
+    ) -> Result<File, JournalError> {
+        use std::ffi::CString;
+        use std::os::fd::{AsRawFd, FromRawFd};
+        use std::os::unix::ffi::OsStrExt;
+
+        let name = CString::new(name.as_bytes()).map_err(|_| JournalError::Scan {
+            path: path.to_path_buf(),
+            source: io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "operation journal entry name contains NUL",
+            ),
+        })?;
+        let parent = directory
+            .try_clone()
+            .map_err(|source| JournalError::Scan {
+                path: path.to_path_buf(),
+                source,
+            })?
+            .into_std_file();
+        let flags = libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK;
+        let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags) };
+        if fd < 0 {
+            return Err(JournalError::Scan {
+                path: path.to_path_buf(),
+                source: io::Error::last_os_error(),
+            });
+        }
+        let file = unsafe { File::from_raw_fd(fd) };
+        let metadata = file.metadata().map_err(|source| JournalError::Scan {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        if !metadata.is_file() {
+            return Err(JournalError::Scan {
+                path: path.to_path_buf(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "operation journal entry is not a regular file",
+                ),
+            });
+        }
+        Ok(file)
     }
 
     fn ingest_scan_entry(&mut self, path: PathBuf, bytes: Vec<u8>) -> Result<(), JournalError> {
@@ -7592,6 +7652,57 @@ mod tests {
             "FIFO leaf open blocked before regular-file rejection"
         );
         assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capability_scan_rejects_replaced_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let json = directory.path().join("replaced.json");
+        fs::write(&json, b"placeholder").unwrap();
+        let journal_dir =
+            Dir::open_ambient_dir(directory.path(), cap_fs_ext::ambient_authority()).unwrap();
+        fs::remove_file(&json).unwrap();
+        let fifo = json;
+        let fifo_name = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let display = directory.path().to_path_buf();
+        let handle = std::thread::spawn(move || {
+            sender
+                .send(OperationJournalStore::open_from_capability(
+                    display,
+                    journal_dir,
+                ))
+                .unwrap();
+        });
+
+        let first_result = receiver.recv_timeout(std::time::Duration::from_millis(250));
+        let completed_without_writer = first_result.is_ok();
+        let result = match first_result {
+            Ok(result) => result,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                let writer = OpenOptions::new().write(true).open(&fifo).unwrap();
+                drop(writer);
+                receiver
+                    .recv_timeout(std::time::Duration::from_secs(1))
+                    .expect("FIFO capability scan did not complete after FIFO writer unblock")
+            }
+            Err(error) => panic!("FIFO capability scan channel failed: {error}"),
+        };
+        handle.join().unwrap();
+
+        assert!(
+            completed_without_writer,
+            "replaced FIFO capability scan blocked before regular-file rejection"
+        );
+        assert!(matches!(
+            result,
+            Err(JournalError::Scan { source, .. })
+                if source.kind() == io::ErrorKind::InvalidData
+        ));
     }
 
     #[test]

--- a/src/native_app/waveform_edits/entrypoints.rs
+++ b/src/native_app/waveform_edits/entrypoints.rs
@@ -214,6 +214,7 @@ impl NativeAppState {
                 .browser_interaction
                 .pending_waveform_destructive_edit = None;
             if let Err(error) = self.queue_destructive_edit_request(request, context) {
+                let error = error.to_string();
                 self.ui.status.sample = format!(
                     "{} failed: {}",
                     kind.action_label(),

--- a/src/native_app/waveform_edits/prompt.rs
+++ b/src/native_app/waveform_edits/prompt.rs
@@ -24,6 +24,7 @@ impl NativeAppState {
         let denied_path = request.absolute_path.clone();
         let result = self.queue_destructive_edit_request(request, context);
         if let Err(error) = result {
+            let error = error.to_string();
             self.flash_protected_source_block_if_error(&error, &denied_path);
             self.flash_denied_waveform_selection_for_error(
                 &error,

--- a/src/native_app/waveform_edits/protected_copy.rs
+++ b/src/native_app/waveform_edits/protected_copy.rs
@@ -138,7 +138,8 @@ impl NativeAppState {
                 harvest_whole_file_derivation: Some((source_path, harvest_operation)),
             },
             context,
-        )?;
+        )
+        .map_err(|error| error.to_string())?;
         Ok(true)
     }
 

--- a/src/native_app/waveform_edits/queue.rs
+++ b/src/native_app/waveform_edits/queue.rs
@@ -9,11 +9,27 @@ use crate::native_app::app::{
     WaveformDestructiveEditKind, WaveformDestructiveEditTarget, WaveformDestructiveEditUiContext,
     sample_path_label,
 };
+use crate::native_app::transaction_history::operation_journal::RecoveryUnavailable;
 use crate::native_app::waveform::WaveformSelectionKind;
 
 use super::worker::{self, WaveformDestructiveEditWorkerRequest};
 
 const WAVEFORM_DESTRUCTIVE_EDIT_TASK_NAME: &str = "gui-waveform-destructive-edit";
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum WaveformDestructiveEditQueueError {
+    #[error("{0}")]
+    RecoveryUnavailable(RecoveryUnavailable),
+    #[error("{0}")]
+    Message(String),
+}
+
+impl From<String> for WaveformDestructiveEditQueueError {
+    fn from(error: String) -> Self {
+        Self::Message(error)
+    }
+}
+
 #[derive(Default)]
 pub(super) struct WaveformDestructiveEditQueueOptions {
     pub(super) copy_source_path: Option<PathBuf>,
@@ -26,7 +42,7 @@ impl NativeAppState {
         &mut self,
         request: PendingWaveformDestructiveEdit,
         context: &mut ui::UiUpdateContext<GuiMessage>,
-    ) -> Result<(), String> {
+    ) -> Result<(), WaveformDestructiveEditQueueError> {
         self.queue_destructive_edit_request_with_options(
             request,
             WaveformDestructiveEditQueueOptions::default(),
@@ -39,18 +55,18 @@ impl NativeAppState {
         request: PendingWaveformDestructiveEdit,
         options: WaveformDestructiveEditQueueOptions,
         context: &mut ui::UiUpdateContext<GuiMessage>,
-    ) -> Result<(), String> {
+    ) -> Result<(), WaveformDestructiveEditQueueError> {
         let recovery_root = self
             .background
-            .waveform_recovery_root
+            .waveform_recovery
             .clone()
-            .ok_or_else(|| String::from("waveform recovery root is not ready"))?;
+            .map_err(WaveformDestructiveEditQueueError::RecoveryUnavailable)?;
         if let Some(error) = self
             .library
             .folder_browser
             .file_change_lock_error(&request.absolute_path, request.prompt.edit.action_label())
         {
-            return Err(error);
+            return Err(error.into());
         }
         let extraction_request =
             if request.prompt.edit == WaveformDestructiveEditKind::ExtractAndTrimSelection {
@@ -159,6 +175,29 @@ impl NativeAppState {
         } else {
             self.waveform.current.flash_denied_selection(fallback_kind);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_recovery_unavailability_is_typed_before_worker_request() {
+        let recovery: Result<
+            crate::native_app::transaction_history::operation_journal::RecoveryRootCapability,
+            RecoveryUnavailable,
+        > = Err(RecoveryUnavailable::ParticipantLeaseRequired);
+        let error = recovery
+            .map(|_| ())
+            .map_err(WaveformDestructiveEditQueueError::RecoveryUnavailable)
+            .expect_err("production recovery must remain unavailable");
+        assert!(matches!(
+            error,
+            WaveformDestructiveEditQueueError::RecoveryUnavailable(
+                RecoveryUnavailable::ParticipantLeaseRequired
+            )
+        ));
     }
 }
 

--- a/src/native_app/waveform_edits/worker.rs
+++ b/src/native_app/waveform_edits/worker.rs
@@ -360,6 +360,8 @@ pub(super) struct WaveformDestructiveEditWorkerRequest {
     edit: PendingWaveformDestructiveEdit,
     extraction: Option<WaveformExtractionRequest>,
     copy_source: Option<PathBuf>,
+    // Production does not provide this capability until the participant-lease and recovery
+    // lifecycle exists; the current capability-backed worker remains an explicit/test seam.
     recovery_root:
         crate::native_app::transaction_history::operation_journal::RecoveryRootCapability,
 }


### PR DESCRIPTION
## Goal

Advance Linear OPT-1336 with the first enforceable profile-wide writable ownership boundary: production operation-journal startup must own the profile before it can create, scan, or admit journal work, and those journal children must remain bound to the acquired profile capability.

Linear issue: https://linear.app/boostnlvp/issue/OPT-1336/wavecrate-establish-profile-wide-writable-ownership-before-journal-and

## Scope

- Add a reusable `WritableProfileGuard` backed by `<profile-root>/profile-owner.lock`.
- Retain a no-follow profile-root directory capability and stable root/lock identities for the guard lifetime.
- Use no-follow, regular-file, nonblocking exclusive locking on Unix and the corresponding fail-closed Windows path.
- Open the production journal relative to the retained profile capability rather than re-resolving a mutable profile pathname.
- Use the retained journal capability for production journal scanning and durable record writes, including nonblocking regular-file validation for special-file races.
- Detect profile-root or profile-owner-lock replacement and fail closed.
- Keep explicit journal-directory APIs and explicit test recovery capabilities available only for isolated tests.
- Reject production waveform recovery before operation-ID creation, journal admission, or filesystem mutation when no leased recovery participant capability exists.
- Distinguish `ProfileOwnedByAnotherProcess`, `JournalOwnedByAnotherProcess`, and `RecoveryUnavailable`.
- Report journal shutdown as close-requested until the asynchronous owner acknowledges actual release; do not claim participant or profile-lock release.
- Preserve shutdown ordering by closing the coordinator before releasing profile ownership.

## Non-goals

- This is the bounded first slice, not completion of OPT-1336.
- It does not implement the future revocable recovery participant lease, cancellation/drain/checkpoint protocol, or async recovery capability publication.
- It does not yet gate global-library writers, source-database writers, source processing startup, CLI/helper processes, or source leases/epochs.
- It does not add `WritableSourceOwnedByAnotherProcess`, automatic takeover, read-only forwarding, or a profile epoch.
- It does not migrate source or global database schemas.
- It does not claim Windows production scan/rename/synchronization support where the platform primitive is unverified; those paths fail closed.

## Definition of Done

- Production journal ownership is attempted only after profile ownership succeeds.
- A losing production owner reports typed profile conflict, does not create or scan `operation_journal`, does not admit durable work, and does not silently retry after the holder exits.
- Journal scan and durable record writes use the acquired journal capability on the supported path.
- Replacement of the configured profile root or acquired lock entry is detected and fails closed; replacement entries cannot silently become the owned profile.
- Production waveform recovery returns typed `RecoveryUnavailable` before an operation ID, journal record, filesystem mutation, or success can be produced without a participant lease.
- Capability-relative journal scan rejects replacement special files without blocking the owner thread.
- Shutdown telemetry reports close requested rather than completed release until the owner actually acknowledges closure.
- Lock diagnostics are non-authoritative and stale contents do not prevent a later acquisition.
- Symlink/reparse lock paths fail closed without modifying their target.
- Existing explicit-directory journal and test-recovery behavior remains green.
- The issue remains In Progress for the remaining writable-entrypoint, recovery-participant, and source-lease work.

## Validation and results

- Profile ownership tests: 7 passed.
- Native journal owner tests: 12 passed.
- Native operation-journal tests: 101 passed, including the replacement-to-FIFO regression.
- Native transaction tests: 24 passed, including the targeted unavailable-owner-recovery test.
- Native `cargo check --locked --offline --lib`: passed using the exact pinned Radiant source revision `fa707ff5cba809d334968416f9bcd1b702083db1` under the managed validation area.
- All touched Rust files pass `rustfmt --edition 2024 --check`.
- `git diff --check` and complete base-to-head diff check: passed.
- Full library `cargo clippy --locked --offline --lib -- -D warnings` reports four pre-existing lints in untouched files; no lint remains in the changed files.
- Full-repository `cargo fmt --all -- --check` reports five pre-existing differences in untouched files; those files are outside this PR.
- Windows compilation and runtime capability tests were unavailable on this macOS host; Windows production paths are fail-closed where unverified.
- Full workspace test/clippy gates were not run.

## Known limitations and follow-up

The broader OPT-1336 contract still requires moving profile ownership ahead of source-processing startup, enforcing it at every global/source writable-open boundary, and adding the revocable recovery participant lease and shutdown drain/checkpoint protocol before production waveform recovery can be enabled. Those callers and the future recovery slice remain intentionally outside this PR.

This PR is review-ready and non-draft. User approval is required before merge; do not merge as part of this delivery.