### PR TITLE
feat: add profile-owned global library writer

### DIFF
--- a/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
+++ b/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
@@ -114,6 +114,11 @@ impl WritableProfileGuard {
         &self.profile_root
     }
 
+    /// Return the identity captured from the retained profile-root capability.
+    pub(crate) fn profile_root_identity(&self) -> &str {
+        &self.profile_identity
+    }
+
     /// Clone this acquired profile capability for another profile-owned participant.
     ///
     /// The clone retains the same lock identity and open lock descriptor. It therefore does not

--- a/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
+++ b/crates/wavecrate-library/src/app_dirs/profile_ownership.rs
@@ -114,6 +114,37 @@ impl WritableProfileGuard {
         &self.profile_root
     }
 
+    /// Clone this acquired profile capability for another profile-owned participant.
+    ///
+    /// The clone retains the same lock identity and open lock descriptor. It therefore does not
+    /// acquire a second profile lock, and the profile remains owned until every participant clone
+    /// has been dropped.
+    pub fn try_clone(&self) -> Result<Self, ProfileOwnershipError> {
+        self.validate_current()?;
+        let root_dir = self
+            .root_dir
+            .try_clone()
+            .map_err(|source| ProfileOwnershipError::Io {
+                path: self.profile_root.clone(),
+                source,
+            })?;
+        let lock_file =
+            self._lock_file
+                .try_clone()
+                .map_err(|source| ProfileOwnershipError::Io {
+                    path: self.lock_path.clone(),
+                    source,
+                })?;
+        Ok(Self {
+            profile_root: self.profile_root.clone(),
+            profile_identity: self.profile_identity.clone(),
+            lock_path: self.lock_path.clone(),
+            lock_identity: self.lock_identity.clone(),
+            root_dir,
+            _lock_file: lock_file,
+        })
+    }
+
     /// Revalidate the acquired root and lock identities without following links.
     ///
     /// A successful check means the configured profile path still names the same root and

--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/mod.rs
@@ -22,6 +22,8 @@ mod store;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use recovery_io::BoundDatabaseRoot;
+
 pub use entry::{
     CopyJournalEntryInit, FileOpJournalEntry, FileOpStage, MoveJournalEntryInit, new_op_id,
     staged_relative_for_target,

--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/recovery_io.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/recovery_io.rs
@@ -12,6 +12,7 @@ use cap_primitives::fs::{FollowSymlinks, OpenOptions, open, open_ambient_dir, op
 #[cfg(test)]
 use cap_primitives::fs::{hard_link, remove_file};
 
+use crate::app_dirs::{ProfileOwnershipError, WritableProfileGuard};
 use crate::filesystem_identity::{
     stable_filesystem_identity, stable_filesystem_identity_from_open_file,
 };
@@ -448,6 +449,7 @@ impl RecoveryRoot {
             return Ok(BoundDatabaseRoot {
                 path,
                 _capability: capability,
+                identity: self.identity.clone(),
             });
         }
 
@@ -460,6 +462,7 @@ impl RecoveryRoot {
             Ok(BoundDatabaseRoot {
                 path,
                 _capability: capability,
+                identity: self.identity.clone(),
             })
         }
     }
@@ -497,18 +500,79 @@ impl RecoveryRoot {
     }
 }
 
-pub(super) struct BoundDatabaseRoot {
+pub(crate) struct BoundDatabaseRoot {
     path: PathBuf,
     _capability: fs::File,
+    identity: String,
 }
 
 impl BoundDatabaseRoot {
-    pub(super) fn path(&self) -> &Path {
+    pub(crate) fn path(&self) -> &Path {
         &self.path
+    }
+
+    pub(crate) fn for_profile_guard(
+        profile_guard: &WritableProfileGuard,
+    ) -> Result<Self, ProfileOwnershipError> {
+        let expected_identity = profile_guard.profile_root_identity();
+
+        #[cfg(windows)]
+        let capability =
+            windows_database_root_binding(profile_guard.profile_root(), expected_identity)
+                .map_err(|error| profile_binding_error(profile_guard, error))?;
+
+        #[cfg(not(windows))]
+        let capability = profile_guard.profile_root_dir()?.into_std_file();
+
+        #[cfg(windows)]
+        let path = windows_final_path(&capability)
+            .map_err(|error| profile_binding_error(profile_guard, error))?;
+
+        #[cfg(not(windows))]
+        let path =
+            database_root_alias(&capability, profile_guard.profile_root(), expected_identity)
+                .map_err(|error| profile_binding_error(profile_guard, error))?;
+
+        validate_database_root_alias(&capability, &path, expected_identity)
+            .map_err(|error| profile_binding_error(profile_guard, error))?;
+        Ok(Self {
+            path,
+            _capability: capability,
+            identity: expected_identity.to_owned(),
+        })
+    }
+
+    pub(crate) fn validate_profile_guard(
+        &self,
+        profile_guard: &WritableProfileGuard,
+    ) -> Result<(), ProfileOwnershipError> {
+        profile_guard.validate_current()?;
+        validate_database_root_alias(
+            &self._capability,
+            &self.path,
+            profile_guard.profile_root_identity(),
+        )
+        .map_err(|error| profile_binding_error(profile_guard, error))?;
+        if self.identity != profile_guard.profile_root_identity() {
+            return Err(ProfileOwnershipError::ProfileRootReplaced {
+                path: profile_guard.profile_root().to_path_buf(),
+            });
+        }
+        Ok(())
     }
 }
 
 impl DatabaseRootBindingGuard for BoundDatabaseRoot {}
+
+fn profile_binding_error(
+    profile_guard: &WritableProfileGuard,
+    error: String,
+) -> ProfileOwnershipError {
+    ProfileOwnershipError::Io {
+        path: profile_guard.profile_root().to_path_buf(),
+        source: io::Error::other(error),
+    }
+}
 
 #[cfg(not(windows))]
 fn database_root_alias(

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -15,6 +15,7 @@ mod directories;
 mod error;
 /// Persistent file operation journal for crash recovery.
 pub mod file_ops_journal;
+pub(crate) use file_ops_journal::BoundDatabaseRoot;
 mod index_entries;
 mod open;
 mod open_profiles;
@@ -113,9 +114,9 @@ pub const SOURCE_DB_READ_ONLY_ENV: &str = "WAVECRATE_SOURCE_DB_READ_ONLY";
 
 /// Keeps a verified database-root namespace alive for the lifetime of its connection.
 ///
-/// Recovery supplies platform-specific implementations when SQLite must open through a
-/// descriptor-bound namespace. This is intentionally private to the library's database
-/// implementation; ordinary callers continue to use pathname-based opening.
+/// Recovery and profile-owned writers supply platform-specific implementations when SQLite must
+/// open through a descriptor-bound namespace. This is intentionally private to the library's
+/// database implementation; ordinary callers continue to use pathname-based opening.
 pub(crate) trait DatabaseRootBindingGuard: Send {}
 
 /// SQLite wrapper that stores wav metadata for a single source folder.

--- a/crates/wavecrate-library/src/sample_sources/library.rs
+++ b/crates/wavecrate-library/src/sample_sources/library.rs
@@ -11,6 +11,7 @@ mod connection;
 mod error;
 mod harvest;
 mod migrations;
+mod owner;
 mod schema_checks;
 mod schema_defs;
 mod sources;
@@ -32,6 +33,11 @@ pub use harvest::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,
     HarvestFileRecord, HarvestMetadataSnapshot, HarvestSourceRange, HarvestState,
     NewHarvestDerivation,
+};
+pub use owner::{
+    GLOBAL_LIBRARY_WRITER_COMMAND_CAPACITY, GlobalLibraryWriter, GlobalLibraryWriterQueueError,
+    GlobalLibraryWriterStartError, GlobalLibraryWriterStatus, GlobalLibraryWriterUnavailable,
+    SourceRegistrySnapshot,
 };
 
 #[cfg(test)]

--- a/crates/wavecrate-library/src/sample_sources/library/connection.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/connection.rs
@@ -1,19 +1,27 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 
 use super::error::map_app_dir_error;
 use super::{LIBRARY_DB_FILE_NAME, LibraryError};
 use crate::app_dirs::{self, WritableProfileGuard};
+#[cfg(test)]
+use crate::filesystem_identity::stable_filesystem_identity;
+use crate::sample_sources::db::BoundDatabaseRoot;
 
 #[cfg(test)]
 use std::collections::HashMap;
 
 #[cfg(test)]
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, Barrier, LazyLock, Mutex};
+
+const LIBRARY_DB_WAL_FILE_NAME: &str = "library.db-wal";
+const LIBRARY_DB_SHM_FILE_NAME: &str = "library.db-shm";
 
 pub(super) struct LibraryDatabase {
     pub(super) connection: Connection,
+    _database_root_binding: Option<BoundDatabaseRoot>,
 }
 
 impl LibraryDatabase {
@@ -24,11 +32,30 @@ impl LibraryDatabase {
 
     pub(super) fn open_for_profile_guard(
         profile_guard: &WritableProfileGuard,
+        #[cfg(test)] binding_open_gate: Option<(Arc<Barrier>, Arc<Barrier>)>,
     ) -> Result<Self, LibraryError> {
         profile_guard.validate_current()?;
-        let db_path = profile_guard.profile_root().join(LIBRARY_DB_FILE_NAME);
-        let database = Self::open_at(&db_path)?;
-        profile_guard.validate_current()?;
+        let binding = BoundDatabaseRoot::for_profile_guard(profile_guard)?;
+        binding.validate_profile_guard(profile_guard)?;
+        validate_database_entries(binding.path())?;
+        #[cfg(test)]
+        if let Some((ready, release)) = binding_open_gate {
+            ready.wait();
+            release.wait();
+        }
+        let db_path = binding.path().join(LIBRARY_DB_FILE_NAME);
+        let connection = Connection::open_with_flags(
+            &db_path,
+            OpenFlags::default() | OpenFlags::SQLITE_OPEN_NOFOLLOW,
+        )?;
+        #[cfg(test)]
+        record_test_open(&db_path);
+        let database = Self::initialize(connection, Some(binding))?;
+        database
+            ._database_root_binding
+            .as_ref()
+            .expect("profile-owned library database retains its root binding")
+            .validate_profile_guard(profile_guard)?;
         Ok(database)
     }
 
@@ -37,7 +64,17 @@ impl LibraryDatabase {
         let connection = Connection::open(db_path)?;
         #[cfg(test)]
         record_test_open(db_path);
-        let mut db = Self { connection };
+        Self::initialize(connection, None)
+    }
+
+    fn initialize(
+        connection: Connection,
+        database_root_binding: Option<BoundDatabaseRoot>,
+    ) -> Result<Self, LibraryError> {
+        let mut db = Self {
+            connection,
+            _database_root_binding: database_root_binding,
+        };
         db.apply_pragmas()?;
         db.apply_schema()?;
         db.migrate_source_roles()?;
@@ -52,8 +89,61 @@ impl LibraryDatabase {
         Ok(db)
     }
 
+    pub(super) fn validate_profile_guard(
+        &self,
+        profile_guard: &WritableProfileGuard,
+    ) -> Result<(), crate::app_dirs::ProfileOwnershipError> {
+        if let Some(binding) = self._database_root_binding.as_ref() {
+            binding.validate_profile_guard(profile_guard)
+        } else {
+            profile_guard.validate_current()
+        }
+    }
+
     pub(super) fn into_connection(self) -> Connection {
         self.connection
+    }
+}
+
+fn validate_database_entries(database_root: &Path) -> Result<(), LibraryError> {
+    for filename in [
+        LIBRARY_DB_FILE_NAME,
+        LIBRARY_DB_WAL_FILE_NAME,
+        LIBRARY_DB_SHM_FILE_NAME,
+    ] {
+        let path = database_root.join(filename);
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(LibraryError::DatabasePathValidation {
+                    path,
+                    reason: error.to_string(),
+                });
+            }
+        };
+        if !is_regular_database_entry(&metadata) {
+            return Err(LibraryError::DatabasePathValidation {
+                path,
+                reason: String::from("entry is not a regular file"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn is_regular_database_entry(metadata: &fs::Metadata) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+        return metadata.is_file()
+            && metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0 == 0;
+    }
+    #[cfg(not(windows))]
+    {
+        metadata.is_file() && !metadata.file_type().is_symlink()
     }
 }
 
@@ -63,20 +153,45 @@ static TEST_OPEN_COUNTS: LazyLock<Mutex<HashMap<PathBuf, usize>>> =
 
 #[cfg(test)]
 fn record_test_open(path: &Path) {
+    let key = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     let mut counts = TEST_OPEN_COUNTS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *counts.entry(path.to_path_buf()).or_default() += 1;
+    *counts.entry(key).or_default() += 1;
 }
 
 #[cfg(test)]
 pub(super) fn test_open_count(path: &Path) -> usize {
-    TEST_OPEN_COUNTS
+    let key = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let counts = TEST_OPEN_COUNTS
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get(path)
-        .copied()
-        .unwrap_or_default()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(count) = counts.get(&key).or_else(|| counts.get(path)).copied() {
+        return count;
+    }
+
+    let Some(expected_name) = path.file_name() else {
+        return 0;
+    };
+    let Some(expected_parent_identity) = parent_identity(path) else {
+        return 0;
+    };
+    counts
+        .iter()
+        .filter(|(opened_path, _)| {
+            opened_path.file_name() == Some(expected_name)
+                && parent_identity(opened_path).as_deref()
+                    == Some(expected_parent_identity.as_str())
+        })
+        .map(|(_, count)| *count)
+        .sum()
+}
+
+#[cfg(test)]
+fn parent_identity(path: &Path) -> Option<String> {
+    let parent = path.parent()?;
+    let metadata = fs::metadata(parent).ok()?;
+    stable_filesystem_identity(parent, &metadata)
 }
 
 fn database_path() -> Result<PathBuf, LibraryError> {

--- a/crates/wavecrate-library/src/sample_sources/library/connection.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/connection.rs
@@ -4,7 +4,13 @@ use rusqlite::Connection;
 
 use super::error::map_app_dir_error;
 use super::{LIBRARY_DB_FILE_NAME, LibraryError};
-use crate::app_dirs;
+use crate::app_dirs::{self, WritableProfileGuard};
+
+#[cfg(test)]
+use std::collections::HashMap;
+
+#[cfg(test)]
+use std::sync::{LazyLock, Mutex};
 
 pub(super) struct LibraryDatabase {
     pub(super) connection: Connection,
@@ -13,8 +19,24 @@ pub(super) struct LibraryDatabase {
 impl LibraryDatabase {
     pub(super) fn open() -> Result<Self, LibraryError> {
         let db_path = database_path()?;
-        create_parent_if_needed(&db_path)?;
-        let connection = Connection::open(&db_path)?;
+        Self::open_at(&db_path)
+    }
+
+    pub(super) fn open_for_profile_guard(
+        profile_guard: &WritableProfileGuard,
+    ) -> Result<Self, LibraryError> {
+        profile_guard.validate_current()?;
+        let db_path = profile_guard.profile_root().join(LIBRARY_DB_FILE_NAME);
+        let database = Self::open_at(&db_path)?;
+        profile_guard.validate_current()?;
+        Ok(database)
+    }
+
+    fn open_at(db_path: &Path) -> Result<Self, LibraryError> {
+        create_parent_if_needed(db_path)?;
+        let connection = Connection::open(db_path)?;
+        #[cfg(test)]
+        record_test_open(db_path);
         let mut db = Self { connection };
         db.apply_pragmas()?;
         db.apply_schema()?;
@@ -33,6 +55,28 @@ impl LibraryDatabase {
     pub(super) fn into_connection(self) -> Connection {
         self.connection
     }
+}
+
+#[cfg(test)]
+static TEST_OPEN_COUNTS: LazyLock<Mutex<HashMap<PathBuf, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[cfg(test)]
+fn record_test_open(path: &Path) {
+    let mut counts = TEST_OPEN_COUNTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *counts.entry(path.to_path_buf()).or_default() += 1;
+}
+
+#[cfg(test)]
+pub(super) fn test_open_count(path: &Path) -> usize {
+    TEST_OPEN_COUNTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(path)
+        .copied()
+        .unwrap_or_default()
 }
 
 fn database_path() -> Result<PathBuf, LibraryError> {

--- a/crates/wavecrate-library/src/sample_sources/library/error.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/error.rs
@@ -24,6 +24,17 @@ pub enum LibraryError {
         /// Rejected profile name.
         profile: String,
     },
+    /// The profile ownership capability could not be used for a library operation.
+    #[error(transparent)]
+    ProfileOwnership(#[from] app_dirs::ProfileOwnershipError),
+    /// Profile ownership changed while an accepted library command was in flight.
+    #[error("profile ownership changed at {path}: {reason}")]
+    ProfileOwnershipChanged {
+        /// Profile root whose ownership boundary changed.
+        path: PathBuf,
+        /// Stable reason for the fail-closed result.
+        reason: String,
+    },
     /// Failed to open or query the database.
     #[error("Library database query failed: {0}")]
     Sql(#[from] rusqlite::Error),

--- a/crates/wavecrate-library/src/sample_sources/library/error.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/error.rs
@@ -18,6 +18,14 @@ pub enum LibraryError {
         /// Underlying IO error.
         source: std::io::Error,
     },
+    /// A database, WAL, or SHM entry was not safe to hand to SQLite.
+    #[error("Library database path validation failed at {path}: {reason}")]
+    DatabasePathValidation {
+        /// Entry that failed no-follow validation.
+        path: PathBuf,
+        /// Stable validation failure description.
+        reason: String,
+    },
     /// Failed to resolve the configured persistence profile.
     #[error("Invalid library persistence profile '{profile}'")]
     InvalidProfile {

--- a/crates/wavecrate-library/src/sample_sources/library/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/owner.rs
@@ -1,0 +1,970 @@
+//! Profile-owned asynchronous ownership for the global library database.
+
+use std::path::PathBuf;
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use thiserror::Error;
+
+use super::connection::LibraryDatabase;
+use super::error::LibraryError;
+use crate::app_dirs::{ProfileOwnershipError, WritableProfileGuard};
+use crate::sample_sources::SampleSource;
+
+/// Maximum number of global-library commands waiting for the owner thread.
+pub const GLOBAL_LIBRARY_WRITER_COMMAND_CAPACITY: usize = 32;
+
+const OWNER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
+
+/// An immutable, owned snapshot of the configured source registry.
+#[derive(Clone, Debug)]
+pub struct SourceRegistrySnapshot {
+    sources: Arc<[SampleSource]>,
+}
+
+impl SourceRegistrySnapshot {
+    /// Own a source registry snapshot without retaining a caller-owned mutable collection.
+    pub fn new(sources: Vec<SampleSource>) -> Self {
+        Self {
+            sources: Arc::from(sources.into_boxed_slice()),
+        }
+    }
+
+    /// Borrow the sources in this immutable snapshot.
+    pub fn as_slice(&self) -> &[SampleSource] {
+        &self.sources
+    }
+
+    /// Return the number of sources in this snapshot.
+    pub fn len(&self) -> usize {
+        self.sources.len()
+    }
+
+    /// Return whether this snapshot contains no sources.
+    pub fn is_empty(&self) -> bool {
+        self.sources.is_empty()
+    }
+
+    pub(super) fn from_sources(sources: Vec<SampleSource>) -> Self {
+        Self::new(sources)
+    }
+}
+
+impl From<Vec<SampleSource>> for SourceRegistrySnapshot {
+    fn from(sources: Vec<SampleSource>) -> Self {
+        Self::new(sources)
+    }
+}
+
+/// Lifecycle state visible at the global-library writer boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GlobalLibraryWriterStatus {
+    /// The owner thread has not completed profile-owned database initialization.
+    Initializing,
+    /// The owner has one initialized writable library database connection.
+    Available,
+    /// Initialization failed and this participant will not admit commands.
+    Unavailable {
+        /// Reason that the participant is unavailable.
+        reason: GlobalLibraryWriterUnavailable,
+    },
+    /// Shutdown has stopped new command admission and is draining accepted commands.
+    Closing,
+    /// The writer has closed its library database connection and worker thread.
+    Closed,
+}
+
+/// Fail-closed reasons retained by the global-library owner.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GlobalLibraryWriterUnavailable {
+    /// The acquired profile root or lock entry no longer names the owned object.
+    ProfileOwnershipChanged {
+        /// Profile root whose ownership boundary changed.
+        path: PathBuf,
+        /// Stable profile-boundary failure description.
+        reason: String,
+    },
+    /// The library database could not be initialized or became unusable.
+    DatabaseUnavailable {
+        /// Stable database failure description.
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for GlobalLibraryWriterUnavailable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProfileOwnershipChanged { path, reason } => write!(
+                formatter,
+                "profile ownership changed at {}: {reason}",
+                path.display()
+            ),
+            Self::DatabaseUnavailable { reason } => {
+                write!(formatter, "global library database unavailable: {reason}")
+            }
+        }
+    }
+}
+
+/// Nonblocking command-admission result for the global-library owner.
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+pub enum GlobalLibraryWriterQueueError {
+    /// The owner is still applying schema and migrations.
+    #[error("global library writer is initializing")]
+    Initializing,
+    /// The fixed-capacity owner queue is full.
+    #[error("global library writer queue is full")]
+    Full,
+    /// Initialization failed or the owner is otherwise unavailable.
+    #[error("global library writer is unavailable: {0}")]
+    Unavailable(GlobalLibraryWriterUnavailable),
+    /// The owner is closing or has already closed.
+    #[error("global library writer is closed")]
+    Closed,
+}
+
+/// Failure to start a profile-owned global-library worker.
+#[derive(Debug, Error)]
+pub enum GlobalLibraryWriterStartError {
+    /// The supplied profile capability was no longer valid before handoff.
+    #[error(transparent)]
+    ProfileOwnership(#[from] ProfileOwnershipError),
+    /// The operating system rejected creation of the owner thread.
+    #[error("failed to start global library writer thread: {0}")]
+    ThreadSpawn(#[source] std::io::Error),
+}
+
+enum WriterCommand {
+    LoadSourceRegistry {
+        result: SyncSender<Result<SourceRegistrySnapshot, LibraryError>>,
+    },
+    ReplaceSourceRegistry {
+        snapshot: SourceRegistrySnapshot,
+        result: SyncSender<Result<(), LibraryError>>,
+    },
+}
+
+/// Profile-owned asynchronous writer for `library.db`.
+///
+/// The handle contains only typed command and lifecycle state. The writable SQLite connection
+/// remains on one owner thread for the handle's lifetime and is never exposed to callers.
+pub struct GlobalLibraryWriter {
+    commands: Mutex<Option<SyncSender<WriterCommand>>>,
+    admission_gate: Arc<Mutex<()>>,
+    lifecycle: Arc<std::sync::atomic::AtomicU8>,
+    unavailable: Arc<Mutex<Option<GlobalLibraryWriterUnavailable>>>,
+    worker: Option<JoinHandle<()>>,
+    #[cfg(test)]
+    blocked_receiver: Option<Receiver<WriterCommand>>,
+}
+
+impl GlobalLibraryWriter {
+    /// Start an owner using a clone of an already-acquired profile capability.
+    ///
+    /// Cloning the capability duplicates its retained descriptors without acquiring a second
+    /// profile lock. The supplied guard remains owned by its caller until this writer is shut
+    /// down, which lets a profile owner coordinate release order explicitly.
+    pub fn start(
+        profile_guard: &WritableProfileGuard,
+    ) -> Result<Self, GlobalLibraryWriterStartError> {
+        Self::start_inner(profile_guard, None)
+    }
+
+    fn start_inner(
+        profile_guard: &WritableProfileGuard,
+        initialization_gate: Option<Arc<std::sync::Barrier>>,
+    ) -> Result<Self, GlobalLibraryWriterStartError> {
+        let worker_profile_guard = profile_guard.try_clone()?;
+        let (commands, command_rx) = mpsc::sync_channel(GLOBAL_LIBRARY_WRITER_COMMAND_CAPACITY);
+        let lifecycle = Arc::new(std::sync::atomic::AtomicU8::new(
+            WriterLifecycle::Initializing as u8,
+        ));
+        let worker_lifecycle = Arc::clone(&lifecycle);
+        let unavailable = Arc::new(Mutex::new(None));
+        let worker_unavailable = Arc::clone(&unavailable);
+        let admission_gate = Arc::new(Mutex::new(()));
+        let worker_admission_gate = Arc::clone(&admission_gate);
+        let worker = thread::Builder::new()
+            .name(String::from("wavecrate-global-library-writer"))
+            .spawn(move || {
+                run_owner(
+                    worker_profile_guard,
+                    command_rx,
+                    worker_lifecycle,
+                    worker_unavailable,
+                    initialization_gate,
+                    worker_admission_gate,
+                );
+            })
+            .map_err(GlobalLibraryWriterStartError::ThreadSpawn)?;
+
+        Ok(Self {
+            commands: Mutex::new(Some(commands)),
+            admission_gate,
+            lifecycle,
+            unavailable,
+            worker: Some(worker),
+            #[cfg(test)]
+            blocked_receiver: None,
+        })
+    }
+
+    #[cfg(test)]
+    fn start_with_initialization_gate_for_test(
+        profile_guard: &WritableProfileGuard,
+    ) -> (Self, Arc<std::sync::Barrier>) {
+        let gate = Arc::new(std::sync::Barrier::new(2));
+        let writer =
+            Self::start_inner(profile_guard, Some(Arc::clone(&gate))).expect("writer start");
+        (writer, gate)
+    }
+
+    #[cfg(test)]
+    fn disabled() -> Self {
+        let (commands, blocked_receiver) =
+            mpsc::sync_channel(GLOBAL_LIBRARY_WRITER_COMMAND_CAPACITY);
+        Self {
+            commands: Mutex::new(Some(commands)),
+            admission_gate: Arc::new(Mutex::new(())),
+            lifecycle: Arc::new(std::sync::atomic::AtomicU8::new(
+                WriterLifecycle::Available as u8,
+            )),
+            unavailable: Arc::new(Mutex::new(None)),
+            worker: None,
+            blocked_receiver: Some(blocked_receiver),
+        }
+    }
+
+    /// Return the current owner lifecycle without waiting for initialization or I/O.
+    pub fn status(&self) -> GlobalLibraryWriterStatus {
+        match WriterLifecycle::from_u8(self.lifecycle.load(std::sync::atomic::Ordering::Acquire)) {
+            WriterLifecycle::Initializing => GlobalLibraryWriterStatus::Initializing,
+            WriterLifecycle::Available => GlobalLibraryWriterStatus::Available,
+            WriterLifecycle::Unavailable => GlobalLibraryWriterStatus::Unavailable {
+                reason: self
+                    .unavailable
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .clone()
+                    .unwrap_or_else(|| GlobalLibraryWriterUnavailable::DatabaseUnavailable {
+                        reason: String::from("global library writer is unavailable"),
+                    }),
+            },
+            WriterLifecycle::Closing => GlobalLibraryWriterStatus::Closing,
+            WriterLifecycle::Closed => GlobalLibraryWriterStatus::Closed,
+        }
+    }
+
+    /// Return the retained reason for an initialization or profile-boundary failure, if any.
+    pub fn unavailable_reason(&self) -> Option<GlobalLibraryWriterUnavailable> {
+        self.unavailable
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    /// Queue a load of the immutable source-registry snapshot.
+    pub fn load_source_registry_snapshot(
+        &self,
+    ) -> Result<Receiver<Result<SourceRegistrySnapshot, LibraryError>>, GlobalLibraryWriterQueueError>
+    {
+        self.ensure_available()?;
+        let (result_tx, result_rx) = mpsc::sync_channel(1);
+        self.send(WriterCommand::LoadSourceRegistry { result: result_tx })?;
+        Ok(result_rx)
+    }
+
+    /// Queue an idempotent replacement of the source-registry snapshot.
+    pub fn replace_source_registry(
+        &self,
+        snapshot: SourceRegistrySnapshot,
+    ) -> Result<Receiver<Result<(), LibraryError>>, GlobalLibraryWriterQueueError> {
+        self.ensure_available()?;
+        let (result_tx, result_rx) = mpsc::sync_channel(1);
+        self.send(WriterCommand::ReplaceSourceRegistry {
+            snapshot,
+            result: result_tx,
+        })?;
+        Ok(result_rx)
+    }
+
+    /// Stop new admission, drain accepted commands, close `library.db`, and join the owner.
+    pub fn shutdown(&mut self) -> bool {
+        let previous = self.lifecycle.swap(
+            WriterLifecycle::Closing as u8,
+            std::sync::atomic::Ordering::AcqRel,
+        );
+        let _admission = self
+            .admission_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let sender = self
+            .commands
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        drop(sender);
+        #[cfg(test)]
+        self.blocked_receiver.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+        self.lifecycle.store(
+            WriterLifecycle::Closed as u8,
+            std::sync::atomic::Ordering::Release,
+        );
+        WriterLifecycle::from_u8(previous) != WriterLifecycle::Closed
+    }
+
+    fn ensure_available(&self) -> Result<(), GlobalLibraryWriterQueueError> {
+        match WriterLifecycle::from_u8(self.lifecycle.load(std::sync::atomic::Ordering::Acquire)) {
+            WriterLifecycle::Initializing => Err(GlobalLibraryWriterQueueError::Initializing),
+            WriterLifecycle::Available => Ok(()),
+            WriterLifecycle::Unavailable => Err(GlobalLibraryWriterQueueError::Unavailable(
+                self.unavailable
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .clone()
+                    .unwrap_or_else(|| GlobalLibraryWriterUnavailable::DatabaseUnavailable {
+                        reason: String::from("global library writer is unavailable"),
+                    }),
+            )),
+            WriterLifecycle::Closing | WriterLifecycle::Closed => {
+                Err(GlobalLibraryWriterQueueError::Closed)
+            }
+        }
+    }
+
+    fn send(&self, command: WriterCommand) -> Result<(), GlobalLibraryWriterQueueError> {
+        let _admission = self
+            .admission_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.ensure_available()?;
+        let sender = self
+            .commands
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .cloned()
+            .ok_or(GlobalLibraryWriterQueueError::Closed)?;
+        sender.try_send(command).map_err(|error| match error {
+            TrySendError::Full(_) => GlobalLibraryWriterQueueError::Full,
+            TrySendError::Disconnected(_) => GlobalLibraryWriterQueueError::Closed,
+        })
+    }
+}
+
+impl Drop for GlobalLibraryWriter {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WriterLifecycle {
+    Initializing = 0,
+    Available = 1,
+    Unavailable = 2,
+    Closing = 3,
+    Closed = 4,
+}
+
+impl WriterLifecycle {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Available,
+            2 => Self::Unavailable,
+            3 => Self::Closing,
+            4 => Self::Closed,
+            _ => Self::Initializing,
+        }
+    }
+}
+
+fn run_owner(
+    profile_guard: WritableProfileGuard,
+    command_rx: Receiver<WriterCommand>,
+    lifecycle: Arc<std::sync::atomic::AtomicU8>,
+    unavailable: Arc<Mutex<Option<GlobalLibraryWriterUnavailable>>>,
+    initialization_gate: Option<Arc<std::sync::Barrier>>,
+    admission_gate: Arc<Mutex<()>>,
+) {
+    if let Some(initialization_gate) = initialization_gate {
+        initialization_gate.wait();
+    }
+    let mut database = match LibraryDatabase::open_for_profile_guard(&profile_guard) {
+        Ok(database) => database,
+        Err(error) => {
+            let reason = unavailable_from_library_error(&error);
+            *unavailable
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(reason);
+            lifecycle.store(
+                if matches!(error, LibraryError::ProfileOwnership(_)) {
+                    WriterLifecycle::Closed as u8
+                } else {
+                    WriterLifecycle::Unavailable as u8
+                },
+                std::sync::atomic::Ordering::Release,
+            );
+            return;
+        }
+    };
+
+    if let Err(error) = profile_guard.validate_current() {
+        close_after_profile_change(
+            &command_rx,
+            &lifecycle,
+            &unavailable,
+            &admission_gate,
+            error,
+        );
+        return;
+    }
+    lifecycle.store(
+        WriterLifecycle::Available as u8,
+        std::sync::atomic::Ordering::Release,
+    );
+
+    loop {
+        if let Err(error) = profile_guard.validate_current() {
+            close_after_profile_change(
+                &command_rx,
+                &lifecycle,
+                &unavailable,
+                &admission_gate,
+                error,
+            );
+            break;
+        }
+        let command = match command_rx.recv_timeout(OWNER_POLL_INTERVAL) {
+            Ok(command) => command,
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+        if let Err(error) = profile_guard.validate_current() {
+            reject_after_profile_change(command, &error);
+            close_after_profile_change(
+                &command_rx,
+                &lifecycle,
+                &unavailable,
+                &admission_gate,
+                error,
+            );
+            break;
+        }
+
+        match command {
+            WriterCommand::LoadSourceRegistry { result } => {
+                let command_result = database.load_source_registry();
+                let _ = result.send(command_result);
+            }
+            WriterCommand::ReplaceSourceRegistry { snapshot, result } => {
+                let command_result = database.replace_source_registry(&snapshot);
+                let _ = result.send(command_result);
+            }
+        }
+
+        if let Err(error) = profile_guard.validate_current() {
+            close_after_profile_change(
+                &command_rx,
+                &lifecycle,
+                &unavailable,
+                &admission_gate,
+                error,
+            );
+            break;
+        }
+    }
+
+    drop(database);
+    lifecycle.store(
+        WriterLifecycle::Closed as u8,
+        std::sync::atomic::Ordering::Release,
+    );
+}
+
+fn close_after_profile_change(
+    command_rx: &Receiver<WriterCommand>,
+    lifecycle: &Arc<std::sync::atomic::AtomicU8>,
+    unavailable: &Arc<Mutex<Option<GlobalLibraryWriterUnavailable>>>,
+    admission_gate: &Arc<Mutex<()>>,
+    error: ProfileOwnershipError,
+) {
+    let _admission = admission_gate
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let reason = unavailable_from_profile_error(&error);
+    *unavailable
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(reason.clone());
+    lifecycle.store(
+        WriterLifecycle::Closed as u8,
+        std::sync::atomic::Ordering::Release,
+    );
+    reject_remaining_profile_change(command_rx, &error);
+}
+
+fn reject_after_profile_change(command: WriterCommand, error: &ProfileOwnershipError) {
+    let library_error = LibraryError::ProfileOwnershipChanged {
+        path: profile_error_path(error),
+        reason: error.to_string(),
+    };
+    send_command_error(command, library_error);
+}
+
+fn reject_remaining_profile_change(
+    command_rx: &Receiver<WriterCommand>,
+    error: &ProfileOwnershipError,
+) {
+    while let Ok(command) = command_rx.try_recv() {
+        reject_after_profile_change(command, error);
+    }
+}
+
+fn send_command_error(command: WriterCommand, error: LibraryError) {
+    match command {
+        WriterCommand::LoadSourceRegistry { result } => {
+            let _ = result.send(Err(error));
+        }
+        WriterCommand::ReplaceSourceRegistry { result, .. } => {
+            let _ = result.send(Err(error));
+        }
+    }
+}
+
+fn profile_error_path(error: &ProfileOwnershipError) -> PathBuf {
+    match error {
+        ProfileOwnershipError::ProfileRootReplaced { path }
+        | ProfileOwnershipError::ProfileOwnerLockReplaced { path }
+        | ProfileOwnershipError::ProfileOwnedByAnotherProcess { path }
+        | ProfileOwnershipError::Io { path, .. }
+        | ProfileOwnershipError::NotRegularFile { path }
+        | ProfileOwnershipError::IdentityUnavailable { path }
+        | ProfileOwnershipError::Unsupported { path } => path.clone(),
+        ProfileOwnershipError::AppDirectory(_) => PathBuf::new(),
+    }
+}
+
+fn unavailable_from_profile_error(error: &ProfileOwnershipError) -> GlobalLibraryWriterUnavailable {
+    GlobalLibraryWriterUnavailable::ProfileOwnershipChanged {
+        path: profile_error_path(error),
+        reason: error.to_string(),
+    }
+}
+
+fn unavailable_from_library_error(error: &LibraryError) -> GlobalLibraryWriterUnavailable {
+    match error {
+        LibraryError::ProfileOwnership(error) => unavailable_from_profile_error(error),
+        LibraryError::ProfileOwnershipChanged { path, reason } => {
+            GlobalLibraryWriterUnavailable::ProfileOwnershipChanged {
+                path: path.clone(),
+                reason: reason.clone(),
+            }
+        }
+        error => GlobalLibraryWriterUnavailable::DatabaseUnavailable {
+            reason: error.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_dirs::{ConfigBaseGuard, PersistenceProfileGuard};
+    use crate::sample_sources::{SourceId, SourceRole};
+    use crate::test_runtime::TestRuntimeGuard;
+    use rusqlite::Connection;
+    use std::fs;
+    use std::path::Path;
+    use std::thread;
+    use std::time::{Duration, Instant};
+    use tempfile::tempdir;
+
+    fn wait_until_available(writer: &GlobalLibraryWriter) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            match writer.status() {
+                GlobalLibraryWriterStatus::Available => return,
+                GlobalLibraryWriterStatus::Unavailable { reason } => {
+                    panic!("writer unavailable: {reason}")
+                }
+                status if Instant::now() >= deadline => panic!("writer status: {status:?}"),
+                _ => thread::sleep(Duration::from_millis(5)),
+            }
+        }
+    }
+
+    fn wait_until_closed(writer: &GlobalLibraryWriter) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !matches!(writer.status(), GlobalLibraryWriterStatus::Closed) {
+            assert!(Instant::now() < deadline, "writer did not close");
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    fn source(root: &Path, id: &str) -> SampleSource {
+        SampleSource {
+            id: SourceId::from_string(id),
+            root: root.to_path_buf(),
+            role: SourceRole::Normal,
+            metadata_storage: crate::sample_sources::SourceMetadataStorage::SourceFolder,
+            primary_import_folder: crate::sample_sources::default_primary_import_folder(),
+        }
+    }
+
+    fn start_writer(
+        base: &tempfile::TempDir,
+        name: &str,
+    ) -> (
+        ConfigBaseGuard,
+        PersistenceProfileGuard,
+        WritableProfileGuard,
+        GlobalLibraryWriter,
+    ) {
+        let base_path = std::fs::canonicalize(base.path()).expect("canonical test base");
+        let base_guard = ConfigBaseGuard::set(base_path);
+        let profile_guard = PersistenceProfileGuard::named(name);
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let writer = GlobalLibraryWriter::start(&writable_guard).expect("writer start");
+        (base_guard, profile_guard, writable_guard, writer)
+    }
+
+    #[test]
+    fn queue_admission_distinguishes_initializing_and_full() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let base_guard =
+            ConfigBaseGuard::set(std::fs::canonicalize(temp.path()).expect("canonical test base"));
+        let profile_guard = PersistenceProfileGuard::named("queue");
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let (writer, gate) =
+            GlobalLibraryWriter::start_with_initialization_gate_for_test(&writable_guard);
+        assert_eq!(writer.status(), GlobalLibraryWriterStatus::Initializing);
+        assert!(matches!(
+            writer.load_source_registry_snapshot(),
+            Err(GlobalLibraryWriterQueueError::Initializing)
+        ));
+        gate.wait();
+        wait_until_available(&writer);
+        drop(writer);
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[test]
+    fn queue_admission_is_nonblocking_and_reports_full() {
+        let writer = GlobalLibraryWriter::disabled();
+        for _ in 0..GLOBAL_LIBRARY_WRITER_COMMAND_CAPACITY {
+            writer
+                .load_source_registry_snapshot()
+                .expect("bounded queue admission");
+        }
+        assert!(matches!(
+            writer.load_source_registry_snapshot(),
+            Err(GlobalLibraryWriterQueueError::Full)
+        ));
+    }
+
+    #[test]
+    fn source_registry_snapshot_owns_an_immutable_copy() {
+        let temp = tempdir().expect("base");
+        let mut original = source(&temp.path().join("original"), "source");
+        let snapshot = SourceRegistrySnapshot::new(vec![original.clone()]);
+        original.root = temp.path().join("mutated");
+
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot.as_slice()[0].root, temp.path().join("original"));
+    }
+
+    #[test]
+    fn writer_keeps_shared_profile_ownership_after_original_guard_is_dropped() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let base_path = std::fs::canonicalize(temp.path()).expect("canonical test base");
+        let base_guard = ConfigBaseGuard::set(base_path);
+        let profile_guard = PersistenceProfileGuard::named("shared-ownership");
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let mut writer = GlobalLibraryWriter::start(&writable_guard).expect("writer start");
+        wait_until_available(&writer);
+        drop(writable_guard);
+
+        assert!(matches!(
+            WritableProfileGuard::acquire_current(),
+            Err(crate::app_dirs::ProfileOwnershipError::ProfileOwnedByAnotherProcess { .. })
+        ));
+        assert!(writer.shutdown());
+        let replacement = WritableProfileGuard::acquire_current().expect("released ownership");
+        drop(replacement);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[test]
+    fn one_owner_connection_serves_repeated_commands_and_shutdown_drains() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let (base_guard, profile_guard, writable_guard, mut writer) =
+            start_writer(&temp, "one-connection");
+        let _ = (&base_guard, &profile_guard);
+        wait_until_available(&writer);
+        let root = temp.path().join("source");
+        let snapshot = SourceRegistrySnapshot::new(vec![source(&root, "source-1")]);
+        for _ in 0..3 {
+            writer
+                .replace_source_registry(snapshot.clone())
+                .expect("replace admission")
+                .recv_timeout(Duration::from_secs(2))
+                .expect("replace result")
+                .expect("replace success");
+        }
+        let loaded = writer
+            .load_source_registry_snapshot()
+            .expect("load admission")
+            .recv_timeout(Duration::from_secs(2))
+            .expect("load result")
+            .expect("load success");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded.as_slice()[0].id.as_str(), "source-1");
+        assert_eq!(
+            super::super::connection::test_open_count(
+                &writable_guard
+                    .profile_root()
+                    .join(super::super::LIBRARY_DB_FILE_NAME)
+            ),
+            1
+        );
+        assert!(writer.shutdown());
+        assert!(matches!(writer.status(), GlobalLibraryWriterStatus::Closed));
+    }
+
+    #[test]
+    fn failed_replacement_rolls_back_active_sources() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let base_path = std::fs::canonicalize(temp.path()).expect("canonical test base");
+        let base_guard = ConfigBaseGuard::set(base_path);
+        let profile_guard = PersistenceProfileGuard::named("rollback");
+        let original = source(&temp.path().join("original"), "original");
+        crate::sample_sources::library::save(&crate::sample_sources::library::LibraryState {
+            sources: vec![original.clone()],
+        })
+        .expect("initial source");
+        let connection = crate::sample_sources::library::open_connection().expect("fixture DB");
+        connection
+            .execute_batch(
+                "CREATE TRIGGER fail_known_source_update
+                 BEFORE UPDATE OF value ON metadata
+                 WHEN OLD.key = 'known_sources_v1'
+                 BEGIN SELECT RAISE(FAIL, 'rollback fixture'); END;",
+            )
+            .expect("rollback trigger");
+        drop(connection);
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let mut writer = GlobalLibraryWriter::start(&writable_guard).expect("writer start");
+        wait_until_available(&writer);
+        let replacement = SourceRegistrySnapshot::new(vec![source(
+            &temp.path().join("replacement"),
+            "replacement",
+        )]);
+        assert!(matches!(
+            writer
+                .replace_source_registry(replacement)
+                .expect("replace admission")
+                .recv_timeout(Duration::from_secs(2))
+                .expect("replace result"),
+            Err(LibraryError::Sql(_))
+        ));
+        let loaded = writer
+            .load_source_registry_snapshot()
+            .expect("load admission")
+            .recv_timeout(Duration::from_secs(2))
+            .expect("load result")
+            .expect("load success");
+        assert_eq!(loaded.as_slice()[0].id.as_str(), original.id.as_str());
+        assert!(writer.shutdown());
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[test]
+    fn source_registry_and_known_sources_survive_writer_reopen() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let base_path = std::fs::canonicalize(temp.path()).expect("canonical test base");
+        let base_guard = ConfigBaseGuard::set(base_path);
+        let profile_guard = PersistenceProfileGuard::named("reopen");
+        let root = temp.path().join("persistent-source");
+        let retained = source(&root, "persistent-id");
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let mut writer = GlobalLibraryWriter::start(&writable_guard).expect("writer start");
+        wait_until_available(&writer);
+        writer
+            .replace_source_registry(SourceRegistrySnapshot::new(vec![retained.clone()]))
+            .expect("initial replace admission")
+            .recv_timeout(Duration::from_secs(2))
+            .expect("initial replace result")
+            .expect("initial replace");
+        assert!(writer.shutdown());
+        drop(writable_guard);
+
+        let writable_guard = WritableProfileGuard::acquire_current().expect("reopen ownership");
+        let mut writer = GlobalLibraryWriter::start(&writable_guard).expect("reopen writer");
+        wait_until_available(&writer);
+        let loaded = writer
+            .load_source_registry_snapshot()
+            .expect("reopen load admission")
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reopen load result")
+            .expect("reopen load");
+        assert_eq!(loaded.as_slice()[0].id.as_str(), retained.id.as_str());
+        writer
+            .replace_source_registry(SourceRegistrySnapshot::new(Vec::new()))
+            .expect("remove admission")
+            .recv_timeout(Duration::from_secs(2))
+            .expect("remove result")
+            .expect("remove");
+        assert!(writer.shutdown());
+        drop(writable_guard);
+
+        assert_eq!(
+            crate::sample_sources::library::lookup_retained_source_for_root(&root)
+                .expect("retained source lookup")
+                .expect("retained source")
+                .id
+                .as_str(),
+            retained.id.as_str()
+        );
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[test]
+    fn corrupt_database_is_unavailable_without_repeated_open_attempts() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let base_guard =
+            ConfigBaseGuard::set(std::fs::canonicalize(temp.path()).expect("canonical test base"));
+        let profile_guard = PersistenceProfileGuard::named("corrupt");
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let path = writable_guard
+            .profile_root()
+            .join(super::super::LIBRARY_DB_FILE_NAME);
+        fs::write(&path, b"not sqlite").expect("corrupt fixture");
+        let writer = GlobalLibraryWriter::start(&writable_guard).expect("writer start");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !matches!(
+            writer.status(),
+            GlobalLibraryWriterStatus::Unavailable { .. }
+        ) {
+            assert!(
+                Instant::now() < deadline,
+                "writer did not become unavailable"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert!(matches!(
+            writer.load_source_registry_snapshot(),
+            Err(GlobalLibraryWriterQueueError::Unavailable(
+                GlobalLibraryWriterUnavailable::DatabaseUnavailable { .. }
+            ))
+        ));
+        assert_eq!(super::super::connection::test_open_count(&path), 1);
+        drop(writer);
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[test]
+    fn profile_replacement_closes_owner_and_rejects_later_commands() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let (base_guard, profile_guard, writable_guard, mut writer) =
+            start_writer(&temp, "replacement");
+        let root = writable_guard.profile_root().to_path_buf();
+        wait_until_available(&writer);
+        let displaced = temp.path().join("displaced-profile");
+        fs::rename(&root, &displaced).expect("displace profile");
+        fs::create_dir(&root).expect("replacement profile");
+        wait_until_closed(&writer);
+        assert!(matches!(
+            writer.load_source_registry_snapshot(),
+            Err(GlobalLibraryWriterQueueError::Closed)
+        ));
+        assert!(matches!(
+            writer.unavailable_reason(),
+            Some(GlobalLibraryWriterUnavailable::ProfileOwnershipChanged { .. })
+        ));
+        let _ = writer.shutdown();
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn profile_lock_replacement_closes_owner_and_rejects_later_commands() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let (base_guard, profile_guard, writable_guard, mut writer) =
+            start_writer(&temp, "lock-replacement");
+        let root = writable_guard.profile_root().to_path_buf();
+        wait_until_available(&writer);
+        let lock_path = root.join("profile-owner.lock");
+        let displaced = root.join("profile-owner.lock.old");
+        fs::rename(&lock_path, &displaced).expect("displace profile lock");
+        fs::write(&lock_path, b"replacement").expect("replacement profile lock");
+        wait_until_closed(&writer);
+        assert!(matches!(
+            writer.load_source_registry_snapshot(),
+            Err(GlobalLibraryWriterQueueError::Closed)
+        ));
+        assert!(matches!(
+            writer.unavailable_reason(),
+            Some(GlobalLibraryWriterUnavailable::ProfileOwnershipChanged { path, .. })
+                if path == lock_path
+        ));
+        let _ = writer.shutdown();
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[test]
+    fn shutdown_closes_database_before_guard_can_be_released() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let (base_guard, profile_guard, writable_guard, mut writer) =
+            start_writer(&temp, "shutdown");
+        wait_until_available(&writer);
+        let snapshot = SourceRegistrySnapshot::new(vec![source(&temp.path().join("source"), "id")]);
+        let result = writer
+            .replace_source_registry(snapshot)
+            .expect("replace admission");
+        assert!(writer.shutdown());
+        assert!(
+            result
+                .recv_timeout(Duration::from_secs(2))
+                .expect("drained command")
+                .is_ok()
+        );
+        assert!(matches!(writer.status(), GlobalLibraryWriterStatus::Closed));
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+        let _ = Connection::open(
+            temp.path()
+                .join(".wavecrate")
+                .join("profiles")
+                .join("shutdown")
+                .join("library.db"),
+        )
+        .expect("closed database is reopenable");
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/library/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/owner.rs
@@ -380,15 +380,16 @@ impl GlobalLibraryWriter {
             WriterLifecycle::Closing as u8,
             std::sync::atomic::Ordering::AcqRel,
         );
-        let _admission = self
-            .admission_gate
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let sender = self
-            .commands
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take();
+        let sender = {
+            let _admission = self
+                .admission_gate
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            self.commands
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+        };
         drop(sender);
         #[cfg(test)]
         self.blocked_receiver.take();

--- a/crates/wavecrate-library/src/sample_sources/library/owner.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/owner.rs
@@ -145,6 +145,49 @@ enum WriterCommand {
     },
 }
 
+enum WriterReply {
+    Load {
+        result: SyncSender<Result<SourceRegistrySnapshot, LibraryError>>,
+        value: Result<SourceRegistrySnapshot, LibraryError>,
+    },
+    Replace {
+        result: SyncSender<Result<(), LibraryError>>,
+        value: Result<(), LibraryError>,
+    },
+}
+
+impl WriterReply {
+    fn send(self) {
+        match self {
+            Self::Load { result, value } => {
+                let _ = result.send(value);
+            }
+            Self::Replace { result, value } => {
+                let _ = result.send(value);
+            }
+        }
+    }
+
+    fn send_error(self, error: LibraryError) {
+        match self {
+            Self::Load { result, .. } => {
+                let _ = result.send(Err(error));
+            }
+            Self::Replace { result, .. } => {
+                let _ = result.send(Err(error));
+            }
+        }
+    }
+}
+
+struct OwnerHooks {
+    initialization_gate: Option<Arc<std::sync::Barrier>>,
+    #[cfg(test)]
+    binding_open_gate: Option<(Arc<std::sync::Barrier>, Arc<std::sync::Barrier>)>,
+    #[cfg(test)]
+    post_command_gate: Option<(Arc<std::sync::Barrier>, Arc<std::sync::Barrier>)>,
+}
+
 /// Profile-owned asynchronous writer for `library.db`.
 ///
 /// The handle contains only typed command and lifecycle state. The writable SQLite connection
@@ -168,12 +211,14 @@ impl GlobalLibraryWriter {
     pub fn start(
         profile_guard: &WritableProfileGuard,
     ) -> Result<Self, GlobalLibraryWriterStartError> {
-        Self::start_inner(profile_guard, None)
+        Self::start_inner(profile_guard, None, None, None)
     }
 
     fn start_inner(
         profile_guard: &WritableProfileGuard,
         initialization_gate: Option<Arc<std::sync::Barrier>>,
+        binding_open_gate: Option<(Arc<std::sync::Barrier>, Arc<std::sync::Barrier>)>,
+        post_command_gate: Option<(Arc<std::sync::Barrier>, Arc<std::sync::Barrier>)>,
     ) -> Result<Self, GlobalLibraryWriterStartError> {
         let worker_profile_guard = profile_guard.try_clone()?;
         let (commands, command_rx) = mpsc::sync_channel(GLOBAL_LIBRARY_WRITER_COMMAND_CAPACITY);
@@ -185,6 +230,8 @@ impl GlobalLibraryWriter {
         let worker_unavailable = Arc::clone(&unavailable);
         let admission_gate = Arc::new(Mutex::new(()));
         let worker_admission_gate = Arc::clone(&admission_gate);
+        #[cfg(not(test))]
+        let _ = (binding_open_gate, post_command_gate);
         let worker = thread::Builder::new()
             .name(String::from("wavecrate-global-library-writer"))
             .spawn(move || {
@@ -193,7 +240,13 @@ impl GlobalLibraryWriter {
                     command_rx,
                     worker_lifecycle,
                     worker_unavailable,
-                    initialization_gate,
+                    OwnerHooks {
+                        initialization_gate,
+                        #[cfg(test)]
+                        binding_open_gate,
+                        #[cfg(test)]
+                        post_command_gate,
+                    },
                     worker_admission_gate,
                 );
             })
@@ -215,9 +268,41 @@ impl GlobalLibraryWriter {
         profile_guard: &WritableProfileGuard,
     ) -> (Self, Arc<std::sync::Barrier>) {
         let gate = Arc::new(std::sync::Barrier::new(2));
-        let writer =
-            Self::start_inner(profile_guard, Some(Arc::clone(&gate))).expect("writer start");
+        let writer = Self::start_inner(profile_guard, Some(Arc::clone(&gate)), None, None)
+            .expect("writer start");
         (writer, gate)
+    }
+
+    #[cfg(test)]
+    fn start_with_binding_open_gate_for_test(
+        profile_guard: &WritableProfileGuard,
+    ) -> (Self, Arc<std::sync::Barrier>, Arc<std::sync::Barrier>) {
+        let ready = Arc::new(std::sync::Barrier::new(2));
+        let release = Arc::new(std::sync::Barrier::new(2));
+        let writer = Self::start_inner(
+            profile_guard,
+            None,
+            Some((Arc::clone(&ready), Arc::clone(&release))),
+            None,
+        )
+        .expect("writer start");
+        (writer, ready, release)
+    }
+
+    #[cfg(test)]
+    fn start_with_post_command_gate_for_test(
+        profile_guard: &WritableProfileGuard,
+    ) -> (Self, Arc<std::sync::Barrier>, Arc<std::sync::Barrier>) {
+        let ready = Arc::new(std::sync::Barrier::new(2));
+        let release = Arc::new(std::sync::Barrier::new(2));
+        let writer = Self::start_inner(
+            profile_guard,
+            None,
+            None,
+            Some((Arc::clone(&ready), Arc::clone(&release))),
+        )
+        .expect("writer start");
+        (writer, ready, release)
     }
 
     #[cfg(test)]
@@ -389,21 +474,30 @@ fn run_owner(
     command_rx: Receiver<WriterCommand>,
     lifecycle: Arc<std::sync::atomic::AtomicU8>,
     unavailable: Arc<Mutex<Option<GlobalLibraryWriterUnavailable>>>,
-    initialization_gate: Option<Arc<std::sync::Barrier>>,
+    hooks: OwnerHooks,
     admission_gate: Arc<Mutex<()>>,
 ) {
-    if let Some(initialization_gate) = initialization_gate {
+    if let Some(initialization_gate) = hooks.initialization_gate {
         initialization_gate.wait();
     }
-    let mut database = match LibraryDatabase::open_for_profile_guard(&profile_guard) {
+    #[cfg(test)]
+    let open_result =
+        LibraryDatabase::open_for_profile_guard(&profile_guard, hooks.binding_open_gate);
+    #[cfg(not(test))]
+    let open_result = { LibraryDatabase::open_for_profile_guard(&profile_guard) };
+    let mut database = match open_result {
         Ok(database) => database,
         Err(error) => {
-            let reason = unavailable_from_library_error(&error);
+            let profile_error = profile_guard.validate_current().err();
+            let reason = profile_error
+                .as_ref()
+                .map(unavailable_from_profile_error)
+                .unwrap_or_else(|| unavailable_from_library_error(&error));
             *unavailable
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(reason);
             lifecycle.store(
-                if matches!(error, LibraryError::ProfileOwnership(_)) {
+                if profile_error.is_some() || matches!(error, LibraryError::ProfileOwnership(_)) {
                     WriterLifecycle::Closed as u8
                 } else {
                     WriterLifecycle::Unavailable as u8
@@ -414,7 +508,7 @@ fn run_owner(
         }
     };
 
-    if let Err(error) = profile_guard.validate_current() {
+    if let Err(error) = database.validate_profile_guard(&profile_guard) {
         close_after_profile_change(
             &command_rx,
             &lifecycle,
@@ -430,7 +524,7 @@ fn run_owner(
     );
 
     loop {
-        if let Err(error) = profile_guard.validate_current() {
+        if let Err(error) = database.validate_profile_guard(&profile_guard) {
             close_after_profile_change(
                 &command_rx,
                 &lifecycle,
@@ -445,7 +539,7 @@ fn run_owner(
             Err(mpsc::RecvTimeoutError::Timeout) => continue,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         };
-        if let Err(error) = profile_guard.validate_current() {
+        if let Err(error) = database.validate_profile_guard(&profile_guard) {
             reject_after_profile_change(command, &error);
             close_after_profile_change(
                 &command_rx,
@@ -457,18 +551,16 @@ fn run_owner(
             break;
         }
 
-        match command {
-            WriterCommand::LoadSourceRegistry { result } => {
-                let command_result = database.load_source_registry();
-                let _ = result.send(command_result);
-            }
-            WriterCommand::ReplaceSourceRegistry { snapshot, result } => {
-                let command_result = database.replace_source_registry(&snapshot);
-                let _ = result.send(command_result);
-            }
+        let reply = execute_command(command, &mut database);
+
+        #[cfg(test)]
+        if let Some((ready, release)) = hooks.post_command_gate.as_ref() {
+            ready.wait();
+            release.wait();
         }
 
-        if let Err(error) = profile_guard.validate_current() {
+        if let Err(error) = database.validate_profile_guard(&profile_guard) {
+            reply.send_error(profile_change_library_error(&error, true));
             close_after_profile_change(
                 &command_rx,
                 &lifecycle,
@@ -478,6 +570,7 @@ fn run_owner(
             );
             break;
         }
+        reply.send();
     }
 
     drop(database);
@@ -485,6 +578,19 @@ fn run_owner(
         WriterLifecycle::Closed as u8,
         std::sync::atomic::Ordering::Release,
     );
+}
+
+fn execute_command(command: WriterCommand, database: &mut LibraryDatabase) -> WriterReply {
+    match command {
+        WriterCommand::LoadSourceRegistry { result } => WriterReply::Load {
+            value: database.load_source_registry(),
+            result,
+        },
+        WriterCommand::ReplaceSourceRegistry { snapshot, result } => WriterReply::Replace {
+            value: database.replace_source_registry(&snapshot),
+            result,
+        },
+    }
 }
 
 fn close_after_profile_change(
@@ -509,11 +615,7 @@ fn close_after_profile_change(
 }
 
 fn reject_after_profile_change(command: WriterCommand, error: &ProfileOwnershipError) {
-    let library_error = LibraryError::ProfileOwnershipChanged {
-        path: profile_error_path(error),
-        reason: error.to_string(),
-    };
-    send_command_error(command, library_error);
+    send_command_error(command, profile_change_library_error(error, false));
 }
 
 fn reject_remaining_profile_change(
@@ -533,6 +635,21 @@ fn send_command_error(command: WriterCommand, error: LibraryError) {
         WriterCommand::ReplaceSourceRegistry { result, .. } => {
             let _ = result.send(Err(error));
         }
+    }
+}
+
+fn profile_change_library_error(
+    error: &ProfileOwnershipError,
+    completion_not_confirmable: bool,
+) -> LibraryError {
+    let reason = if completion_not_confirmable {
+        format!("completion not confirmable: {error}")
+    } else {
+        error.to_string()
+    };
+    LibraryError::ProfileOwnershipChanged {
+        path: profile_error_path(error),
+        reason,
     }
 }
 
@@ -882,6 +999,178 @@ mod tests {
     }
 
     #[test]
+    fn profile_owned_open_rejects_nonregular_sidecar_before_sqlite() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let base_path = std::fs::canonicalize(temp.path()).expect("canonical test base");
+        let base_guard = ConfigBaseGuard::set(base_path);
+        let profile_guard = PersistenceProfileGuard::named("sidecar-entry");
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let root = writable_guard.profile_root().to_path_buf();
+        fs::create_dir(root.join("library.db-wal")).expect("nonregular WAL fixture");
+        let db_path = root.join(super::super::LIBRARY_DB_FILE_NAME);
+        let opens_before = super::super::connection::test_open_count(&db_path);
+        let writer = GlobalLibraryWriter::start(&writable_guard).expect("writer start");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !matches!(
+            writer.status(),
+            GlobalLibraryWriterStatus::Unavailable { .. }
+        ) {
+            assert!(
+                Instant::now() < deadline,
+                "writer did not reject the nonregular sidecar"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert!(matches!(
+            writer.status(),
+            GlobalLibraryWriterStatus::Unavailable {
+                reason: GlobalLibraryWriterUnavailable::DatabaseUnavailable { reason }
+            } if reason.contains("library.db-wal")
+        ));
+        assert_eq!(
+            super::super::connection::test_open_count(&db_path),
+            opens_before
+        );
+        drop(writer);
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn profile_owned_open_rejects_database_symlink_without_following_it() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let base_path = std::fs::canonicalize(temp.path()).expect("canonical test base");
+        let base_guard = ConfigBaseGuard::set(base_path);
+        let profile_guard = PersistenceProfileGuard::named("database-symlink");
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let root = writable_guard.profile_root().to_path_buf();
+        let outside = temp.path().join("outside.db");
+        fs::write(&outside, b"outside database").expect("outside database");
+        std::os::unix::fs::symlink(&outside, root.join(super::super::LIBRARY_DB_FILE_NAME))
+            .expect("database symlink fixture");
+        let db_path = root.join(super::super::LIBRARY_DB_FILE_NAME);
+        let opens_before = super::super::connection::test_open_count(&db_path);
+        let writer = GlobalLibraryWriter::start(&writable_guard).expect("writer start");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !matches!(
+            writer.status(),
+            GlobalLibraryWriterStatus::Unavailable { .. }
+        ) {
+            assert!(
+                Instant::now() < deadline,
+                "writer did not reject the database symlink"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert!(matches!(
+            writer.status(),
+            GlobalLibraryWriterStatus::Unavailable {
+                reason: GlobalLibraryWriterUnavailable::DatabaseUnavailable { reason }
+            } if reason.contains("library.db")
+        ));
+        assert_eq!(
+            super::super::connection::test_open_count(&db_path),
+            opens_before
+        );
+        drop(writer);
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn profile_root_replacement_during_initialization_does_not_redirect_database() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let base_path = std::fs::canonicalize(temp.path()).expect("canonical test base");
+        let base_guard = ConfigBaseGuard::set(base_path);
+        let profile_guard = PersistenceProfileGuard::named("initialization-replacement");
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let root = writable_guard.profile_root().to_path_buf();
+        let (mut writer, ready, release) =
+            GlobalLibraryWriter::start_with_binding_open_gate_for_test(&writable_guard);
+
+        ready.wait();
+        let displaced = temp.path().join("initialization-replacement-old");
+        fs::rename(&root, &displaced).expect("displace original profile root");
+        fs::create_dir(&root).expect("replacement profile root");
+        release.wait();
+
+        wait_until_closed(&writer);
+        assert!(!root.join(super::super::LIBRARY_DB_FILE_NAME).exists());
+        assert!(displaced.join(super::super::LIBRARY_DB_FILE_NAME).is_file());
+        assert!(matches!(
+            writer.unavailable_reason(),
+            Some(GlobalLibraryWriterUnavailable::ProfileOwnershipChanged { path, .. })
+                if path == root
+        ));
+        assert!(!writer.shutdown());
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn profile_replacement_before_reply_returns_completion_not_confirmable() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let base_path = std::fs::canonicalize(temp.path()).expect("canonical test base");
+        let base_guard = ConfigBaseGuard::set(base_path);
+        let profile_guard = PersistenceProfileGuard::named("inflight-replacement");
+        let writable_guard = WritableProfileGuard::acquire_current().expect("profile ownership");
+        let (mut writer, ready, release) =
+            GlobalLibraryWriter::start_with_post_command_gate_for_test(&writable_guard);
+        wait_until_available(&writer);
+        let root = writable_guard.profile_root().to_path_buf();
+        let result = writer
+            .replace_source_registry(SourceRegistrySnapshot::new(Vec::new()))
+            .expect("replace admission");
+
+        ready.wait();
+        let queued_result = writer
+            .load_source_registry_snapshot()
+            .expect("queued load admission");
+        let displaced = temp.path().join("inflight-replacement-old");
+        fs::rename(&root, &displaced).expect("displace original profile root");
+        fs::create_dir(&root).expect("replacement profile root");
+        release.wait();
+
+        let result = result
+            .recv_timeout(Duration::from_secs(2))
+            .expect("in-flight command result");
+        match result {
+            Err(LibraryError::ProfileOwnershipChanged { path, reason }) => {
+                assert_eq!(path, root);
+                assert!(reason.contains("completion not confirmable"));
+            }
+            other => panic!("profile replacement returned {other:?}"),
+        }
+        assert!(matches!(
+            queued_result
+                .recv_timeout(Duration::from_secs(2))
+                .expect("queued command result"),
+            Err(LibraryError::ProfileOwnershipChanged { .. })
+        ));
+        wait_until_closed(&writer);
+        assert!(matches!(
+            writer.load_source_registry_snapshot(),
+            Err(GlobalLibraryWriterQueueError::Closed)
+        ));
+        assert!(displaced.join(super::super::LIBRARY_DB_FILE_NAME).is_file());
+        assert!(!writer.shutdown());
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn profile_replacement_closes_owner_and_rejects_later_commands() {
         let temp = tempdir().expect("base");
         let _runtime = TestRuntimeGuard::acquire();
@@ -907,7 +1196,7 @@ mod tests {
         drop(base_guard);
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[test]
     fn profile_lock_replacement_closes_owner_and_rejects_later_commands() {
         let temp = tempdir().expect("base");
@@ -931,6 +1220,27 @@ mod tests {
                 if path == lock_path
         ));
         let _ = writer.shutdown();
+        drop(writable_guard);
+        drop(profile_guard);
+        drop(base_guard);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn profile_root_rename_is_blocked_by_retained_database_binding() {
+        let temp = tempdir().expect("base");
+        let _runtime = TestRuntimeGuard::acquire();
+        let (base_guard, profile_guard, writable_guard, mut writer) =
+            start_writer(&temp, "root-rename-barrier");
+        let root = writable_guard.profile_root().to_path_buf();
+        wait_until_available(&writer);
+        let displaced = temp.path().join("root-rename-barrier-old");
+        assert!(fs::rename(&root, &displaced).is_err());
+        assert!(matches!(
+            writer.status(),
+            GlobalLibraryWriterStatus::Available
+        ));
+        assert!(writer.shutdown());
         drop(writable_guard);
         drop(profile_guard);
         drop(base_guard);

--- a/crates/wavecrate-library/src/sample_sources/library/sources.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/sources.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::connection::LibraryDatabase;
 use super::error::map_sql_error;
+use super::owner::SourceRegistrySnapshot;
 use super::telemetry::record_library_db_event;
 use super::{KNOWN_SOURCES_KEY, LibraryError, LibraryState};
 use crate::sample_sources::normalize_path;
@@ -23,13 +24,35 @@ impl LibraryDatabase {
     }
 
     pub(super) fn replace_state(&mut self, state: &LibraryState) -> Result<(), LibraryError> {
+        self.replace_source_registry_with_event(
+            &SourceRegistrySnapshot::from_sources(state.sources.clone()),
+            "library.replace_state",
+        )
+    }
+
+    pub(super) fn load_source_registry(&self) -> Result<SourceRegistrySnapshot, LibraryError> {
+        Ok(SourceRegistrySnapshot::from_sources(self.load_sources()?))
+    }
+
+    pub(super) fn replace_source_registry(
+        &mut self,
+        snapshot: &SourceRegistrySnapshot,
+    ) -> Result<(), LibraryError> {
+        self.replace_source_registry_with_event(snapshot, "library.replace_source_registry")
+    }
+
+    fn replace_source_registry_with_event(
+        &mut self,
+        snapshot: &SourceRegistrySnapshot,
+        event: &'static str,
+    ) -> Result<(), LibraryError> {
         let started_at = Instant::now();
         let tx = self.connection.transaction().map_err(map_sql_error)?;
         let mut mappings = Self::load_known_sources_from(&tx)?;
-        Self::replace_sources(&tx, &state.sources)?;
-        Self::remember_known_sources_in_tx(&tx, &mut mappings, &state.sources)?;
+        Self::replace_sources(&tx, snapshot.as_slice())?;
+        Self::remember_known_sources_in_tx(&tx, &mut mappings, snapshot.as_slice())?;
         tx.commit().map_err(map_sql_error)?;
-        record_library_db_event("library.replace_state", started_at, Ok(()));
+        record_library_db_event(event, started_at, Ok(()));
         Ok(())
     }
 

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -27,9 +27,11 @@ pub use db::{
     SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
 };
 pub use library::{
+    GLOBAL_LIBRARY_WRITER_COMMAND_CAPACITY, GlobalLibraryWriter, GlobalLibraryWriterQueueError,
+    GlobalLibraryWriterStartError, GlobalLibraryWriterStatus, GlobalLibraryWriterUnavailable,
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,
     HarvestFileRecord, HarvestMetadataSnapshot, HarvestSourceRange, HarvestState,
-    LIBRARY_DB_FILE_NAME, LibraryError, LibraryState, NewHarvestDerivation,
+    LIBRARY_DB_FILE_NAME, LibraryError, LibraryState, NewHarvestDerivation, SourceRegistrySnapshot,
 };
 pub use source_entry::{
     HiddenDirectoryPolicy, SOURCE_FORMAT_POLICY_VERSION, SourceEntryClassification,


### PR DESCRIPTION
## Goal

Implement the first durable, profile-owned global-library writer seam for OPT-1357, with capability-rooted SQLite ownership and truthful lifecycle completion.

## Scope

- Add a profile-owned `GlobalLibraryWriter` with one worker-owned long-lived SQLite connection.
- Add typed bounded source-registry load/replace commands with nonblocking admission.
- Bind profile-owned SQLite access to the retained profile-root capability using platform-specific namespace handling.
- Preflight existing database/WAL/SHM entries for regular-file/no-follow safety.
- Fence initialization and every command before reporting availability or success.
- Return typed completion-not-confirmable ownership errors and drain/reject queued work on ownership loss.
- Preserve transactional rollback/reopen behavior, shared profile guard ownership, shutdown ordering, and existing synchronous compatibility APIs.

## Non-goals

- No source lease/writer migration.
- No native journal or Harvest caller migration.
- No coordinator/saga/recovery orchestration or cache payload writes.
- No schema or migration rewrite.
- No changes to unrelated open PRs (#980 or #1054).
- No claim that all existing synchronous writable callers have already migrated.

## Definition of Done

- SQLite initialization and sidecars cannot be redirected by profile-root replacement under the stated platform capability guarantees.
- The owner validates ownership before/after initialization and before/after each command.
- A command returns `Ok` only after the post-command ownership fence passes; ownership loss is typed and queued work is resolved.
- Existing rollback, reopen/preservation, bounded queue, shared-guard, and shutdown behavior remains covered.
- Focused checks pass and the complete exact-head diff is independently reviewed.

## Validation/results

- Owner tests: 15/15 passed.
- Library tests: 38/38 passed.
- Locked `cargo check`, Clippy with pre-existing baseline lint allowances, rustfmt, and diff checks passed.
- Full disposable harness: 439/445; six unchanged/pre-existing macOS profile-ownership path tests fail because of /var symlink handling.
- Linux and Windows runtime/cross-target checks were unavailable because the required toolchains/workspace dependencies were unavailable; Windows runtime behavior remains unexercised.
- Fresh independent Terra persistence/ownership review of exact head `bddd8f76d92963d8195b5729fb2cbe7eb8621552` returned `APPROVE` with no required findings.

## Known limitations

The retained pathname/VFS design provides the documented macOS/Linux namespace guarantee and Windows directory-handle rename/delete protection. Stronger Windows child-reparse protection would require a separate custom SQLite VFS issue. Existing synchronous compatibility paths remain unchanged and will be migrated in later dependency-correct slices.

## Merge

Do not merge this PR without separate explicit user approval.